### PR TITLE
Manually pass -D__ADX__ in CFLAGS instead of reading /proc/cpuinfo

### DIFF
--- a/scripts/build_x86.sh
+++ b/scripts/build_x86.sh
@@ -6,7 +6,8 @@ rm -r build/x86
 cp -r blst build/x86
 cd build/x86
 
-export CFLAGS='-g -fPIC -Wall -Wextra -Werror'
+export CFLAGS='-g -fPIC -Wall -Wextra -Werror -D__ADX__'
 export CC=clang
 sed -i'' 's/^trap/# trap/' build.sh
+sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
 ./build.sh -shared


### PR DESCRIPTION
This has been occasionally breaking CI, since reading `/proc/cpuinfo` makes the success of the proof dependent on the ISA extensions available on the runner.

For now, we only build the ADX version. In the future, we'll need to build both in order to verify the `mulq` implementations alongside the `mulx` implementations.