### PR TITLE
Modifications to allow for an easy switch in the representation of Fp

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -28,8 +28,4 @@ cryptol <<EOF
 :check
 :l tests/HashToCurveE2Tests.cry
 :check
-:l tests/FrobeniusTests.cry
-:set tests=10
-:check
-:set tests=100
 EOF

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Most of these validation properties are more provable woth SMT solvers
+# as they rely on some difficult algebraic properties, and the base types involved
+# are far too large fopr the SMT solver to handle effectively.  So they are just tested
+# with random values, or with test vectors from the specification.
+
+cryptol <<EOF
+:set tests=100
+:l tests/PolynomialTest.cry
+:check
+:l tests/ParameterTests.cry
+:check
+:l tests/ShortWeierstrassCurveTests.cry
+:check
+:l tests/ParameterTests.cry
+:check
+:l tests/HashToCurveE1Tests.cry
+:check
+:l tests/HashToCurveE2Tests.cry
+:check
+:l tests/FrobeniusTests.cry
+:set tests=10
+:check
+:set tests=100
+EOF
+
+# long-running and a big memory footprint:
+cryptol <<EOF
+:set tests=100
+:l tests/PairingTest.cry
+:check
+EOF

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
-# Most of these validation properties are more provable woth SMT solvers
+# There are two sorts of validation checks in the tests directory: property checks
+# and test vectors from the specifications.
+# 
+# Most of the validation properties are not easily provable with SMT solvers
 # as they rely on some difficult algebraic properties, and the base types involved
-# are far too large fopr the SMT solver to handle effectively.  So they are just tested
-# with random values, or with test vectors from the specification.
+# are far too large for the SMT solver to handle effectively.  So they are just tested
+# with random values
+#
+# The test vectors are just evaluations of the functions on a small selection of
+# arguments, with known answers. Whether we :prove or :check does not matter;
+# the Cryptol iterpreter just evaluates them.
+
+# Some long-running or memory-intensive checks are in a separate file.
 
 cryptol <<EOF
 :set tests=100
@@ -23,11 +32,4 @@ cryptol <<EOF
 :set tests=10
 :check
 :set tests=100
-EOF
-
-# long-running and a big memory footprint:
-cryptol <<EOF
-:set tests=100
-:l tests/PairingTest.cry
-:check
 EOF

--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -6,3 +6,4 @@ export PATH=/workdir/bin:$PATH
 ./scripts/build_llvm.sh
 ./scripts/build_x86.sh
 ./scripts/prove.sh
+./scripts/check.sh | if grep False; then exit 1; fi # look for any failed checks

--- a/scripts/expensive-checks.sh
+++ b/scripts/expensive-checks.sh
@@ -4,6 +4,9 @@
 # See the comments in `checks.sh`.
 
 cryptol <<EOF
+:set tests=10
+:l tests/FrobeniusTests.cry
+:check
 :set tests=100
 :l tests/PairingTest.cry
 :check

--- a/scripts/expensive-checks.sh
+++ b/scripts/expensive-checks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Validations checks that are long-running and with a big memory footprint.
+# See the comments in `checks.sh`.
+
+cryptol <<EOF
+:set tests=100
+:l tests/PairingTest.cry
+:check
+EOF

--- a/spec/HashToCurveE1.cry
+++ b/spec/HashToCurveE1.cry
@@ -2,7 +2,8 @@
  * Copyright (c) 2020 Galois, Inc.
  * SPDX-License-Identifier: Apache-2.0 OR MIT
 */
-// hash_to_curve algorithm from 
+
+// hash_to_curve algorithm from draft-irtf-cfrg-hash-to-curve-09
 
 module HashToCurveE1 = HashToCurveGeneric where
 
@@ -41,14 +42,14 @@ sqrt x = F_expt`{n=width p} F x `((p+1)/4) // the =3 (mod 4) variant
 
 // sgn0 for m=1, from Section 4.1 
 // sgn0 x = if x > `((p - 1) / 2) then -1 else 1 -- old Draft 6 definition
-sgn0 x = [x!0]
+sgn0: P::t_Fp -> [1]
+sgn0 x = [(P::from_Fp x)!0]
 
 inv0 x = F_expt`{n=width q} F x `(q-2) // but could be F.div (F.field_unit, x)
 
 // for the isogenous curve
 private
-    to_Fp: {n} (fin n, n <= 384) => [n] -> t_F
-    to_Fp bits = (zext bits) // mod something?
+    to_Fp = P::to_Fp
 
 
 // Constants from Section 8.8.1
@@ -69,7 +70,7 @@ iso_map (x', y') = (x, y) where
     x = F.div (x_num, x_den)
     y = F.mul (y', F.div(y_num, y_den))
 
-k1s = // k1s@i is "k_(1,i)" from the spec
+k1s = map to_Fp // k1s@i is "k_(1,i)" from the spec
    [ 0x11a05f2b1e833340b809101dd99815856b303e88a2d7005ff2627b56cdb4e2c85610c2d5f2e62d6eaeac1662734649b7
    , 0x17294ed3e943ab2f0588bab22147a81c7c17e75b2f6a8417f565e33c70d1e86b4838f2a6f318c356e834eef1b3cb83bb
    , 0x0d54005db97678ec1d1048c5d10a9a1bce032473295983e56878e501ec68e25c958c3e3d2a09729fe0179f9dac9edcb0
@@ -84,7 +85,7 @@ k1s = // k1s@i is "k_(1,i)" from the spec
    , 0x06e08c248e260e70bd1e962381edee3d31d79d7e22c837bc23c0bf1bc24c6b68c24b1b80b64d391fa9c8ba2e8ba2d229
    ]
 
-k2s = // k2s@i is "k_(2,i)" from the spec
+k2s = map to_Fp // k2s@i is "k_(2,i)" from the spec
    [ 0x08ca8d548cff19ae18b2e62f4bd3fa6f01d5ef4ba35b48ba9c9588617fc8ac62b558d681be343df8993cf9fa40d21b1c
    , 0x12561a5deb559c4348b4711298e536367041e8ca0cf0800c0126c2588c48bf5713daa8846cb026e9e5c8276ec82b3bff
    , 0x0b2962fe57a3225e8137e629bff2991f6f89416f5a718cd1fca64e00b11aceacd6a3d0967c94fedcfcc239ba5cb83e19
@@ -97,7 +98,7 @@ k2s = // k2s@i is "k_(2,i)" from the spec
    , 0x095fc13ab9e92ad4476d6e3eb3a56680f682b4ee96f7d03776df533978f31c1593174e4b4b7865002d6384d168ecdd0a
    ]
 
-k3s =
+k3s = map to_Fp
    [ 0x090d97c81ba24ee0259d1f094980dcfa11ad138e48a869522b52af6c956543d3cd0c7aee9b3ba3c2be9845719707bb33
    , 0x134996a104ee5811d51036d776fb46831223e96c254f383d0f906343eb67ad34d6c56711962fa8bfe097e75a2e41c696
    , 0x00cc786baa966e66f4a384c86a3b49942552e2d658a31ce2c344be4b91400da7d26d521628b00523b8dfe240c72de1f6
@@ -116,7 +117,7 @@ k3s =
    , 0x15e6be4e990f03ce4ea50b3b42df2eb5cb181d8f84965a3957add4fa95af01b2b665027efec01c7704b456be69c8b604
    ]
 
-k4s =
+k4s = map to_Fp
    [ 0x16112c4c3a9c98b252181140fad0eae9601a6de578980be6eec3232b5be72e7a07f3688ef60c206d01479253b03663c1
    , 0x1962d75c2381201e1a0cbd6c43c348b885c84ff731c4d59ca4a10356f453e01f78a4260763529e3532f6102c2e49a03d
    , 0x058df3306640da276faaae7d6e8eb15778c4855551ae7f310c35a5dd279cd2eca6757cd636f96f891e2538b53dbf67f2

--- a/spec/HashToCurveE2.cry
+++ b/spec/HashToCurveE2.cry
@@ -61,22 +61,23 @@ sqrt x = z where
     k = 1028732146235106349975324479215795277384839936929757896155643118032610843298655225875571310552543014690878354869257
     // Then (k(u+1))^2 = k^2(2u) = -u and
     //      (k(u-1))^2 = k^2(-2u) = u
-    c2 = [k, `p-k] // k*(u-1)
+    c2 = [k, P::Fp.neg k] // k*(u-1)
     c3 = [k, k] // k*(u+1)
 
 // sgn0 for m=2, from Section 4.1 
 sgn0 [x_1, x_0] =  sign_0 || (zero_0 && sign_1) where
     // [x_1, x_0] because Section 2.1 asks for a little-endian order of elements
-    sign_0 = [x_0!0] // least-signiifcant bit
-    zero_0 = [x_0 == 0] // represent the Boolean as 0 or 1
-    sign_1 = [x_1!0]  
+    x_0' = P::from_Fp x_0
+    x_1' = P::from_Fp x_1
+    sign_0 = [x_0'!0] // least-signiifcant bit
+    zero_0 = [x_0' == 0] // represent the Boolean as 0 or 1
+    sign_1 = [x_1'!0]  
 
 inv0 x = F_expt`{n=width q} F x `(q-2) // but could be F.div (F.field_unit, x)
 
 // for the isogenous curve
 private
-    to_Fp: {n} (fin n, n <= 384) => [n] -> [384]
-    to_Fp bits = (zext bits) // % something?
+    to_Fp  = P::to_Fp
 
 
 // Constants from Section 8.8.2
@@ -100,8 +101,8 @@ iso_map (x', y') = (x, y) where
     x = F.div (x_num, x_den)
     y = F.mul (y', F.div(y_num, y_den))
 
-to_Fp2: (P::t_Fp, P::t_Fp) -> P::t_Fp_2
-to_Fp2 (a,b) = [b, a] // a+b*I
+to_Fp2: ([384], [384]) -> P::t_Fp_2
+to_Fp2 (a,b) = [to_Fp b, to_Fp a] // a+b*I
 
 k1s = map to_Fp2 
    [ (0x05c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6,

--- a/spec/HashToCurveGeneric.cry
+++ b/spec/HashToCurveGeneric.cry
@@ -11,7 +11,7 @@ module HashToCurveGeneric where
 import rfc8017 (I2OSP, OS2IP)
 import Primitive::Keyless::Hash::SHA256 as SHA256
 import Common::Field
-import Parameters (t_Fp, Fp)
+import Parameters (t_Fp, Fp, to_Fp)
 import FieldExtras
 import ShortWeierstrassCurve as EC
 import ExpandMessage
@@ -120,7 +120,7 @@ hash_to_field (msg, DST) = us where
       us = [ make_u_i part | part <- parts ]
       make_u_i: [m][L][8] -> t_F
       // "drop" here takes the 8*L-bit result and drops leading zeros to get to [384]
-      make_u_i part = base_to_F [drop ((OS2IP`{a=[L*8]} bytes) % `p) | bytes <- part]
+      make_u_i part = base_to_F [to_Fp (drop`{back=384} ((OS2IP`{a=[L*8]} bytes) % `p)) | bytes <- part]
 
 // 6.6.2 Simplified SWU
 

--- a/spec/Parameters.cry
+++ b/spec/Parameters.cry
@@ -50,7 +50,6 @@ from_Fp x = x
 
 
 //       F_p^2 = F_p[u] / (u^2 + 1)
-// Fp_2 = extension_field Fp [0,`p-1] // [Fp.field_zero, Fp.neg Fp.field_unit] // [0,-1]
 Fp_2 = extension_field Fp [Fp.field_zero, Fp.neg Fp.field_unit] // [0,-1]
 type t_Fp_2 = [2]t_Fp
 

--- a/spec/Parameters.cry
+++ b/spec/Parameters.cry
@@ -22,15 +22,36 @@ t_signed_form = [ [bit,bit] | bit <-  <| x^^63 + x^^62 + x^^60 + x^^57 + x^^48 +
 
 type p = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
 
-/*
-Fp = PrimeField`{p}
+// Choice of base representation for GF(p) is made here:
+
+// For the Z p version:
+Fp = prime_field`{p}
 type t_Fp = Z p
-*/
+
+to_Fp: {n} (fin n, n <= 384) => [n] -> t_Fp
+to_Fp bits = fromInteger (toInteger (zext`{m=384} bits))
+
+from_Fp: t_Fp -> [384]
+from_Fp x = fromInteger (fromZ x)
+
+/*
+// For the bivector version:
 Fp = prime_field_bv`{384} `p  // representation of F_p
 type t_Fp = [384]  // ... and the underlying Cryptol type
 
+to_Fp: {n} (fin n, n <= 384) => [n] -> t_Fp
+to_Fp bits = (zext bits) // mod something?
+
+from_Fp: t_Fp -> [384]
+from_Fp x = x
+*/
+
+// Nothing else should need to change depending on the version of base representation chosen above.
+
+
 //       F_p^2 = F_p[u] / (u^2 + 1)
-Fp_2 = extension_field Fp [0,`p-1] // [Fp.field_zero, Fp.neg Fp.field_unit] // [0,-1]
+// Fp_2 = extension_field Fp [0,`p-1] // [Fp.field_zero, Fp.neg Fp.field_unit] // [0,-1]
+Fp_2 = extension_field Fp [Fp.field_zero, Fp.neg Fp.field_unit] // [0,-1]
 type t_Fp_2 = [2]t_Fp
 
 /** u is the generator for F_p^2 over F_p */
@@ -104,7 +125,7 @@ private
   poly_to_octets f p = join (map f (reverse p))
 
 Fp_to_octets: t_Fp -> [48*8] // big endian
-Fp_to_octets x = x
+Fp_to_octets = from_Fp
 
 Fp_12_to_octets: t_Fp_12 -> [12*48*8]
 Fp_12_to_octets = poly_to_octets (poly_to_octets (poly_to_octets Fp_to_octets))
@@ -114,7 +135,8 @@ private
   octets_to_poly f octets = map f (reverse (split octets))
 
 octets_to_Fp: [48*8] -> t_Fp
-octets_to_Fp octets = octets // TODO: chould we check that they are not too big?
+// octets_to_Fp octets = octets // TODO: chould we check that they are not too big?
+octets_to_Fp octets = to_Fp octets // fromInteger (toInteger octets)
 
 octets_to_Fp_2: [2*48*8] -> t_Fp_2
 octets_to_Fp_2 = (octets_to_poly`{k=2} octets_to_Fp)

--- a/tests/HashToCurveE1Tests.cry
+++ b/tests/HashToCurveE1Tests.cry
@@ -4,6 +4,7 @@
 */
 // Tests for hashing to curve E1, from draft-irtf-cfrg-hash-to-curve-09
 
+import ExpandMessage
 import HashToCurveE1
 import ShortWeierstrassCurve as EC
 import Parameters as P
@@ -13,15 +14,15 @@ import Parameters as P
 dst_1 = "QUUX-V01-CS02-with-expander"
 
 property expand_test_1 =
-    expand_msg ("", dst_1) ==
+    expand_msg "" dst_1 ==
     split 0xf659819a6473c1835b25ea59e3d38914c98b374f0970b7e4c92181df928fca88
 
 property expand_test_2 =
-    expand_msg ("abc", dst_1) ==
+    expand_msg  "abc" dst_1 ==
     split 0x1c38f7c211ef233367b2420d04798fa4698080a8901021a795a1151775fe4da7
 
 property expand_test_3 =
-    expand_msg ("abcdef0123456789", dst_1) ==
+    expand_msg "abcdef0123456789" dst_1 ==
     split 0x8f7e7b66791f0da0dbb5ec7c22ec637f79758c0a48170bfb7c4611bd304ece89
 
 msg_q128 = "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq" #
@@ -29,14 +30,14 @@ msg_q128 = "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq" #
            "qqqqqqqqqqqqqqqqqqqqqqqqq"
 
 property expand_test_4 =
-    expand_msg (msg_q128, dst_1) ==
+    expand_msg msg_q128 dst_1 ==
     split 0x72d5aa5ec810370d1f0013c0df2f1d65699494ee2a39f72e1716b1b964e1c642
 
 
 msg_a512 = "a512_"  # ['a' | _ <- [0..511]]
 
 property expand_test_5 =
-    expand_msg (msg_a512, dst_1) ==
+    expand_msg msg_a512 dst_1 ==
     split 0x3b8e704fc48336aca4c2a12195b720882f2162a4b7b13a9c350db46f429b771b
 
 // From Section H.9.1, BLS12381G1_XMD:SHA-256_SSWU_RO_

--- a/tests/HashToCurveE1Tests.cry
+++ b/tests/HashToCurveE1Tests.cry
@@ -41,8 +41,7 @@ property expand_test_5 =
 
 // From Section H.9.1, BLS12381G1_XMD:SHA-256_SSWU_RO_
 
-to_Fp: {n} (fin n, n <= 384) => [n] -> [384]
-to_Fp bits = (zext bits) // mod something?
+to_Fp = P::to_Fp // shorter name
 
 dst = "QUUX-V01-CS02-with-BLS12381G1_XMD:SHA-256_SSWU_RO_"
 
@@ -78,20 +77,20 @@ property map_to_curve_test_1_2_b =
 
 property map_to_curve_test_1_3_a =
     EC::same_point_affine P::E (map_to_curve_simple_swu_AB0 (ex1_us@0))
-    (0x11a3cce7e1d90975990066b2f2643b9540fa40d6137780df4e753a8054d07580db3b7f1f03396333d4a359d1fe3766fe,
-     0x0eeaf6d794e479e270da10fdaf768db4c96b650a74518fc67b04b03927754bac66f3ac720404f339ecdcc028afa091b7)
+    (to_Fp 0x11a3cce7e1d90975990066b2f2643b9540fa40d6137780df4e753a8054d07580db3b7f1f03396333d4a359d1fe3766fe,
+     to_Fp 0x0eeaf6d794e479e270da10fdaf768db4c96b650a74518fc67b04b03927754bac66f3ac720404f339ecdcc028afa091b7)
 
 property map_to_curve_test_1_3_b =
     EC::same_point_affine P::E (map_to_curve_simple_swu_AB0 (ex1_us@1))
-    (0x160003aaf1632b13396dbad518effa00fff532f604de1a7fc2082ff4cb0afa2d63b2c32da1bef2bf6c5ca62dc6b72f9c,
-     0x0d8bb2d14e20cf9f6036152ed386d79189415b6d015a20133acb4e019139b94e9c146aaad5817f866c95d609a361735e)
+    (to_Fp 0x160003aaf1632b13396dbad518effa00fff532f604de1a7fc2082ff4cb0afa2d63b2c32da1bef2bf6c5ca62dc6b72f9c,
+     to_Fp 0x0d8bb2d14e20cf9f6036152ed386d79189415b6d015a20133acb4e019139b94e9c146aaad5817f866c95d609a361735e)
 
 // ... finally, the overall mapping gets us the correct result.
 
 property hash_to_curve_test_1 =
     EC::same_point_affine P::E (hash_to_curve ("", dst))
-    (0x052926add2207b76ca4fa57a8734416c8dc95e24501772c814278700eed6d1e4e8cf62d9c09db0fac349612b759e79a1,
-     0x08ba738453bfed09cb546dbb0783dbb3a5f1f566ed67bb6be0e8c67e2e81a4cc68ee29813bb7994998f3eae0c9c6a265)
+    (to_Fp 0x052926add2207b76ca4fa57a8734416c8dc95e24501772c814278700eed6d1e4e8cf62d9c09db0fac349612b759e79a1,
+     to_Fp 0x08ba738453bfed09cb546dbb0783dbb3a5f1f566ed67bb6be0e8c67e2e81a4cc68ee29813bb7994998f3eae0c9c6a265)
 
 // Example 2
 
@@ -108,22 +107,22 @@ property hash_to_field_test_2 =
 
 property hash_to_curve_test_2 =
     EC::same_point_affine P::E (hash_to_curve ("abc", dst))
-    (0x03567bc5ef9c690c2ab2ecdf6a96ef1c139cc0b2f284dca0a9a7943388a49a3aee664ba5379a7655d3c68900be2f6903,
-     0x0b9c15f3fe6e5cf4211f346271d7b01c8f3b28be689c8429c85b67af215533311f0b8dfaaa154fa6b88176c229f2885d)
+    (to_Fp 0x03567bc5ef9c690c2ab2ecdf6a96ef1c139cc0b2f284dca0a9a7943388a49a3aee664ba5379a7655d3c68900be2f6903,
+     to_Fp 0x0b9c15f3fe6e5cf4211f346271d7b01c8f3b28be689c8429c85b67af215533311f0b8dfaaa154fa6b88176c229f2885d)
 
 // Examples 3 .. 
 
 property hash_to_curve_test_3 =
     EC::same_point_affine P::E (hash_to_curve ("abcdef0123456789", dst))
-    (0x11e0b079dea29a68f0383ee94fed1b940995272407e3bb916bbf268c263ddd57a6a27200a784cbc248e84f357ce82d98,
-     0x03a87ae2caf14e8ee52e51fa2ed8eefe80f02457004ba4d486d6aa1f517c0889501dc7413753f9599b099ebcbbd2d709)
+    (to_Fp 0x11e0b079dea29a68f0383ee94fed1b940995272407e3bb916bbf268c263ddd57a6a27200a784cbc248e84f357ce82d98,
+     to_Fp 0x03a87ae2caf14e8ee52e51fa2ed8eefe80f02457004ba4d486d6aa1f517c0889501dc7413753f9599b099ebcbbd2d709)
 
 property hash_to_curve_test_4 =
     EC::same_point_affine P::E (hash_to_curve (msg_q128, dst))
-    (0x15f68eaa693b95ccb85215dc65fa81038d69629f70aeee0d0f677cf22285e7bf58d7cb86eefe8f2e9bc3f8cb84fac488,
-     0x1807a1d50c29f430b8cafc4f8638dfeeadf51211e1602a5f184443076715f91bb90a48ba1e370edce6ae1062f5e6dd38)
+    (to_Fp 0x15f68eaa693b95ccb85215dc65fa81038d69629f70aeee0d0f677cf22285e7bf58d7cb86eefe8f2e9bc3f8cb84fac488,
+     to_Fp 0x1807a1d50c29f430b8cafc4f8638dfeeadf51211e1602a5f184443076715f91bb90a48ba1e370edce6ae1062f5e6dd38)
 
 property hash_to_curve_test_5 =
     EC::same_point_affine P::E (hash_to_curve (msg_a512, dst))
-    (0x082aabae8b7dedb0e78aeb619ad3bfd9277a2f77ba7fad20ef6aabdc6c31d19ba5a6d12283553294c1825c4b3ca2dcfe,
-     0x05b84ae5a942248eea39e1d91030458c40153f3b654ab7872d779ad1e942856a20c438e8d99bc8abfbf74729ce1f7ac8)
+    (to_Fp 0x082aabae8b7dedb0e78aeb619ad3bfd9277a2f77ba7fad20ef6aabdc6c31d19ba5a6d12283553294c1825c4b3ca2dcfe,
+     to_Fp 0x05b84ae5a942248eea39e1d91030458c40153f3b654ab7872d779ad1e942856a20c438e8d99bc8abfbf74729ce1f7ac8)

--- a/tests/HashToCurveE2Tests.cry
+++ b/tests/HashToCurveE2Tests.cry
@@ -21,9 +21,8 @@ msg_a512 = "a512_"  # ['a' | _ <- [0..511]]
 
 // From Section H.10.1, BLS12381G2_XMD:SHA-256_SSWU_RO_
 
-to_Fp2: (P::t_Fp, P::t_Fp) -> P::t_Fp_2
-to_Fp2 (a,b) = [b, a] // a+b*I
-
+to_Fp2: ([384], [384]) -> P::t_Fp_2
+to_Fp2 (a,b) = [P::to_Fp b, P::to_Fp a] // a+b*I
 
 dst = "QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_"
 

--- a/tests/PairingTest.cry
+++ b/tests/PairingTest.cry
@@ -6,6 +6,8 @@ import Pairing
 import Parameters as P
 import ShortWeierstrassCurve as EC
 
+to_Fp = P::to_Fp // shorter expression for the injection
+
 // These tests consist of some sanity checks on some of the functions used in the
 // pairing calculation, followed by a check of the test vectors given in Appendix B
 // of the Draft.
@@ -27,8 +29,8 @@ property phi_2_is_OK (m:[8]) =
 
 // .. first point
 
-x = 0x17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb
-y = 0x08b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1
+x = to_Fp 0x17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb
+y = to_Fp 0x08b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1
 
 // ... confirm we are on the curve
 
@@ -41,14 +43,14 @@ property p1_on_c12 = EC::is_point_affine c12 p1
 
 // .. second point
 
-x'_0 = 0x024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8
-x'_1 = 0x13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e
+x'_0 = to_Fp 0x024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8
+x'_1 = to_Fp 0x13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e
 
 x': t2
 x' = [x'_1, x'_0]
 
-y'_0 = 0x0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801
-y'_1 = 0x0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be
+y'_0 = to_Fp 0x0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801
+y'_1 = to_Fp 0x0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be
 
 y': t2
 y' = [y'_1, y'_0]
@@ -62,7 +64,7 @@ p2 = phi_2 (x', y')
 property p2_on_c12 = EC::is_point_affine c12 p2
 
 // expected results, 12 coefficients fom e_0 to e_11:
-expected_pairing =
+expected_pairing = map to_Fp
     [ // e0 .. e3:
       0x11619b45f61edfe3b47a15fac19442526ff489dcda25e59121d9931438907dfd448299a87dde3a649bdba96e84d54558
     , 0x153ce14a76a53e205ba8f275ef1137c56a566f638b52d34ba3bf3bf22f277d70f76316218c0dfd583a394b8448d2be7f
@@ -81,7 +83,7 @@ expected_pairing =
     ]
 
 out1: t12
-out1 = 
+out1 = map (map (map to_Fp))
     [[[0x10c839fd7d6519131e14836b595789b7121ba39388491a972b713f92f9c75d3612a4758fe5614d7877cdaf2292b7dcf2,
        0x0ced20608aa7112c205ee7a703c2e77f96d1aef6fd865caafcb4a363d2f9de8ecc3acf61f888c8eedb1483397ba6438b],
       [0x0cbccf94f2a6bcc12d54395ad34d72e308d2b753adce82cd21e864d7bdbc5dfdd093caa671baba5189ceb2764a4664ff,
@@ -99,7 +101,7 @@ property ate_pairing'_OK =
     ate_pairing' p1 p2 == out1
 
 out2: t12
-out2 =
+out2 = map (map (map to_Fp))
     [[[0x07e850bc5bf5dcb89dc030a689f045f36e464093aa549b95c3eace6873451db6cf6374a8a9c29bed19e0f3fa2899f03b,
        0x0832f3fef66f64b46560617243b5e38291a18c2e1c4e5c3383bfcf87b2f40996f5505d61197a00ac57ac462e389aeeb9],
       [0x19aa5557f245b2ca84ed238cb32b279150dbbf88415386a23c6fb0f05f167b86bef07a74921f06bb88092a6206cc58c3,
@@ -127,3 +129,7 @@ property final_exponentiation_OK =
 // Note: There is no test here for the overall Ate pairing, because even though Cryptol can test both
 // main steps (ate_pairing'_OK and final_exponentiation_OK), it exhausts memory when computing
 // the composition of those two functions.
+
+//property ate_pairing_OK =
+//    ate_pairing p1 p2 == split`{parts=2} (split`{parts=6} (reverse expected_pairing))
+    

--- a/tests/PolynomialTest.cry
+++ b/tests/PolynomialTest.cry
@@ -16,7 +16,8 @@ poly_mul_0:  {t,k} (fin k, k>=1) => FieldRep t -> [k]t ->Bool
 poly_mul_0 F x = poly_equal F (poly_mul F x (poly_0 F), poly_0 F)
 
 poly_mul_1:  {t,k} (fin k, k>=1) => FieldRep t -> [k]t ->Bool
-poly_mul_1 F x = poly_equal F (poly_mul F x (poly_1 F), x)
+poly_mul_1 F x =
+   is_OK F x ==> poly_equal F (poly_mul F x (poly_1 F), x)
 
 poly_mul_commutes:  {t,k} (fin k, k>=1) => FieldRep t -> [k]t -> [k]t ->Bool
 poly_mul_commutes F x y =
@@ -34,7 +35,7 @@ poly_div_mod_prop F x y =
 poly_inverse_mod_prop: {k,t} (fin k, k >= 1) => FieldRep t -> [k]t -> [k]t -> Bool
 // only when q represents an irreducible polynomial
 poly_inverse_mod_prop F q p =
-    (is_OK F q) /\ is_OK F p /\ ~ (poly_equal F (p, poly_0 F)) ==>
+    (is_OK F q) /\ is_OK F p /\ ~ (poly_equal F (p, poly_0 F)) ==> 
     poly_equal F (poly_mul_mod F p (poly_inverse_mod F p q) q, poly_1 F)
 
 
@@ -51,8 +52,9 @@ property mul_mod_commutes_F7 = poly_mul_mod_commutes`{k=4} F7
 property div_mod_F7 = poly_div_mod_prop`{k=3} F7
 property div_mod_F7' = poly_div_mod_prop`{k=8} F7
 
-property inverse_mod_F7  p = poly_inverse_mod_prop`{k=3} F7 p [1,1,3] // q=x^2+x+3 is irreducible in F7
-property inverse_mod_F7' p = poly_inverse_mod_prop`{k=4} F7 p [1,1,2,3] // x^3+x^2+2x+3 is irreducible in F7
+// for the inverse_mod property, take care to recall the unusual representatin of the modulus.
+property inverse_mod_F7 = poly_inverse_mod_prop`{k=3} F7 [1,1,3] // q=x^3-x^2-x-3 is irreducible in F7
+property inverse_mod_F7' = poly_inverse_mod_prop`{k=4} F7 [2,0,1,1] // x^4-2*x^3-x-1 is irreducible in F7
 
 property mul_0_F29 = poly_mul_0`{k=4} F29
 property mul_1_F29 = poly_mul_1`{k=4} F29
@@ -61,5 +63,5 @@ property mul_mod_commutes_F29 = poly_mul_mod_commutes`{k=4} F29
 
 property div_mod_F29 = poly_div_mod_prop`{k=3} F29
 
-property inverse_mod_F29 p = poly_inverse_mod_prop`{k=3} F29 p [2,3,5]
-property inverse_mod_F29' p = poly_inverse_mod_prop`{k=4} F29 p [1,0,1,4]
+property inverse_mod_F29 = poly_inverse_mod_prop`{k=3} F29 [2,3,5] // x^3-2x^2-3y-5 is irreducible in F29
+property inverse_mod_F29' = poly_inverse_mod_prop`{k=4} F29 [27,1,1,6] // x^4-27x^3-x^2-x-6, also irreducible


### PR DESCRIPTION
There are two representations for field F_p, namely bitvector or a modular type, and a small section at the top of `Parameters.cry` that can be commented in or out to change from one to the other.    Nothing else needs to change in the other parts of the specification, although some of the not-yet merged branches like `bls-API` may need small changes to conform.