### PR TITLE
Enable previously-disabled x86 memory safety proofs (addition)

### DIFF
--- a/proof/x86/add_mod_256.saw
+++ b/proof/x86/add_mod_256.saw
@@ -172,17 +172,13 @@ add_mod_256_alias_ret_b_ov <- verify_x86 "add_mod_256" add_mod_256_alias_ret_b_s
 add_mod_256_alias_a_b_ov <- verify_x86 "add_mod_256" add_mod_256_alias_a_b_spec;
 add_mod_256_alias_ret_a_b_ov <- verify_x86 "add_mod_256" add_mod_256_alias_ret_a_b_spec;
 
-// mul_by_3_mod_256 - sbb in __lshift_mod_256 used to crab cf?
-let do_prove_x86 = false;
+// mul_by_3_mod_256
 mul_by_3_mod_256_ov <- verify_x86 "mul_by_3_mod_256" mul_by_3_mod_256_spec;
 mul_by_3_mod_256_alias_ret_a_ov <- verify_x86 "mul_by_3_mod_256" mul_by_3_mod_256_alias_ret_a_spec;
-let do_prove_x86 = true;
 
-// lshift_mod_256 - sbb in __lshift_mod_256 used to crab cf?
-let do_prove_x86 = false;
+// lshift_mod_256
 lshift_mod_256_ov <- verify_x86 "lshift_mod_256" (lshift_mod_256_spec {{ 5 : [64] }});
 lshift_mod_256_alias_ret_a_ov <- verify_x86 "lshift_mod_256" (lshift_mod_256_alias_ret_a_spec {{ 5 : [64] }});
-let do_prove_x86 = true;
 
 // rshift_mod_256
 rshift_mod_256_ov <- verify_x86 "rshift_mod_256" (rshift_mod_256_spec {{ 5 : [64] }});

--- a/proof/x86/add_mod_384.saw
+++ b/proof/x86/add_mod_384.saw
@@ -144,6 +144,12 @@ let mul_by_8_mod_384_alias_ret_a_spec = do {
 
 // mul_by_b_onE1
 let mul_by_b_onE1_spec = do {
+  crucible_alloc_global "BLS12_381_P";
+  BLS12_381_P <- crucible_fresh_var "BLS12_381_P" vec384_type;
+  crucible_points_to
+    (crucible_global "BLS12_381_P")
+    (crucible_term BLS12_381_P);
+
   out_ptr <- crucible_alloc vec384_type;
   (_, in_ptr) <- ptr_to_fresh_readonly "in" vec384_type;
   crucible_execute_func [out_ptr, in_ptr];
@@ -151,6 +157,12 @@ let mul_by_b_onE1_spec = do {
   crucible_points_to out_ptr (crucible_term new_out);
 };
 let mul_by_b_onE1_alias_out_in_spec = do {
+  crucible_alloc_global "BLS12_381_P";
+  BLS12_381_P <- crucible_fresh_var "BLS12_381_P" vec384_type;
+  crucible_points_to
+    (crucible_global "BLS12_381_P")
+    (crucible_term BLS12_381_P);
+
   (_, out_ptr) <- ptr_to_fresh "out" vec384_type;
   crucible_execute_func [out_ptr, out_ptr];
   new_out <- crucible_fresh_var "new_out" vec384_type;
@@ -208,6 +220,12 @@ let mul_by_8_mod_384x_alias_ret_a_spec = do {
 
 // mul_by_b_onE2
 let mul_by_b_onE2_spec = do {
+  crucible_alloc_global "BLS12_381_P";
+  BLS12_381_P <- crucible_fresh_var "BLS12_381_P" vec384_type;
+  crucible_points_to
+    (crucible_global "BLS12_381_P")
+    (crucible_term BLS12_381_P);
+
   out_ptr <- crucible_alloc vec384x_type;
   (_, in_ptr) <- ptr_to_fresh_readonly "in" vec384x_type;
   crucible_execute_func [out_ptr, in_ptr];
@@ -215,6 +233,12 @@ let mul_by_b_onE2_spec = do {
   crucible_points_to out_ptr (crucible_term new_out);
 };
 let mul_by_b_onE2_alias_out_in_spec = do {
+  crucible_alloc_global "BLS12_381_P";
+  BLS12_381_P <- crucible_fresh_var "BLS12_381_P" vec384_type;
+  crucible_points_to
+    (crucible_global "BLS12_381_P")
+    (crucible_term BLS12_381_P);
+
   (_, out_ptr) <- ptr_to_fresh "out" vec384x_type;
   crucible_execute_func [out_ptr, out_ptr];
   new_out <- crucible_fresh_var "new_out" vec384x_type;
@@ -434,10 +458,8 @@ mul_by_8_mod_384_ov <- verify_x86 "mul_by_8_mod_384" mul_by_8_mod_384_spec;
 mul_by_8_mod_384_alias_ret_a_ov <- verify_x86 "mul_by_8_mod_384" mul_by_8_mod_384_alias_ret_a_spec;
 
 // mul_by_b_onE1
-let do_prove_x86 = false;
 mul_by_b_onE1_ov <- verify_x86 "mul_by_b_onE1" mul_by_b_onE1_spec;
 mul_by_b_onE1_alias_out_in_ov <- verify_x86 "mul_by_b_onE1" mul_by_b_onE1_alias_out_in_spec;
-let do_prove_x86 = true;
 
 // mul_by_3_mod_384x
 mul_by_3_mod_384x_ov <- verify_x86 "mul_by_3_mod_384x" mul_by_3_mod_384x_spec;
@@ -448,10 +470,8 @@ mul_by_8_mod_384x_ov <- verify_x86 "mul_by_8_mod_384x" mul_by_8_mod_384x_spec;
 mul_by_8_mod_384x_alias_ret_a_ov <- verify_x86 "mul_by_8_mod_384x" mul_by_8_mod_384x_alias_ret_a_spec;
 
 // mul_by_b_onE2
-let do_prove_x86 = false;
 mul_by_b_onE2_ov <- verify_x86 "mul_by_b_onE2" mul_by_b_onE2_spec;
 mul_by_b_onE2_alias_out_in_ov <- verify_x86 "mul_by_b_onE2" mul_by_b_onE2_alias_out_in_spec;
-let do_prove_x86 = true;
 
 // cneg_mod_384
 cneg_mod_384_ov <- verify_x86 "cneg_mod_384" cneg_mod_384_spec;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@ if [ $# -ne 0 ] && [ "$1" = "--latest" ]; then
   CRYPTOL_NIGHTLY=$(curl -s https://cryptol.net/builds/nightly/ | grep -oP "cryptol.*?${CRYPTOL_DATE}-Ubuntu.*?\.tar\.gz"  | head -n 1) # `curl -s` means silent; `grep -o` says print only the matched substring; `grep -P` says Perl syntax, which we use to get a lazy match (shortest) with .*?
   CRYPTOL_URL="https://cryptol.net/builds/nightly/${CRYPTOL_NIGHTLY}"
 else
-  SAW_URL="https://saw.galois.com/builds/nightly/saw-0.6.0.99-2020-10-12-Ubuntu14.04-64.tar.gz"
+  SAW_URL="https://saw.galois.com/builds/nightly/saw-0.6.0.99-2020-11-20-Linux-x86_64.tar.gz"
   CRYPTOL_URL="https://github.com/GaloisInc/cryptol/releases/download/2.9.1/cryptol-2.9.1-Linux-x86_64.tar.gz"
 
 fi


### PR DESCRIPTION
Specifically, this enables `mul_by_3_mod_256`, `lshift_mod_256`, `mul_by_b_onE1`, and `mul_by_b_onE2`.
This depends on an updated `saw`, built since GaloisInc/saw-script@99f62b6144622434331e916002a83874d823b375, and so shouldn't be merged until we update `scripts/install.sh`.

@jared-w It looks like we're no longer uploading nightly builds of SAWScript to https://saw.galois.com/builds/nightly. I see that you've done some work to build nightlies in GaloisInc/saw-script#889 - is the plan to upload those artifacts to GitHub releases? It seems like I can't currently download artifacts directly from actions without authentication (actions/upload-artifact#51).