### PR TITLE
Add memory safety proofs for remaining x86_64 routines

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,5 @@
 	path = cryptol-specs
 	url = git://github.com/GaloisInc/cryptol-specs
 [submodule "blst_patched"]
-	path = blst_patched
+	path = blst_recent
 	url = git@github.com:supranational/blst.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	url = git://github.com/GaloisInc/cryptol-specs
+[submodule "blst_patched"]
+	path = blst_patched
+	url = git@github.com:supranational/blst.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:20.04
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-RUN apt-get update
-RUN apt-get install -y apt-utils
+RUN apt-get update && apt-get install -y apt-utils
 
 # Install and configure locale `en_US.UTF-8` (otherwise SAW sometimes fails to write to the
 # console)

--- a/README.md
+++ b/README.md
@@ -53,4 +53,6 @@ Function `blst_keygen` has been shown to give a result in agreement with the Cry
 
 * For now, the assembly language subroutines have their functional correctness assumed.
 
+* We make an additional assumption about the stack pointer when verifying `ctx_inverse_mod_383` and `ct_inverse_mod_383` - see the comment in `proof/x86/ctx_inverse_mod_384.saw`
+
 * We have assumed the memory-safety and functional correctness of the implementation of SHA-256.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Cryptol definitions exist for the BLS12-381 parameters, and for all functions ne
 
 ## Memory Safety proofs
 
-We have proved memory safety for the following x86_64 routines: `add_mod_256`, `mul_by_3_mod_256`, `lshift_mod_256`, `rshift_mod_256`, `cneg_mod_256`, `sub_mod_256`, `add_mod_384`, `add_mod_384x`, `lshift_mod_384`, `mul_by_3_mod_384`, `mul_by_8_mod_384`, `mul_by_b_onE1`, `mul_by_3_mod_384x`, `mul_by_8_mod_384x`, `mul_by_b_onE2`, `cneg_mod_384`, `sub_mod_384`, `sub_mod_384x`, `mul_by_1_plus_i_mod_384x`, `sgn0_pty_mod_384`, `sgn0_pty_mod_384x`, `add_mod_384x384`, `sub_mod_384x384`, `mulx_mont_sparse_256`, `sqrx_mont_sparse_256`, `from_mont_256`, `redcx_mont_256`, `mulx_mont_384x`, `mulx_382x, sqrx_382x`, `redcx_mont_384`, `fromx_mont_384`, `sgn0x_pty_mont_384`, and `sgn0x_pty_mont_384x`.
+We have proved memory safety for the following x86_64 routines: `add_mod_256`, `mul_by_3_mod_256`, `lshift_mod_256`, `rshift_mod_256`, `cneg_mod_256`, `sub_mod_256`, `add_mod_384`, `add_mod_384x`, `lshift_mod_384`, `mul_by_3_mod_384`, `mul_by_8_mod_384`, `mul_by_b_onE1`, `mul_by_3_mod_384x`, `mul_by_8_mod_384x`, `mul_by_b_onE2`, `cneg_mod_384`, `sub_mod_384`, `sub_mod_384x`, `mul_by_1_plus_i_mod_384x`, `sgn0_pty_mod_384`, `sgn0_pty_mod_384x`, `add_mod_384x384`, `sub_mod_384x384`, `mulx_mont_sparse_256`, `sqrx_mont_sparse_256`, `from_mont_256`, `redcx_mont_256`, `mulx_mont_384x`, `sqrx_mont_384x`, `mulx_382x`, `sqrx_382x`, `redcx_mont_384`, `fromx_mont_384`, `sgn0x_pty_mont_384`, `sgn0x_pty_mont_384x`, `mulx_mont_384`, `sqrx_mont_384`, `sqrx_n_mul_mont_383`, and `sqrx_mont_382x`. There are variants of some routines that do not use the ADX instruction `mulx`; these are also proven memory-safe. A few changes from newer versions of BLST are introduced as patches in order to make the proofs more tractable, notably commit `5e3d137`.
 
-We still assume memory safety for `sqrx_mont_384x`, `mulx_mont_384`, `sqrx_mont_384`, `sqrx_n_mul_mont_383`, and `sqrx_mont_382x`. There are also variants of the routines prefixed with` mulx`, `sqrx`, `redcx`, and `fromx` that use the `mulq` instruction rather than `mulx` that are currently unverified.
+We do not prove the memory safety of `eucl_inverse_mod_384`, as it is difficult for SAW to establish termination. Instead, we prove memory safety for `ctx_inverse_mod_383` (and the non-`mulx` counterpart `ct_inverse_mod_383`). This is done against a newer version of BLST, as that routine does not exist in the older version we use otherwise.
 
 Under these assumptions, memory safety has been shown for all the following C functions: `blst_sk_to_pk_in_g1`, `blst_sk_to_pk_in_g2`, `blst_p1_affine_in_g1`, `blst_p2_affine_in_g2`, `blst_p1_deserialize`, `blst_p2_deserialize`, `hash_to_field`, `map_to_g1`, `map_to_g2`, `blst_core_verify_pk_in_g1`, `blst_core_verify_pk_in_g1`, `blst_pairing_init`, `blst_pairing_aggregate_pk_in_g1`, `blst_pairing_aggregate_pk_in_g2`, `blst_pairing_commit`, `blst_pairing_finalverify`.
 As noted below, for a few of these we have had to restrict the proof to a few specific input sizes.
@@ -51,6 +51,6 @@ Function `blst_keygen` has been shown to give a result in agreement with the Cry
 
 * Many algebraic properties of field operations, such as the associative and unit laws, have been assumed rather than proved.  Similarly, some algebraic properties relating to elliptic curves are assumed.
 
-* For now, the assembly language subroutines have their functional correctness assumed, and in a few cases as noted above, their memory safety is also assumed.
+* For now, the assembly language subroutines have their functional correctness assumed.
 
 * We have assumed the memory-safety and functional correctness of the implementation of SHA-256.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ./build:/workdir/build:rw
       - ./blst:/workdir/blst:ro
-      - ./blst_patched:/workdir/blst_patched:ro
+      - ./blst_recent:/workdir/blst_recent:ro
       - ./cryptol-specs:/workdir/cryptol-specs:ro
       - ./proof:/workdir/proof:ro
       - ./spec:/workdir/spec:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     volumes:
       - ./build:/workdir/build:rw
       - ./blst:/workdir/blst:ro
+      - ./blst_patched:/workdir/blst_patched:ro
       - ./cryptol-specs:/workdir/cryptol-specs:ro
       - ./proof:/workdir/proof:ro
       - ./spec:/workdir/spec:ro

--- a/patches/noxmmptr.patch
+++ b/patches/noxmmptr.patch
@@ -1,0 +1,1446 @@
+diff --git a/build/coff/mulq_mont_384-x86_64.s b/build/coff/mulq_mont_384-x86_64.s
+index f0d52f5..5663463 100644
+--- a/build/coff/mulq_mont_384-x86_64.s
++++ b/build/coff/mulq_mont_384-x86_64.s
+@@ -329,8 +329,8 @@ sqr_mont_384x:
+ 
+ 	movq	%rcx,0(%rsp)
+ 	movq	%rdx,%rcx
++	movq	%rdi,8(%rsp)
+ 	movq	%rsi,16(%rsp)
+-.byte	102,72,15,110,199
+ 
+ 
+ 	leaq	48(%rsi),%rdx
+@@ -2084,7 +2084,7 @@ mul_mont_384:
+ 
+ 	pushq	%r15
+ 
+-	pushq	%r8
++	subq	$24,%rsp
+ 
+ .LSEH_body_mul_mont_384:
+ 
+@@ -2095,23 +2095,24 @@ mul_mont_384:
+ 	movq	16(%rsi),%r12
+ 	movq	24(%rsi),%r13
+ 	movq	%rdx,%rbx
+-.byte	102,72,15,110,199
++	movq	%r8,0(%rsp)
++	movq	%rdi,8(%rsp)
+ 
+ 	call	__mulq_mont_384
+ 
+-	movq	8(%rsp),%r15
++	movq	24(%rsp),%r15
+ 
+-	movq	16(%rsp),%r14
++	movq	32(%rsp),%r14
+ 
+-	movq	24(%rsp),%r13
++	movq	40(%rsp),%r13
+ 
+-	movq	32(%rsp),%r12
++	movq	48(%rsp),%r12
+ 
+-	movq	40(%rsp),%rbx
++	movq	56(%rsp),%rbx
+ 
+-	movq	48(%rsp),%rbp
++	movq	64(%rsp),%rbp
+ 
+-	leaq	56(%rsp),%rsp
++	leaq	72(%rsp),%rsp
+ 
+ .LSEH_epilogue_mul_mont_384:
+ 	mov	8(%rsp),%rdi
+@@ -2693,7 +2694,7 @@ __mulq_mont_384:
+ 
+ 
+ 
+-.byte	102,72,15,126,199
++	movq	16(%rsp),%rdi
+ 	subq	0(%rcx),%r14
+ 	movq	%r15,%rdx
+ 	sbbq	8(%rcx),%r15
+@@ -2758,8 +2759,8 @@ sqr_n_mul_mont_384:
+ 
+ 
+ 	movq	%r8,0(%rsp)
+-	movq	%rcx,8(%rsp)
+-.byte	102,72,15,110,199
++	movq	%rdi,8(%rsp)
++	movq	%rcx,16(%rsp)
+ 	leaq	32(%rsp),%rdi
+ 	movq	%r9,24(%rsp)
+ 	movq	(%r9),%xmm2
+@@ -2771,7 +2772,7 @@ sqr_n_mul_mont_384:
+ 
+ 	leaq	0(%rdi),%rsi
+ 	movq	0(%rsp),%rcx
+-	movq	8(%rsp),%rbx
++	movq	16(%rsp),%rbx
+ 	call	__mulq_by_1_mont_384
+ 	call	__redc_tail_mont_384
+ 
+@@ -2853,8 +2854,8 @@ sqr_n_mul_mont_383:
+ 
+ 
+ 	movq	%r8,0(%rsp)
+-	movq	%rcx,8(%rsp)
+-.byte	102,72,15,110,199
++	movq	%rdi,8(%rsp)
++	movq	%rcx,16(%rsp)
+ 	leaq	32(%rsp),%rdi
+ 	movq	%r9,24(%rsp)
+ 	movq	(%r9),%xmm2
+@@ -2866,7 +2867,7 @@ sqr_n_mul_mont_383:
+ 
+ 	leaq	0(%rdi),%rsi
+ 	movq	0(%rsp),%rcx
+-	movq	8(%rsp),%rbx
++	movq	16(%rsp),%rbx
+ 	call	__mulq_by_1_mont_384
+ 
+ 	movd	%xmm1,%edx
+@@ -4118,15 +4119,15 @@ sqr_mont_382x:
+ .byte	0,0
+ .LSEH_info_mul_mont_384_body:
+ .byte	1,0,17,0
+-.byte	0x00,0xf4,0x01,0x00
+-.byte	0x00,0xe4,0x02,0x00
+-.byte	0x00,0xd4,0x03,0x00
+-.byte	0x00,0xc4,0x04,0x00
+-.byte	0x00,0x34,0x05,0x00
+-.byte	0x00,0x54,0x06,0x00
+-.byte	0x00,0x74,0x08,0x00
+-.byte	0x00,0x64,0x09,0x00
+-.byte	0x00,0x62
++.byte	0x00,0xf4,0x03,0x00
++.byte	0x00,0xe4,0x04,0x00
++.byte	0x00,0xd4,0x05,0x00
++.byte	0x00,0xc4,0x06,0x00
++.byte	0x00,0x34,0x07,0x00
++.byte	0x00,0x54,0x08,0x00
++.byte	0x00,0x74,0x0a,0x00
++.byte	0x00,0x64,0x0b,0x00
++.byte	0x00,0x82
+ .byte	0x00,0x00
+ .LSEH_info_mul_mont_384_epilogue:
+ .byte	1,0,4,0
+diff --git a/build/coff/mulx_mont_384-x86_64.s b/build/coff/mulx_mont_384-x86_64.s
+index defd0bd..12306a7 100644
+--- a/build/coff/mulx_mont_384-x86_64.s
++++ b/build/coff/mulx_mont_384-x86_64.s
+@@ -331,8 +331,8 @@ sqrx_mont_384x:
+ 	movq	%rcx,0(%rsp)
+ 	movq	%rdx,%rcx
+ 
+-	movq	%rsi,16(%rsp)
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
++	movq	%rsi,24(%rsp)
+ 
+ 
+ 	leaq	48(%rsi),%rdx
+@@ -340,13 +340,13 @@ sqrx_mont_384x:
+ 	call	__add_mod_384
+ 
+ 
+-	movq	16(%rsp),%rsi
++	movq	24(%rsp),%rsi
+ 	leaq	48(%rsi),%rdx
+ 	leaq	32+48(%rsp),%rdi
+ 	call	__sub_mod_384
+ 
+ 
+-	movq	16(%rsp),%rsi
++	movq	24(%rsp),%rsi
+ 	leaq	48(%rsi),%rbx
+ 
+ 	movq	48(%rsi),%rdx
+@@ -1004,7 +1004,6 @@ __sqrx_384:
+ 	movq	16(%rsi),%r15
+ 	movq	24(%rsi),%rcx
+ 	movq	32(%rsi),%rbx
+-.byte	102,72,15,110,199
+ 
+ 
+ 	mulxq	%r14,%r8,%rdi
+@@ -1072,7 +1071,7 @@ __sqrx_384:
+ 	mulxq	%rbp,%rdi,%rbx
+ 	movq	0(%rsi),%rdx
+ 	addq	%rdi,%rcx
+-.byte	102,72,15,126,199
++	movq	8(%rsp),%rdi
+ 	adcq	$0,%rbx
+ 
+ 
+@@ -1774,7 +1773,7 @@ mulx_mont_384:
+ 	movq	8(%rsi),%r15
+ 	movq	16(%rsi),%rax
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 	leaq	-128(%rsi),%rsi
+@@ -2141,7 +2140,7 @@ __mulx_mont_384:
+ 	adoxq	%r12,%r11
+ 	adcxq	%r12,%r11
+ 	imulq	8(%rsp),%rdx
+-.byte	102,72,15,126,195
++	movq	24(%rsp),%rbx
+ 
+ 
+ 	xorq	%r12,%r12
+@@ -2245,7 +2244,7 @@ sqrx_mont_384:
+ 	movq	8(%rsi),%r15
+ 	movq	16(%rsi),%rax
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 
+@@ -2308,7 +2307,7 @@ sqrx_n_mul_mont_384:
+ 
+ 	pushq	%r15
+ 
+-	leaq	-24(%rsp),%rsp
++	leaq	-40(%rsp),%rsp
+ 
+ .LSEH_body_sqrx_n_mul_mont_384:
+ 
+@@ -2319,12 +2318,12 @@ sqrx_n_mul_mont_384:
+ 	movq	16(%rsi),%rax
+ 	movq	%rsi,%rbx
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 
+ 	movq	%r8,(%rsp)
+-	movq	%r9,16(%rsp)
++	movq	%r9,24(%rsp)
+ 	movq	0(%r9),%xmm2
+ 
+ .Loop_sqrx_384:
+@@ -2342,25 +2341,25 @@ sqrx_n_mul_mont_384:
+ 	movq	%rdx,%r14
+ .byte	102,72,15,126,210
+ 	leaq	-128(%rbx),%rsi
+-	movq	16(%rsp),%rbx
++	movq	24(%rsp),%rbx
+ 	leaq	-128(%rcx),%rcx
+ 
+ 	mulxq	%r14,%r8,%r9
+ 	call	__mulx_mont_384
+ 
+-	movq	24(%rsp),%r15
++	movq	40(%rsp),%r15
+ 
+-	movq	32(%rsp),%r14
++	movq	48(%rsp),%r14
+ 
+-	movq	40(%rsp),%r13
++	movq	56(%rsp),%r13
+ 
+-	movq	48(%rsp),%r12
++	movq	64(%rsp),%r12
+ 
+-	movq	56(%rsp),%rbx
++	movq	72(%rsp),%rbx
+ 
+-	movq	64(%rsp),%rbp
++	movq	80(%rsp),%rbp
+ 
+-	leaq	72(%rsp),%rsp
++	leaq	88(%rsp),%rsp
+ 
+ .LSEH_epilogue_sqrx_n_mul_mont_384:
+ 	mov	8(%rsp),%rdi
+@@ -2400,7 +2399,7 @@ sqrx_n_mul_mont_383:
+ 
+ 	pushq	%r15
+ 
+-	leaq	-24(%rsp),%rsp
++	leaq	-40(%rsp),%rsp
+ 
+ .LSEH_body_sqrx_n_mul_mont_383:
+ 
+@@ -2411,12 +2410,12 @@ sqrx_n_mul_mont_383:
+ 	movq	16(%rsi),%rax
+ 	movq	%rsi,%rbx
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 
+ 	movq	%r8,(%rsp)
+-	movq	%r9,16(%rsp)
++	movq	%r9,24(%rsp)
+ 	movq	0(%r9),%xmm2
+ 	leaq	-128(%rcx),%rcx
+ 
+@@ -2434,24 +2433,24 @@ sqrx_n_mul_mont_383:
+ 	movq	%rdx,%r14
+ .byte	102,72,15,126,210
+ 	leaq	-128(%rbx),%rsi
+-	movq	16(%rsp),%rbx
++	movq	24(%rsp),%rbx
+ 
+ 	mulxq	%r14,%r8,%r9
+ 	call	__mulx_mont_384
+ 
+-	movq	24(%rsp),%r15
++	movq	40(%rsp),%r15
+ 
+-	movq	32(%rsp),%r14
++	movq	48(%rsp),%r14
+ 
+-	movq	40(%rsp),%r13
++	movq	56(%rsp),%r13
+ 
+-	movq	48(%rsp),%r12
++	movq	64(%rsp),%r12
+ 
+-	movq	56(%rsp),%rbx
++	movq	72(%rsp),%rbx
+ 
+-	movq	64(%rsp),%rbp
++	movq	80(%rsp),%rbp
+ 
+-	leaq	72(%rsp),%rsp
++	leaq	88(%rsp),%rsp
+ 
+ .LSEH_epilogue_sqrx_n_mul_mont_383:
+ 	mov	8(%rsp),%rdi
+@@ -2779,7 +2778,7 @@ __mulx_mont_383_nonred:
+ 	adoxq	%r11,%r10
+ 	adcxq	%r11,%r10
+ 	imulq	8(%rsp),%rdx
+-.byte	102,72,15,126,195
++	movq	24(%rsp),%rbx
+ 
+ 
+ 	xorq	%r12,%r12
+@@ -2857,8 +2856,8 @@ sqrx_mont_382x:
+ 
+ 	movq	%rcx,0(%rsp)
+ 	movq	%rdx,%rcx
+-	movq	%rsi,16(%rsp)
+-	movq	%rdi,%xmm0
++	movq	%rdi,16(%rsp)
++	movq	%rsi,24(%rsp)
+ 
+ 
+ 	movq	0(%rsi),%r8
+@@ -3495,15 +3494,15 @@ sqrx_mont_382x:
+ .byte	0,0
+ .LSEH_info_sqrx_n_mul_mont_384_body:
+ .byte	1,0,17,0
+-.byte	0x00,0xf4,0x03,0x00
+-.byte	0x00,0xe4,0x04,0x00
+-.byte	0x00,0xd4,0x05,0x00
+-.byte	0x00,0xc4,0x06,0x00
+-.byte	0x00,0x34,0x07,0x00
+-.byte	0x00,0x54,0x08,0x00
+-.byte	0x00,0x74,0x0a,0x00
+-.byte	0x00,0x64,0x0b,0x00
+-.byte	0x00,0x82
++.byte	0x00,0xf4,0x05,0x00
++.byte	0x00,0xe4,0x06,0x00
++.byte	0x00,0xd4,0x07,0x00
++.byte	0x00,0xc4,0x08,0x00
++.byte	0x00,0x34,0x09,0x00
++.byte	0x00,0x54,0x0a,0x00
++.byte	0x00,0x74,0x0c,0x00
++.byte	0x00,0x64,0x0d,0x00
++.byte	0x00,0xa2
+ .byte	0x00,0x00
+ .LSEH_info_sqrx_n_mul_mont_384_epilogue:
+ .byte	1,0,4,0
+@@ -3519,15 +3518,15 @@ sqrx_mont_382x:
+ .byte	0,0
+ .LSEH_info_sqrx_n_mul_mont_383_body:
+ .byte	1,0,17,0
+-.byte	0x00,0xf4,0x03,0x00
+-.byte	0x00,0xe4,0x04,0x00
+-.byte	0x00,0xd4,0x05,0x00
+-.byte	0x00,0xc4,0x06,0x00
+-.byte	0x00,0x34,0x07,0x00
+-.byte	0x00,0x54,0x08,0x00
+-.byte	0x00,0x74,0x0a,0x00
+-.byte	0x00,0x64,0x0b,0x00
+-.byte	0x00,0x82
++.byte	0x00,0xf4,0x05,0x00
++.byte	0x00,0xe4,0x06,0x00
++.byte	0x00,0xd4,0x07,0x00
++.byte	0x00,0xc4,0x08,0x00
++.byte	0x00,0x34,0x09,0x00
++.byte	0x00,0x54,0x0a,0x00
++.byte	0x00,0x74,0x0c,0x00
++.byte	0x00,0x64,0x0d,0x00
++.byte	0x00,0xa2
+ .byte	0x00,0x00
+ .LSEH_info_sqrx_n_mul_mont_383_epilogue:
+ .byte	1,0,4,0
+diff --git a/build/elf/mulq_mont_384-x86_64.s b/build/elf/mulq_mont_384-x86_64.s
+index dabf3ff..fa9dd35 100644
+--- a/build/elf/mulq_mont_384-x86_64.s
++++ b/build/elf/mulq_mont_384-x86_64.s
+@@ -327,8 +327,8 @@ sqr_mont_384x:
+ 
+ 	movq	%rcx,0(%rsp)
+ 	movq	%rdx,%rcx
++	movq	%rdi,8(%rsp)
+ 	movq	%rsi,16(%rsp)
+-.byte	102,72,15,110,199
+ 
+ 
+ 	leaq	48(%rsi),%rdx
+@@ -2043,8 +2043,8 @@ mul_mont_384:
+ 	pushq	%r15
+ .cfi_adjust_cfa_offset	8
+ .cfi_offset	%r15,-56
+-	pushq	%r8
+-.cfi_adjust_cfa_offset	8
++	subq	$24,%rsp
++.cfi_adjust_cfa_offset	8*3
+ 
+ 
+ 	movq	0(%rdx),%rax
+@@ -2053,24 +2053,25 @@ mul_mont_384:
+ 	movq	16(%rsi),%r12
+ 	movq	24(%rsi),%r13
+ 	movq	%rdx,%rbx
+-.byte	102,72,15,110,199
++	movq	%r8,0(%rsp)
++	movq	%rdi,8(%rsp)
+ 
+ 	call	__mulq_mont_384
+ 
+-	movq	8(%rsp),%r15
++	movq	24(%rsp),%r15
+ .cfi_restore	%r15
+-	movq	16(%rsp),%r14
++	movq	32(%rsp),%r14
+ .cfi_restore	%r14
+-	movq	24(%rsp),%r13
++	movq	40(%rsp),%r13
+ .cfi_restore	%r13
+-	movq	32(%rsp),%r12
++	movq	48(%rsp),%r12
+ .cfi_restore	%r12
+-	movq	40(%rsp),%rbx
++	movq	56(%rsp),%rbx
+ .cfi_restore	%rbx
+-	movq	48(%rsp),%rbp
++	movq	64(%rsp),%rbp
+ .cfi_restore	%rbp
+-	leaq	56(%rsp),%rsp
+-.cfi_adjust_cfa_offset	-56
++	leaq	72(%rsp),%rsp
++.cfi_adjust_cfa_offset	-72
+ 
+ 	.byte	0xf3,0xc3
+ .cfi_endproc	
+@@ -2649,7 +2650,7 @@ __mulq_mont_384:
+ 
+ 
+ 
+-.byte	102,72,15,126,199
++	movq	16(%rsp),%rdi
+ 	subq	0(%rcx),%r14
+ 	movq	%r15,%rdx
+ 	sbbq	8(%rcx),%r15
+@@ -2711,8 +2712,8 @@ sqr_n_mul_mont_384:
+ 
+ 
+ 	movq	%r8,0(%rsp)
+-	movq	%rcx,8(%rsp)
+-.byte	102,72,15,110,199
++	movq	%rdi,8(%rsp)
++	movq	%rcx,16(%rsp)
+ 	leaq	32(%rsp),%rdi
+ 	movq	%r9,24(%rsp)
+ 	movq	(%r9),%xmm2
+@@ -2724,7 +2725,7 @@ sqr_n_mul_mont_384:
+ 
+ 	leaq	0(%rdi),%rsi
+ 	movq	0(%rsp),%rcx
+-	movq	8(%rsp),%rbx
++	movq	16(%rsp),%rbx
+ 	call	__mulq_by_1_mont_384
+ 	call	__redc_tail_mont_384
+ 
+@@ -2799,8 +2800,8 @@ sqr_n_mul_mont_383:
+ 
+ 
+ 	movq	%r8,0(%rsp)
+-	movq	%rcx,8(%rsp)
+-.byte	102,72,15,110,199
++	movq	%rdi,8(%rsp)
++	movq	%rcx,16(%rsp)
+ 	leaq	32(%rsp),%rdi
+ 	movq	%r9,24(%rsp)
+ 	movq	(%r9),%xmm2
+@@ -2812,7 +2813,7 @@ sqr_n_mul_mont_383:
+ 
+ 	leaq	0(%rdi),%rsi
+ 	movq	0(%rsp),%rcx
+-	movq	8(%rsp),%rbx
++	movq	16(%rsp),%rbx
+ 	call	__mulq_by_1_mont_384
+ 
+ 	movd	%xmm1,%edx
+diff --git a/build/elf/mulx_mont_384-x86_64.s b/build/elf/mulx_mont_384-x86_64.s
+index 3748954..9f9f740 100644
+--- a/build/elf/mulx_mont_384-x86_64.s
++++ b/build/elf/mulx_mont_384-x86_64.s
+@@ -329,8 +329,8 @@ sqrx_mont_384x:
+ 	movq	%rcx,0(%rsp)
+ 	movq	%rdx,%rcx
+ 
+-	movq	%rsi,16(%rsp)
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
++	movq	%rsi,24(%rsp)
+ 
+ 
+ 	leaq	48(%rsi),%rdx
+@@ -338,13 +338,13 @@ sqrx_mont_384x:
+ 	call	__add_mod_384
+ 
+ 
+-	movq	16(%rsp),%rsi
++	movq	24(%rsp),%rsi
+ 	leaq	48(%rsi),%rdx
+ 	leaq	32+48(%rsp),%rdi
+ 	call	__sub_mod_384
+ 
+ 
+-	movq	16(%rsp),%rsi
++	movq	24(%rsp),%rsi
+ 	leaq	48(%rsi),%rbx
+ 
+ 	movq	48(%rsi),%rdx
+@@ -986,7 +986,6 @@ __sqrx_384:
+ 	movq	16(%rsi),%r15
+ 	movq	24(%rsi),%rcx
+ 	movq	32(%rsi),%rbx
+-.byte	102,72,15,110,199
+ 
+ 
+ 	mulxq	%r14,%r8,%rdi
+@@ -1054,7 +1053,7 @@ __sqrx_384:
+ 	mulxq	%rbp,%rdi,%rbx
+ 	movq	0(%rsi),%rdx
+ 	addq	%rdi,%rcx
+-.byte	102,72,15,126,199
++	movq	8(%rsp),%rdi
+ 	adcq	$0,%rbx
+ 
+ 
+@@ -1740,7 +1739,7 @@ mulx_mont_384:
+ 	movq	8(%rsi),%r15
+ 	movq	16(%rsi),%rax
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 	leaq	-128(%rsi),%rsi
+@@ -2105,7 +2104,7 @@ __mulx_mont_384:
+ 	adoxq	%r12,%r11
+ 	adcxq	%r12,%r11
+ 	imulq	8(%rsp),%rdx
+-.byte	102,72,15,126,195
++	movq	24(%rsp),%rbx
+ 
+ 
+ 	xorq	%r12,%r12
+@@ -2207,7 +2206,7 @@ sqrx_mont_384:
+ 	movq	8(%rsi),%r15
+ 	movq	16(%rsi),%rax
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 
+@@ -2264,8 +2263,8 @@ sqrx_n_mul_mont_384:
+ 	pushq	%r15
+ .cfi_adjust_cfa_offset	8
+ .cfi_offset	%r15,-56
+-	leaq	-24(%rsp),%rsp
+-.cfi_adjust_cfa_offset	8*3
++	leaq	-40(%rsp),%rsp
++.cfi_adjust_cfa_offset	8*5
+ 
+ 
+ 	movq	%rdx,%r10
+@@ -2274,12 +2273,12 @@ sqrx_n_mul_mont_384:
+ 	movq	16(%rsi),%rax
+ 	movq	%rsi,%rbx
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 
+ 	movq	%r8,(%rsp)
+-	movq	%r9,16(%rsp)
++	movq	%r9,24(%rsp)
+ 	movq	0(%r9),%xmm2
+ 
+ .Loop_sqrx_384:
+@@ -2297,26 +2296,26 @@ sqrx_n_mul_mont_384:
+ 	movq	%rdx,%r14
+ .byte	102,72,15,126,210
+ 	leaq	-128(%rbx),%rsi
+-	movq	16(%rsp),%rbx
++	movq	24(%rsp),%rbx
+ 	leaq	-128(%rcx),%rcx
+ 
+ 	mulxq	%r14,%r8,%r9
+ 	call	__mulx_mont_384
+ 
+-	movq	24(%rsp),%r15
++	movq	40(%rsp),%r15
+ .cfi_restore	%r15
+-	movq	32(%rsp),%r14
++	movq	48(%rsp),%r14
+ .cfi_restore	%r14
+-	movq	40(%rsp),%r13
++	movq	56(%rsp),%r13
+ .cfi_restore	%r13
+-	movq	48(%rsp),%r12
++	movq	64(%rsp),%r12
+ .cfi_restore	%r12
+-	movq	56(%rsp),%rbx
++	movq	72(%rsp),%rbx
+ .cfi_restore	%rbx
+-	movq	64(%rsp),%rbp
++	movq	80(%rsp),%rbp
+ .cfi_restore	%rbp
+-	leaq	72(%rsp),%rsp
+-.cfi_adjust_cfa_offset	-8*9
++	leaq	88(%rsp),%rsp
++.cfi_adjust_cfa_offset	-8*11
+ 
+ 	.byte	0xf3,0xc3
+ .cfi_endproc	
+@@ -2349,8 +2348,8 @@ sqrx_n_mul_mont_383:
+ 	pushq	%r15
+ .cfi_adjust_cfa_offset	8
+ .cfi_offset	%r15,-56
+-	leaq	-24(%rsp),%rsp
+-.cfi_adjust_cfa_offset	8*3
++	leaq	-40(%rsp),%rsp
++.cfi_adjust_cfa_offset	8*5
+ 
+ 
+ 	movq	%rdx,%r10
+@@ -2359,12 +2358,12 @@ sqrx_n_mul_mont_383:
+ 	movq	16(%rsi),%rax
+ 	movq	%rsi,%rbx
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 
+ 	movq	%r8,(%rsp)
+-	movq	%r9,16(%rsp)
++	movq	%r9,24(%rsp)
+ 	movq	0(%r9),%xmm2
+ 	leaq	-128(%rcx),%rcx
+ 
+@@ -2382,25 +2381,25 @@ sqrx_n_mul_mont_383:
+ 	movq	%rdx,%r14
+ .byte	102,72,15,126,210
+ 	leaq	-128(%rbx),%rsi
+-	movq	16(%rsp),%rbx
++	movq	24(%rsp),%rbx
+ 
+ 	mulxq	%r14,%r8,%r9
+ 	call	__mulx_mont_384
+ 
+-	movq	24(%rsp),%r15
++	movq	40(%rsp),%r15
+ .cfi_restore	%r15
+-	movq	32(%rsp),%r14
++	movq	48(%rsp),%r14
+ .cfi_restore	%r14
+-	movq	40(%rsp),%r13
++	movq	56(%rsp),%r13
+ .cfi_restore	%r13
+-	movq	48(%rsp),%r12
++	movq	64(%rsp),%r12
+ .cfi_restore	%r12
+-	movq	56(%rsp),%rbx
++	movq	72(%rsp),%rbx
+ .cfi_restore	%rbx
+-	movq	64(%rsp),%rbp
++	movq	80(%rsp),%rbp
+ .cfi_restore	%rbp
+-	leaq	72(%rsp),%rsp
+-.cfi_adjust_cfa_offset	-8*9
++	leaq	88(%rsp),%rsp
++.cfi_adjust_cfa_offset	-8*11
+ 
+ 	.byte	0xf3,0xc3
+ .cfi_endproc	
+@@ -2725,7 +2724,7 @@ __mulx_mont_383_nonred:
+ 	adoxq	%r11,%r10
+ 	adcxq	%r11,%r10
+ 	imulq	8(%rsp),%rdx
+-.byte	102,72,15,126,195
++	movq	24(%rsp),%rbx
+ 
+ 
+ 	xorq	%r12,%r12
+@@ -2801,8 +2800,8 @@ sqrx_mont_382x:
+ 
+ 	movq	%rcx,0(%rsp)
+ 	movq	%rdx,%rcx
+-	movq	%rsi,16(%rsp)
+-	movq	%rdi,%xmm0
++	movq	%rdi,16(%rsp)
++	movq	%rsi,24(%rsp)
+ 
+ 
+ 	movq	0(%rsi),%r8
+diff --git a/build/mach-o/mulq_mont_384-x86_64.s b/build/mach-o/mulq_mont_384-x86_64.s
+index 7465af4..0d8ac89 100644
+--- a/build/mach-o/mulq_mont_384-x86_64.s
++++ b/build/mach-o/mulq_mont_384-x86_64.s
+@@ -327,8 +327,8 @@ _sqr_mont_384x:
+ 
+ 	movq	%rcx,0(%rsp)
+ 	movq	%rdx,%rcx
++	movq	%rdi,8(%rsp)
+ 	movq	%rsi,16(%rsp)
+-.byte	102,72,15,110,199
+ 
+ 
+ 	leaq	48(%rsi),%rdx
+@@ -2043,8 +2043,8 @@ _mul_mont_384:
+ 	pushq	%r15
+ .cfi_adjust_cfa_offset	8
+ .cfi_offset	%r15,-56
+-	pushq	%r8
+-.cfi_adjust_cfa_offset	8
++	subq	$24,%rsp
++.cfi_adjust_cfa_offset	8*3
+ 
+ 
+ 	movq	0(%rdx),%rax
+@@ -2053,24 +2053,25 @@ _mul_mont_384:
+ 	movq	16(%rsi),%r12
+ 	movq	24(%rsi),%r13
+ 	movq	%rdx,%rbx
+-.byte	102,72,15,110,199
++	movq	%r8,0(%rsp)
++	movq	%rdi,8(%rsp)
+ 
+ 	call	__mulq_mont_384
+ 
+-	movq	8(%rsp),%r15
++	movq	24(%rsp),%r15
+ .cfi_restore	%r15
+-	movq	16(%rsp),%r14
++	movq	32(%rsp),%r14
+ .cfi_restore	%r14
+-	movq	24(%rsp),%r13
++	movq	40(%rsp),%r13
+ .cfi_restore	%r13
+-	movq	32(%rsp),%r12
++	movq	48(%rsp),%r12
+ .cfi_restore	%r12
+-	movq	40(%rsp),%rbx
++	movq	56(%rsp),%rbx
+ .cfi_restore	%rbx
+-	movq	48(%rsp),%rbp
++	movq	64(%rsp),%rbp
+ .cfi_restore	%rbp
+-	leaq	56(%rsp),%rsp
+-.cfi_adjust_cfa_offset	-56
++	leaq	72(%rsp),%rsp
++.cfi_adjust_cfa_offset	-72
+ 
+ 	.byte	0xf3,0xc3
+ .cfi_endproc	
+@@ -2649,7 +2650,7 @@ __mulq_mont_384:
+ 
+ 
+ 
+-.byte	102,72,15,126,199
++	movq	16(%rsp),%rdi
+ 	subq	0(%rcx),%r14
+ 	movq	%r15,%rdx
+ 	sbbq	8(%rcx),%r15
+@@ -2711,8 +2712,8 @@ _sqr_n_mul_mont_384:
+ 
+ 
+ 	movq	%r8,0(%rsp)
+-	movq	%rcx,8(%rsp)
+-.byte	102,72,15,110,199
++	movq	%rdi,8(%rsp)
++	movq	%rcx,16(%rsp)
+ 	leaq	32(%rsp),%rdi
+ 	movq	%r9,24(%rsp)
+ 	movq	(%r9),%xmm2
+@@ -2724,7 +2725,7 @@ L$oop_sqr_384:
+ 
+ 	leaq	0(%rdi),%rsi
+ 	movq	0(%rsp),%rcx
+-	movq	8(%rsp),%rbx
++	movq	16(%rsp),%rbx
+ 	call	__mulq_by_1_mont_384
+ 	call	__redc_tail_mont_384
+ 
+@@ -2799,8 +2800,8 @@ _sqr_n_mul_mont_383:
+ 
+ 
+ 	movq	%r8,0(%rsp)
+-	movq	%rcx,8(%rsp)
+-.byte	102,72,15,110,199
++	movq	%rdi,8(%rsp)
++	movq	%rcx,16(%rsp)
+ 	leaq	32(%rsp),%rdi
+ 	movq	%r9,24(%rsp)
+ 	movq	(%r9),%xmm2
+@@ -2812,7 +2813,7 @@ L$oop_sqr_383:
+ 
+ 	leaq	0(%rdi),%rsi
+ 	movq	0(%rsp),%rcx
+-	movq	8(%rsp),%rbx
++	movq	16(%rsp),%rbx
+ 	call	__mulq_by_1_mont_384
+ 
+ 	movd	%xmm1,%edx
+diff --git a/build/mach-o/mulx_mont_384-x86_64.s b/build/mach-o/mulx_mont_384-x86_64.s
+index 065d9ac..95d3dad 100644
+--- a/build/mach-o/mulx_mont_384-x86_64.s
++++ b/build/mach-o/mulx_mont_384-x86_64.s
+@@ -329,8 +329,8 @@ _sqrx_mont_384x:
+ 	movq	%rcx,0(%rsp)
+ 	movq	%rdx,%rcx
+ 
+-	movq	%rsi,16(%rsp)
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
++	movq	%rsi,24(%rsp)
+ 
+ 
+ 	leaq	48(%rsi),%rdx
+@@ -338,13 +338,13 @@ _sqrx_mont_384x:
+ 	call	__add_mod_384
+ 
+ 
+-	movq	16(%rsp),%rsi
++	movq	24(%rsp),%rsi
+ 	leaq	48(%rsi),%rdx
+ 	leaq	32+48(%rsp),%rdi
+ 	call	__sub_mod_384
+ 
+ 
+-	movq	16(%rsp),%rsi
++	movq	24(%rsp),%rsi
+ 	leaq	48(%rsi),%rbx
+ 
+ 	movq	48(%rsi),%rdx
+@@ -986,7 +986,6 @@ __sqrx_384:
+ 	movq	16(%rsi),%r15
+ 	movq	24(%rsi),%rcx
+ 	movq	32(%rsi),%rbx
+-.byte	102,72,15,110,199
+ 
+ 
+ 	mulxq	%r14,%r8,%rdi
+@@ -1054,7 +1053,7 @@ __sqrx_384:
+ 	mulxq	%rbp,%rdi,%rbx
+ 	movq	0(%rsi),%rdx
+ 	addq	%rdi,%rcx
+-.byte	102,72,15,126,199
++	movq	8(%rsp),%rdi
+ 	adcq	$0,%rbx
+ 
+ 
+@@ -1740,7 +1739,7 @@ _mulx_mont_384:
+ 	movq	8(%rsi),%r15
+ 	movq	16(%rsi),%rax
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 	leaq	-128(%rsi),%rsi
+@@ -2105,7 +2104,7 @@ __mulx_mont_384:
+ 	adoxq	%r12,%r11
+ 	adcxq	%r12,%r11
+ 	imulq	8(%rsp),%rdx
+-.byte	102,72,15,126,195
++	movq	24(%rsp),%rbx
+ 
+ 
+ 	xorq	%r12,%r12
+@@ -2207,7 +2206,7 @@ _sqrx_mont_384:
+ 	movq	8(%rsi),%r15
+ 	movq	16(%rsi),%rax
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 
+@@ -2264,8 +2263,8 @@ _sqrx_n_mul_mont_384:
+ 	pushq	%r15
+ .cfi_adjust_cfa_offset	8
+ .cfi_offset	%r15,-56
+-	leaq	-24(%rsp),%rsp
+-.cfi_adjust_cfa_offset	8*3
++	leaq	-40(%rsp),%rsp
++.cfi_adjust_cfa_offset	8*5
+ 
+ 
+ 	movq	%rdx,%r10
+@@ -2274,12 +2273,12 @@ _sqrx_n_mul_mont_384:
+ 	movq	16(%rsi),%rax
+ 	movq	%rsi,%rbx
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 
+ 	movq	%r8,(%rsp)
+-	movq	%r9,16(%rsp)
++	movq	%r9,24(%rsp)
+ 	movq	0(%r9),%xmm2
+ 
+ L$oop_sqrx_384:
+@@ -2297,26 +2296,26 @@ L$oop_sqrx_384:
+ 	movq	%rdx,%r14
+ .byte	102,72,15,126,210
+ 	leaq	-128(%rbx),%rsi
+-	movq	16(%rsp),%rbx
++	movq	24(%rsp),%rbx
+ 	leaq	-128(%rcx),%rcx
+ 
+ 	mulxq	%r14,%r8,%r9
+ 	call	__mulx_mont_384
+ 
+-	movq	24(%rsp),%r15
++	movq	40(%rsp),%r15
+ .cfi_restore	%r15
+-	movq	32(%rsp),%r14
++	movq	48(%rsp),%r14
+ .cfi_restore	%r14
+-	movq	40(%rsp),%r13
++	movq	56(%rsp),%r13
+ .cfi_restore	%r13
+-	movq	48(%rsp),%r12
++	movq	64(%rsp),%r12
+ .cfi_restore	%r12
+-	movq	56(%rsp),%rbx
++	movq	72(%rsp),%rbx
+ .cfi_restore	%rbx
+-	movq	64(%rsp),%rbp
++	movq	80(%rsp),%rbp
+ .cfi_restore	%rbp
+-	leaq	72(%rsp),%rsp
+-.cfi_adjust_cfa_offset	-8*9
++	leaq	88(%rsp),%rsp
++.cfi_adjust_cfa_offset	-8*11
+ 
+ 	.byte	0xf3,0xc3
+ .cfi_endproc	
+@@ -2349,8 +2348,8 @@ _sqrx_n_mul_mont_383:
+ 	pushq	%r15
+ .cfi_adjust_cfa_offset	8
+ .cfi_offset	%r15,-56
+-	leaq	-24(%rsp),%rsp
+-.cfi_adjust_cfa_offset	8*3
++	leaq	-40(%rsp),%rsp
++.cfi_adjust_cfa_offset	8*5
+ 
+ 
+ 	movq	%rdx,%r10
+@@ -2359,12 +2358,12 @@ _sqrx_n_mul_mont_383:
+ 	movq	16(%rsi),%rax
+ 	movq	%rsi,%rbx
+ 	movq	24(%rsi),%r12
+-.byte	102,72,15,110,199
++	movq	%rdi,16(%rsp)
+ 	movq	32(%rsi),%rdi
+ 	movq	40(%rsi),%rbp
+ 
+ 	movq	%r8,(%rsp)
+-	movq	%r9,16(%rsp)
++	movq	%r9,24(%rsp)
+ 	movq	0(%r9),%xmm2
+ 	leaq	-128(%rcx),%rcx
+ 
+@@ -2382,25 +2381,25 @@ L$oop_sqrx_383:
+ 	movq	%rdx,%r14
+ .byte	102,72,15,126,210
+ 	leaq	-128(%rbx),%rsi
+-	movq	16(%rsp),%rbx
++	movq	24(%rsp),%rbx
+ 
+ 	mulxq	%r14,%r8,%r9
+ 	call	__mulx_mont_384
+ 
+-	movq	24(%rsp),%r15
++	movq	40(%rsp),%r15
+ .cfi_restore	%r15
+-	movq	32(%rsp),%r14
++	movq	48(%rsp),%r14
+ .cfi_restore	%r14
+-	movq	40(%rsp),%r13
++	movq	56(%rsp),%r13
+ .cfi_restore	%r13
+-	movq	48(%rsp),%r12
++	movq	64(%rsp),%r12
+ .cfi_restore	%r12
+-	movq	56(%rsp),%rbx
++	movq	72(%rsp),%rbx
+ .cfi_restore	%rbx
+-	movq	64(%rsp),%rbp
++	movq	80(%rsp),%rbp
+ .cfi_restore	%rbp
+-	leaq	72(%rsp),%rsp
+-.cfi_adjust_cfa_offset	-8*9
++	leaq	88(%rsp),%rsp
++.cfi_adjust_cfa_offset	-8*11
+ 
+ 	.byte	0xf3,0xc3
+ .cfi_endproc	
+@@ -2725,7 +2724,7 @@ __mulx_mont_383_nonred:
+ 	adoxq	%r11,%r10
+ 	adcxq	%r11,%r10
+ 	imulq	8(%rsp),%rdx
+-.byte	102,72,15,126,195
++	movq	24(%rsp),%rbx
+ 
+ 
+ 	xorq	%r12,%r12
+@@ -2801,8 +2800,8 @@ _sqrx_mont_382x:
+ 
+ 	movq	%rcx,0(%rsp)
+ 	movq	%rdx,%rcx
+-	movq	%rsi,16(%rsp)
+-	movq	%rdi,%xmm0
++	movq	%rdi,16(%rsp)
++	movq	%rsi,24(%rsp)
+ 
+ 
+ 	movq	0(%rsi),%r8
+diff --git a/build/win64/blst.def b/build/win64/blst.def
+index d3ab2f1..78a0c1d 100644
+--- a/build/win64/blst.def
++++ b/build/win64/blst.def
+@@ -1,6 +1,4 @@
+-LIBRARY blst
+-
+-EXPORTS
++LIBRARY blst\n\nEXPORTS
+ 	blst_scalar_from_uint32
+ 	blst_uint32_from_scalar
+ 	blst_scalar_from_uint64
+diff --git a/build/win64/mulq_mont_384-x86_64.asm b/build/win64/mulq_mont_384-x86_64.asm
+index c6d6d29..0ccb467 100644
+--- a/build/win64/mulq_mont_384-x86_64.asm
++++ b/build/win64/mulq_mont_384-x86_64.asm
+@@ -330,8 +330,8 @@ $L$SEH_body_sqr_mont_384x::
+ 
+ 	mov	QWORD PTR[rsp],rcx
+ 	mov	rcx,rdx
++	mov	QWORD PTR[8+rsp],rdi
+ 	mov	QWORD PTR[16+rsp],rsi
+-DB	102,72,15,110,199
+ 
+ 
+ 	lea	rdx,QWORD PTR[48+rsi]
+@@ -2101,7 +2101,7 @@ $L$SEH_begin_mul_mont_384::
+ 
+ 	push	r15
+ 
+-	push	r8
++	sub	rsp,8*3
+ 
+ $L$SEH_body_mul_mont_384::
+ 
+@@ -2112,23 +2112,24 @@ $L$SEH_body_mul_mont_384::
+ 	mov	r12,QWORD PTR[16+rsi]
+ 	mov	r13,QWORD PTR[24+rsi]
+ 	mov	rbx,rdx
+-DB	102,72,15,110,199
++	mov	QWORD PTR[rsp],r8
++	mov	QWORD PTR[8+rsp],rdi
+ 
+ 	call	__mulq_mont_384
+ 
+-	mov	r15,QWORD PTR[8+rsp]
++	mov	r15,QWORD PTR[24+rsp]
+ 
+-	mov	r14,QWORD PTR[16+rsp]
++	mov	r14,QWORD PTR[32+rsp]
+ 
+-	mov	r13,QWORD PTR[24+rsp]
++	mov	r13,QWORD PTR[40+rsp]
+ 
+-	mov	r12,QWORD PTR[32+rsp]
++	mov	r12,QWORD PTR[48+rsp]
+ 
+-	mov	rbx,QWORD PTR[40+rsp]
++	mov	rbx,QWORD PTR[56+rsp]
+ 
+-	mov	rbp,QWORD PTR[48+rsp]
++	mov	rbp,QWORD PTR[64+rsp]
+ 
+-	lea	rsp,QWORD PTR[56+rsp]
++	lea	rsp,QWORD PTR[72+rsp]
+ 
+ $L$SEH_epilogue_mul_mont_384::
+ 	mov	rdi,QWORD PTR[8+rsp]	;WIN64 epilogue
+@@ -2710,7 +2711,7 @@ __mulq_mont_384	PROC PRIVATE
+ 
+ 
+ 
+-DB	102,72,15,126,199
++	mov	rdi,QWORD PTR[16+rsp]
+ 	sub	r14,QWORD PTR[rcx]
+ 	mov	rdx,r15
+ 	sbb	r15,QWORD PTR[8+rcx]
+@@ -2776,8 +2777,8 @@ $L$SEH_body_sqr_n_mul_mont_384::
+ 
+ 
+ 	mov	QWORD PTR[rsp],r8
+-	mov	QWORD PTR[8+rsp],rcx
+-DB	102,72,15,110,199
++	mov	QWORD PTR[8+rsp],rdi
++	mov	QWORD PTR[16+rsp],rcx
+ 	lea	rdi,QWORD PTR[32+rsp]
+ 	mov	QWORD PTR[24+rsp],r9
+ 	movq	xmm2,QWORD PTR[r9]
+@@ -2789,7 +2790,7 @@ $L$oop_sqr_384::
+ 
+ 	lea	rsi,QWORD PTR[rdi]
+ 	mov	rcx,QWORD PTR[rsp]
+-	mov	rbx,QWORD PTR[8+rsp]
++	mov	rbx,QWORD PTR[16+rsp]
+ 	call	__mulq_by_1_mont_384
+ 	call	__redc_tail_mont_384
+ 
+@@ -2873,8 +2874,8 @@ $L$SEH_body_sqr_n_mul_mont_383::
+ 
+ 
+ 	mov	QWORD PTR[rsp],r8
+-	mov	QWORD PTR[8+rsp],rcx
+-DB	102,72,15,110,199
++	mov	QWORD PTR[8+rsp],rdi
++	mov	QWORD PTR[16+rsp],rcx
+ 	lea	rdi,QWORD PTR[32+rsp]
+ 	mov	QWORD PTR[24+rsp],r9
+ 	movq	xmm2,QWORD PTR[r9]
+@@ -2886,7 +2887,7 @@ $L$oop_sqr_383::
+ 
+ 	lea	rsi,QWORD PTR[rdi]
+ 	mov	rcx,QWORD PTR[rsp]
+-	mov	rbx,QWORD PTR[8+rsp]
++	mov	rbx,QWORD PTR[16+rsp]
+ 	call	__mulq_by_1_mont_384
+ 
+ 	movd	edx,xmm1
+@@ -4142,15 +4143,15 @@ DB	0,003h
+ DB	0,0
+ $L$SEH_info_mul_mont_384_body::
+ DB	1,0,17,0
+-DB	000h,0f4h,001h,000h
+-DB	000h,0e4h,002h,000h
+-DB	000h,0d4h,003h,000h
+-DB	000h,0c4h,004h,000h
+-DB	000h,034h,005h,000h
+-DB	000h,054h,006h,000h
+-DB	000h,074h,008h,000h
+-DB	000h,064h,009h,000h
+-DB	000h,062h
++DB	000h,0f4h,003h,000h
++DB	000h,0e4h,004h,000h
++DB	000h,0d4h,005h,000h
++DB	000h,0c4h,006h,000h
++DB	000h,034h,007h,000h
++DB	000h,054h,008h,000h
++DB	000h,074h,00ah,000h
++DB	000h,064h,00bh,000h
++DB	000h,082h
+ DB	000h,000h
+ $L$SEH_info_mul_mont_384_epilogue::
+ DB	1,0,4,0
+diff --git a/build/win64/mulx_mont_384-x86_64.asm b/build/win64/mulx_mont_384-x86_64.asm
+index bd2c091..25bee97 100644
+--- a/build/win64/mulx_mont_384-x86_64.asm
++++ b/build/win64/mulx_mont_384-x86_64.asm
+@@ -332,8 +332,8 @@ $L$SEH_body_sqrx_mont_384x::
+ 	mov	QWORD PTR[rsp],rcx
+ 	mov	rcx,rdx
+ 
+-	mov	QWORD PTR[16+rsp],rsi
+-DB	102,72,15,110,199
++	mov	QWORD PTR[16+rsp],rdi
++	mov	QWORD PTR[24+rsp],rsi
+ 
+ 
+ 	lea	rdx,QWORD PTR[48+rsi]
+@@ -341,13 +341,13 @@ DB	102,72,15,110,199
+ 	call	__add_mod_384
+ 
+ 
+-	mov	rsi,QWORD PTR[16+rsp]
++	mov	rsi,QWORD PTR[24+rsp]
+ 	lea	rdx,QWORD PTR[48+rsi]
+ 	lea	rdi,QWORD PTR[((32+48))+rsp]
+ 	call	__sub_mod_384
+ 
+ 
+-	mov	rsi,QWORD PTR[16+rsp]
++	mov	rsi,QWORD PTR[24+rsp]
+ 	lea	rbx,QWORD PTR[48+rsi]
+ 
+ 	mov	rdx,QWORD PTR[48+rsi]
+@@ -1012,7 +1012,6 @@ __sqrx_384	PROC PRIVATE
+ 	mov	r15,QWORD PTR[16+rsi]
+ 	mov	rcx,QWORD PTR[24+rsi]
+ 	mov	rbx,QWORD PTR[32+rsi]
+-DB	102,72,15,110,199
+ 
+ 
+ 	mulx	rdi,r8,r14
+@@ -1080,7 +1079,7 @@ DB	102,72,15,110,199
+ 	mulx	rbx,rdi,rbp
+ 	mov	rdx,QWORD PTR[rsi]
+ 	add	rcx,rdi
+-DB	102,72,15,126,199
++	mov	rdi,QWORD PTR[8+rsp]
+ 	adc	rbx,0
+ 
+ 
+@@ -1789,7 +1788,7 @@ $L$SEH_body_mulx_mont_384::
+ 	mov	r15,QWORD PTR[8+rsi]
+ 	mov	rax,QWORD PTR[16+rsi]
+ 	mov	r12,QWORD PTR[24+rsi]
+-DB	102,72,15,110,199
++	mov	QWORD PTR[16+rsp],rdi
+ 	mov	rdi,QWORD PTR[32+rsi]
+ 	mov	rbp,QWORD PTR[40+rsi]
+ 	lea	rsi,QWORD PTR[((-128))+rsi]
+@@ -2156,7 +2155,7 @@ __mulx_mont_384	PROC PRIVATE
+ 	adox	r11,r12
+ 	adcx	r11,r12
+ 	imul	rdx,QWORD PTR[8+rsp]
+-DB	102,72,15,126,195
++	mov	rbx,QWORD PTR[24+rsp]
+ 
+ 
+ 	xor	r12,r12
+@@ -2261,7 +2260,7 @@ $L$SEH_body_sqrx_mont_384::
+ 	mov	r15,QWORD PTR[8+rsi]
+ 	mov	rax,QWORD PTR[16+rsi]
+ 	mov	r12,QWORD PTR[24+rsi]
+-DB	102,72,15,110,199
++	mov	QWORD PTR[16+rsp],rdi
+ 	mov	rdi,QWORD PTR[32+rsi]
+ 	mov	rbp,QWORD PTR[40+rsi]
+ 
+@@ -2326,7 +2325,7 @@ $L$SEH_begin_sqrx_n_mul_mont_384::
+ 
+ 	push	r15
+ 
+-	lea	rsp,QWORD PTR[((-24))+rsp]
++	lea	rsp,QWORD PTR[((-40))+rsp]
+ 
+ $L$SEH_body_sqrx_n_mul_mont_384::
+ 
+@@ -2337,12 +2336,12 @@ $L$SEH_body_sqrx_n_mul_mont_384::
+ 	mov	rax,QWORD PTR[16+rsi]
+ 	mov	rbx,rsi
+ 	mov	r12,QWORD PTR[24+rsi]
+-DB	102,72,15,110,199
++	mov	QWORD PTR[16+rsp],rdi
+ 	mov	rdi,QWORD PTR[32+rsi]
+ 	mov	rbp,QWORD PTR[40+rsi]
+ 
+ 	mov	QWORD PTR[rsp],r8
+-	mov	QWORD PTR[16+rsp],r9
++	mov	QWORD PTR[24+rsp],r9
+ 	movq	xmm2,QWORD PTR[r9]
+ 
+ $L$oop_sqrx_384::
+@@ -2360,25 +2359,25 @@ $L$oop_sqrx_384::
+ 	mov	r14,rdx
+ DB	102,72,15,126,210
+ 	lea	rsi,QWORD PTR[((-128))+rbx]
+-	mov	rbx,QWORD PTR[16+rsp]
++	mov	rbx,QWORD PTR[24+rsp]
+ 	lea	rcx,QWORD PTR[((-128))+rcx]
+ 
+ 	mulx	r9,r8,r14
+ 	call	__mulx_mont_384
+ 
+-	mov	r15,QWORD PTR[24+rsp]
++	mov	r15,QWORD PTR[40+rsp]
+ 
+-	mov	r14,QWORD PTR[32+rsp]
++	mov	r14,QWORD PTR[48+rsp]
+ 
+-	mov	r13,QWORD PTR[40+rsp]
++	mov	r13,QWORD PTR[56+rsp]
+ 
+-	mov	r12,QWORD PTR[48+rsp]
++	mov	r12,QWORD PTR[64+rsp]
+ 
+-	mov	rbx,QWORD PTR[56+rsp]
++	mov	rbx,QWORD PTR[72+rsp]
+ 
+-	mov	rbp,QWORD PTR[64+rsp]
++	mov	rbp,QWORD PTR[80+rsp]
+ 
+-	lea	rsp,QWORD PTR[72+rsp]
++	lea	rsp,QWORD PTR[88+rsp]
+ 
+ $L$SEH_epilogue_sqrx_n_mul_mont_384::
+ 	mov	rdi,QWORD PTR[8+rsp]	;WIN64 epilogue
+@@ -2420,7 +2419,7 @@ $L$SEH_begin_sqrx_n_mul_mont_383::
+ 
+ 	push	r15
+ 
+-	lea	rsp,QWORD PTR[((-24))+rsp]
++	lea	rsp,QWORD PTR[((-40))+rsp]
+ 
+ $L$SEH_body_sqrx_n_mul_mont_383::
+ 
+@@ -2431,12 +2430,12 @@ $L$SEH_body_sqrx_n_mul_mont_383::
+ 	mov	rax,QWORD PTR[16+rsi]
+ 	mov	rbx,rsi
+ 	mov	r12,QWORD PTR[24+rsi]
+-DB	102,72,15,110,199
++	mov	QWORD PTR[16+rsp],rdi
+ 	mov	rdi,QWORD PTR[32+rsi]
+ 	mov	rbp,QWORD PTR[40+rsi]
+ 
+ 	mov	QWORD PTR[rsp],r8
+-	mov	QWORD PTR[16+rsp],r9
++	mov	QWORD PTR[24+rsp],r9
+ 	movq	xmm2,QWORD PTR[r9]
+ 	lea	rcx,QWORD PTR[((-128))+rcx]
+ 
+@@ -2454,24 +2453,24 @@ $L$oop_sqrx_383::
+ 	mov	r14,rdx
+ DB	102,72,15,126,210
+ 	lea	rsi,QWORD PTR[((-128))+rbx]
+-	mov	rbx,QWORD PTR[16+rsp]
++	mov	rbx,QWORD PTR[24+rsp]
+ 
+ 	mulx	r9,r8,r14
+ 	call	__mulx_mont_384
+ 
+-	mov	r15,QWORD PTR[24+rsp]
++	mov	r15,QWORD PTR[40+rsp]
+ 
+-	mov	r14,QWORD PTR[32+rsp]
++	mov	r14,QWORD PTR[48+rsp]
+ 
+-	mov	r13,QWORD PTR[40+rsp]
++	mov	r13,QWORD PTR[56+rsp]
+ 
+-	mov	r12,QWORD PTR[48+rsp]
++	mov	r12,QWORD PTR[64+rsp]
+ 
+-	mov	rbx,QWORD PTR[56+rsp]
++	mov	rbx,QWORD PTR[72+rsp]
+ 
+-	mov	rbp,QWORD PTR[64+rsp]
++	mov	rbp,QWORD PTR[80+rsp]
+ 
+-	lea	rsp,QWORD PTR[72+rsp]
++	lea	rsp,QWORD PTR[88+rsp]
+ 
+ $L$SEH_epilogue_sqrx_n_mul_mont_383::
+ 	mov	rdi,QWORD PTR[8+rsp]	;WIN64 epilogue
+@@ -2799,7 +2798,7 @@ __mulx_mont_383_nonred	PROC PRIVATE
+ 	adox	r10,r11
+ 	adcx	r10,r11
+ 	imul	rdx,QWORD PTR[8+rsp]
+-DB	102,72,15,126,195
++	mov	rbx,QWORD PTR[24+rsp]
+ 
+ 
+ 	xor	r12,r12
+@@ -2878,8 +2877,8 @@ $L$SEH_body_sqrx_mont_382x::
+ 
+ 	mov	QWORD PTR[rsp],rcx
+ 	mov	rcx,rdx
+-	mov	QWORD PTR[16+rsp],rsi
+-	movq	xmm0,rdi
++	mov	QWORD PTR[16+rsp],rdi
++	mov	QWORD PTR[24+rsp],rsi
+ 
+ 
+ 	mov	r8,QWORD PTR[rsi]
+@@ -3519,15 +3518,15 @@ DB	0,003h
+ DB	0,0
+ $L$SEH_info_sqrx_n_mul_mont_384_body::
+ DB	1,0,17,0
+-DB	000h,0f4h,003h,000h
+-DB	000h,0e4h,004h,000h
+-DB	000h,0d4h,005h,000h
+-DB	000h,0c4h,006h,000h
+-DB	000h,034h,007h,000h
+-DB	000h,054h,008h,000h
+-DB	000h,074h,00ah,000h
+-DB	000h,064h,00bh,000h
+-DB	000h,082h
++DB	000h,0f4h,005h,000h
++DB	000h,0e4h,006h,000h
++DB	000h,0d4h,007h,000h
++DB	000h,0c4h,008h,000h
++DB	000h,034h,009h,000h
++DB	000h,054h,00ah,000h
++DB	000h,074h,00ch,000h
++DB	000h,064h,00dh,000h
++DB	000h,0a2h
+ DB	000h,000h
+ $L$SEH_info_sqrx_n_mul_mont_384_epilogue::
+ DB	1,0,4,0
+@@ -3543,15 +3542,15 @@ DB	0,003h
+ DB	0,0
+ $L$SEH_info_sqrx_n_mul_mont_383_body::
+ DB	1,0,17,0
+-DB	000h,0f4h,003h,000h
+-DB	000h,0e4h,004h,000h
+-DB	000h,0d4h,005h,000h
+-DB	000h,0c4h,006h,000h
+-DB	000h,034h,007h,000h
+-DB	000h,054h,008h,000h
+-DB	000h,074h,00ah,000h
+-DB	000h,064h,00bh,000h
+-DB	000h,082h
++DB	000h,0f4h,005h,000h
++DB	000h,0e4h,006h,000h
++DB	000h,0d4h,007h,000h
++DB	000h,0c4h,008h,000h
++DB	000h,034h,009h,000h
++DB	000h,054h,00ah,000h
++DB	000h,074h,00ch,000h
++DB	000h,064h,00dh,000h
++DB	000h,0a2h
+ DB	000h,000h
+ $L$SEH_info_sqrx_n_mul_mont_383_epilogue::
+ DB	1,0,4,0

--- a/proof/memory_safety.saw
+++ b/proof/memory_safety.saw
@@ -13,8 +13,8 @@ include "types.saw";
 
 m <- llvm_load_module "../build/llvm/libblst.a.bc";
 m_noadx <- llvm_load_module "../build/llvm_noadx/libblst.a.bc";
-m_patched <- llvm_load_module "../build/llvm_patched/libblst.a.bc";
-m_noadx_patched <- llvm_load_module "../build/llvm_noadx_patched/libblst.a.bc";
+m_recent <- llvm_load_module "../build/llvm_recent/libblst.a.bc";
+m_noadx_recent <- llvm_load_module "../build/llvm_noadx_recent/libblst.a.bc";
 
 let do_prove = true;
 include "proof-helpers.saw";

--- a/proof/memory_safety.saw
+++ b/proof/memory_safety.saw
@@ -13,6 +13,9 @@ include "types.saw";
 
 m <- llvm_load_module "../build/llvm/libblst.a.bc";
 m_noadx <- llvm_load_module "../build/llvm_noadx/libblst.a.bc";
+m_patched <- llvm_load_module "../build/llvm_patched/libblst.a.bc";
+m_noadx_patched <- llvm_load_module "../build/llvm_noadx_patched/libblst.a.bc";
+
 let do_prove = true;
 include "proof-helpers.saw";
 

--- a/proof/memory_safety.saw
+++ b/proof/memory_safety.saw
@@ -12,6 +12,7 @@ include "list_utils.saw";
 include "types.saw";
 
 m <- llvm_load_module "../build/llvm/libblst.a.bc";
+m_noadx <- llvm_load_module "../build/llvm_noadx/libblst.a.bc";
 let do_prove = true;
 include "proof-helpers.saw";
 

--- a/proof/x86.saw
+++ b/proof/x86.saw
@@ -23,8 +23,8 @@ let verify_x86_helper path module name spec =
   crucible_llvm_unsafe_assume_spec module name spec;
 let verify_x86 = verify_x86_helper "../../build/x86/libblst.so" m;
 let verify_x86_noadx = verify_x86_helper "../../build/x86_noadx/libblst.so" m_noadx;
-let verify_x86_patched = verify_x86_helper "../../build/x86_patched/libblst.so" m_patched;
-let verify_x86_noadx_patched = verify_x86_helper "../../build/x86_noadx_patched/libblst.so" m_noadx_patched;
+let verify_x86_recent = verify_x86_helper "../../build/x86_recent/libblst.so" m_recent;
+let verify_x86_noadx_recent = verify_x86_helper "../../build/x86_noadx_recent/libblst.so" m_noadx_recent;
 
 include "x86/add_mod_256.saw";
 include "x86/add_mod_384.saw";

--- a/proof/x86.saw
+++ b/proof/x86.saw
@@ -11,26 +11,20 @@ let x86_tactic = do {
 };
 
 let do_prove_x86 = true;
-let verify_x86 name spec =
+let verify_x86_helper path module name spec =
   if do_prove_x86
   then
-  crucible_llvm_verify_x86 m "../../build/x86/libblst.so" name
+  crucible_llvm_verify_x86 module path name
     []
     false
     spec
     x86_tactic
   else
-  crucible_llvm_unsafe_assume_spec m name spec;
-let verify_x86_noadx name spec =
-  if do_prove_x86
-  then
-  crucible_llvm_verify_x86 m_noadx "../../build/x86_noadx/libblst.so" name
-    []
-    false
-    spec
-    x86_tactic
-  else
-  crucible_llvm_unsafe_assume_spec m_noadx name spec;
+  crucible_llvm_unsafe_assume_spec module name spec;
+let verify_x86 = verify_x86_helper "../../build/x86/libblst.so" m;
+let verify_x86_noadx = verify_x86_helper "../../build/x86_noadx/libblst.so" m_noadx;
+let verify_x86_patched = verify_x86_helper "../../build/x86_patched/libblst.so" m_patched;
+let verify_x86_noadx_patched = verify_x86_helper "../../build/x86_noadx_patched/libblst.so" m_noadx_patched;
 
 include "x86/add_mod_256.saw";
 include "x86/add_mod_384.saw";
@@ -41,6 +35,8 @@ include "x86/mulx_mont_384.saw";
 
 include "x86/mulq_mont_256.saw";
 include "x86/mulq_mont_384.saw";
+include "x86/ctx_inverse_mod_384.saw";
+include "x86/ctq_inverse_mod_384.saw";
 
 let assembly_overrides = concat_all
   [ add_mod_256_overrides

--- a/proof/x86.saw
+++ b/proof/x86.saw
@@ -21,6 +21,16 @@ let verify_x86 name spec =
     x86_tactic
   else
   crucible_llvm_unsafe_assume_spec m name spec;
+let verify_x86_noadx name spec =
+  if do_prove_x86
+  then
+  crucible_llvm_verify_x86 m_noadx "../../build/x86_noadx/libblst.so" name
+    []
+    false
+    spec
+    x86_tactic
+  else
+  crucible_llvm_unsafe_assume_spec m_noadx name spec;
 
 include "x86/add_mod_256.saw";
 include "x86/add_mod_384.saw";
@@ -28,6 +38,9 @@ include "x86/add_mod_384x384.saw";
 include "x86/inverse_mod_384.saw";
 include "x86/mulx_mont_256.saw";
 include "x86/mulx_mont_384.saw";
+
+include "x86/mulq_mont_256.saw";
+include "x86/mulq_mont_384.saw";
 
 let assembly_overrides = concat_all
   [ add_mod_256_overrides

--- a/proof/x86/ctq_inverse_mod_384.saw
+++ b/proof/x86/ctq_inverse_mod_384.saw
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Galois, Inc.
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+///////////////////////////////////////////////////////////////////////////////
+// Specifications
+///////////////////////////////////////////////////////////////////////////////
+
+// ct_inverse_mod_383
+let ct_inverse_mod_383_spec = do {
+  ret_ptr <- crucible_alloc vec768_type;
+  (_, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384_type;
+  (_, mod_ptr) <- ptr_to_fresh_readonly "mod" vec384_type;
+  crucible_execute_func [ret_ptr, inp_ptr, mod_ptr];
+  new_ret <- crucible_fresh_var "new_ret" vec768_type;
+  crucible_points_to ret_ptr (crucible_term new_ret);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Proofs
+///////////////////////////////////////////////////////////////////////////////
+
+enable_what4_hash_consing;
+set_x86_stack_base_align 9;
+
+// ct_inverse_mod_383
+verify_x86_noadx_patched "ct_inverse_mod_383" ct_inverse_mod_383_spec;
+
+disable_what4_hash_consing;
+default_x86_stack_base_align;

--- a/proof/x86/ctq_inverse_mod_384.saw
+++ b/proof/x86/ctq_inverse_mod_384.saw
@@ -25,7 +25,7 @@ enable_what4_hash_consing;
 set_x86_stack_base_align 512;
 
 // ct_inverse_mod_383
-verify_x86_noadx_patched "ct_inverse_mod_383" ct_inverse_mod_383_spec;
+verify_x86_noadx_recent "ct_inverse_mod_383" ct_inverse_mod_383_spec;
 
 disable_what4_hash_consing;
 default_x86_stack_base_align;

--- a/proof/x86/ctq_inverse_mod_384.saw
+++ b/proof/x86/ctq_inverse_mod_384.saw
@@ -22,7 +22,7 @@ let ct_inverse_mod_383_spec = do {
 ///////////////////////////////////////////////////////////////////////////////
 
 enable_what4_hash_consing;
-set_x86_stack_base_align 9;
+set_x86_stack_base_align 512;
 
 // ct_inverse_mod_383
 verify_x86_noadx_patched "ct_inverse_mod_383" ct_inverse_mod_383_spec;

--- a/proof/x86/ctx_inverse_mod_384.saw
+++ b/proof/x86/ctx_inverse_mod_384.saw
@@ -21,8 +21,22 @@ let ct_inverse_mod_383_spec = do {
 // Proofs
 ///////////////////////////////////////////////////////////////////////////////
 
+// Some elements of ctx_inverse_mod_383 present some performance problems for the
+// simulator. We enable some options here in order to make things easier:
+// - enable_x86_what4_hash_consing improves term sharing during simulation in
+//   some cases.
+// - set_x86_stack_base_align sets the alignment of the base of the stack
+//   allocation to 512 bytes. In the simulator's memory model, addresses are
+//   represented as an abstract base plus an offset bitvector. Since the base is
+//   abstract, we know little about the actual value of the address, making it
+//   difficult to perform bitwise operations on addresses. However, if the base
+//   is known to have a certain alignment, we know that a certain number of low
+//   bits of the pointer are determined entirely by the offset. This makes it
+//   possible to apply bitwise operations that only influence those bits
+//   directly to the offset.
+
 enable_x86_what4_hash_consing;
-set_x86_stack_base_align 9;
+set_x86_stack_base_align 512;
 
 // ctx_inverse_mod_383
 verify_x86_patched "ctx_inverse_mod_383" ct_inverse_mod_383_spec;

--- a/proof/x86/ctx_inverse_mod_384.saw
+++ b/proof/x86/ctx_inverse_mod_384.saw
@@ -31,7 +31,7 @@ let ct_inverse_mod_383_spec = do {
 //   abstract, we know little about the actual value of the address, making it
 //   difficult to perform bitwise operations on addresses. However, if the base
 //   is known to have a certain alignment, we know that a certain number of low
-//   bits of the pointer are determined entirely by the offset. This makes it
+//   bits of the address are determined entirely by the offset. This makes it
 //   possible to apply bitwise operations that only influence those bits
 //   directly to the offset.
 

--- a/proof/x86/ctx_inverse_mod_384.saw
+++ b/proof/x86/ctx_inverse_mod_384.saw
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Galois, Inc.
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+///////////////////////////////////////////////////////////////////////////////
+// Specifications
+///////////////////////////////////////////////////////////////////////////////
+
+// ct_inverse_mod_383
+let ct_inverse_mod_383_spec = do {
+  ret_ptr <- crucible_alloc vec768_type;
+  (_, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384_type;
+  (_, mod_ptr) <- ptr_to_fresh_readonly "mod" vec384_type;
+  crucible_execute_func [ret_ptr, inp_ptr, mod_ptr];
+  new_ret <- crucible_fresh_var "new_ret" vec768_type;
+  crucible_points_to ret_ptr (crucible_term new_ret);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Proofs
+///////////////////////////////////////////////////////////////////////////////
+
+enable_what4_hash_consing;
+set_x86_stack_base_align 9;
+
+// ctx_inverse_mod_383
+verify_x86_patched "ctx_inverse_mod_383" ct_inverse_mod_383_spec;
+
+disable_what4_hash_consing;
+default_x86_stack_base_align;

--- a/proof/x86/ctx_inverse_mod_384.saw
+++ b/proof/x86/ctx_inverse_mod_384.saw
@@ -21,11 +21,11 @@ let ct_inverse_mod_383_spec = do {
 // Proofs
 ///////////////////////////////////////////////////////////////////////////////
 
-enable_what4_hash_consing;
+enable_x86_what4_hash_consing;
 set_x86_stack_base_align 9;
 
 // ctx_inverse_mod_383
 verify_x86_patched "ctx_inverse_mod_383" ct_inverse_mod_383_spec;
 
-disable_what4_hash_consing;
+disable_x86_what4_hash_consing;
 default_x86_stack_base_align;

--- a/proof/x86/ctx_inverse_mod_384.saw
+++ b/proof/x86/ctx_inverse_mod_384.saw
@@ -33,7 +33,9 @@ let ct_inverse_mod_383_spec = do {
 //   is known to have a certain alignment, we know that a certain number of low
 //   bits of the address are determined entirely by the offset. This makes it
 //   possible to apply bitwise operations that only influence those bits
-//   directly to the offset.
+//   directly to the offset. From an assurance perspective, this corresponds to
+//   a loss of some generality in the precondition describing the initial value
+//   of RSP.
 
 enable_x86_what4_hash_consing;
 set_x86_stack_base_align 512;

--- a/proof/x86/ctx_inverse_mod_384.saw
+++ b/proof/x86/ctx_inverse_mod_384.saw
@@ -39,7 +39,7 @@ enable_x86_what4_hash_consing;
 set_x86_stack_base_align 512;
 
 // ctx_inverse_mod_383
-verify_x86_patched "ctx_inverse_mod_383" ct_inverse_mod_383_spec;
+verify_x86_recent "ctx_inverse_mod_383" ct_inverse_mod_383_spec;
 
 disable_x86_what4_hash_consing;
 default_x86_stack_base_align;

--- a/proof/x86/inverse_mod_384.saw
+++ b/proof/x86/inverse_mod_384.saw
@@ -34,7 +34,7 @@ let eucl_inverse_mod_384_alias_ret_a_spec = do {
 // Proofs
 ///////////////////////////////////////////////////////////////////////////////
 
-// eucl_inverse_mod_384 - runs out of memory
+// eucl_inverse_mod_384 - assumed
 let do_prove_x86 = false;
 eucl_inverse_mod_384_ov <- verify_x86 "eucl_inverse_mod_384" eucl_inverse_mod_384_spec;
 eucl_inverse_mod_384_alias_ret_a_ov <- verify_x86 "eucl_inverse_mod_384" eucl_inverse_mod_384_alias_ret_a_spec;

--- a/proof/x86/inverse_mod_384.saw
+++ b/proof/x86/inverse_mod_384.saw
@@ -35,10 +35,8 @@ let eucl_inverse_mod_384_alias_ret_a_spec = do {
 ///////////////////////////////////////////////////////////////////////////////
 
 // eucl_inverse_mod_384 - assumed
-let do_prove_x86 = false;
-eucl_inverse_mod_384_ov <- verify_x86 "eucl_inverse_mod_384" eucl_inverse_mod_384_spec;
-eucl_inverse_mod_384_alias_ret_a_ov <- verify_x86 "eucl_inverse_mod_384" eucl_inverse_mod_384_alias_ret_a_spec;
-let do_prove_x86 = true;
+eucl_inverse_mod_384_ov <- admit "eucl_inverse_mod_384" eucl_inverse_mod_384_spec;
+eucl_inverse_mod_384_alias_ret_a_ov <- admit "eucl_inverse_mod_384" eucl_inverse_mod_384_alias_ret_a_spec;
 
 let inverse_mod_384_overrides =
   [ eucl_inverse_mod_384_ov

--- a/proof/x86/mulq_mont_256.saw
+++ b/proof/x86/mulq_mont_256.saw
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020 Galois, Inc.
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+///////////////////////////////////////////////////////////////////////////////
+// Specifications
+///////////////////////////////////////////////////////////////////////////////
+
+// mulq_mont_sparse_256
+let mulq_mont_sparse_256_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term n0];
+  new_mul_mont_sparse_256_ret <- crucible_fresh_var "new_mul_mont_sparse_256_ret" vec256_type;
+  crucible_points_to ret_ptr (crucible_term new_mul_mont_sparse_256_ret);
+};
+
+let mulq_mont_sparse_256_alias_ret_a_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term n0];
+  new_mul_mont_sparse_256_alias_ret <- crucible_fresh_var "new_mul_mont_sparse_256_alias_ret" vec256_type;
+  crucible_points_to ret_ptr (crucible_term new_mul_mont_sparse_256_alias_ret);
+};
+
+// sqrq_mont_sparse_256
+let sqrq_mont_sparse_256_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
+  new_sqr_mont_sparse_256_ret <- crucible_fresh_var "new_sqr_mont_sparse_256_ret" vec256_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_mont_sparse_256_ret);
+};
+
+// fromq_mont_256
+let fromq_mont_256_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
+  new_from_mont_256_ret <- crucible_fresh_var "new_from_mont_256_ret" vec256_type;
+  crucible_points_to ret_ptr (crucible_term new_from_mont_256_ret);
+};
+
+// redcq_mont_256
+let redcq_mont_256_spec = do {
+  ret_ptr <- crucible_alloc vec256_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec512_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term n0];
+  new_redc_mont_256_ret <- crucible_fresh_var "new_redc_mont_256_ret" vec256_type;
+  crucible_points_to ret_ptr (crucible_term new_redc_mont_256_ret);
+};
+
+let redcq_mont_256_alias_ret_a_spec = do {
+  (_, a_ptr) <- ptr_to_fresh "a" vec512_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [a_ptr, a_ptr, b_ptr, crucible_term n0];
+  new_redc_mont_256_alias_1_2_a <- crucible_fresh_var "new_redc_mont_256_alias_1_2_a" vec512_type;
+  crucible_points_to a_ptr (crucible_term new_redc_mont_256_alias_1_2_a);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Proofs
+///////////////////////////////////////////////////////////////////////////////
+
+// mulq_mont_sparse_256
+mulq_mont_sparse_256_ov <- verify_x86_noadx "mul_mont_sparse_256" mulq_mont_sparse_256_spec;
+mulq_mont_sparse_256_alias_ret_a_ov <- verify_x86_noadx "mul_mont_sparse_256" mulq_mont_sparse_256_alias_ret_a_spec;
+
+// sqrq_mont_sparse_256
+sqrq_mont_sparse_256_ov <- verify_x86_noadx "sqr_mont_sparse_256" sqrq_mont_sparse_256_spec;
+
+// fromq_mont_256
+fromq_mont_256_ov <- verify_x86_noadx "from_mont_256" fromq_mont_256_spec;
+
+// redcq_mont_256
+redcq_mont_256_ov <- verify_x86_noadx "redc_mont_256" redcq_mont_256_spec;
+redcq_mont_256_alias_ret_a_ov <- verify_x86_noadx "redc_mont_256" redcq_mont_256_alias_ret_a_spec;
+
+let mulq_mont_256_overrides =
+  [ mulq_mont_sparse_256_ov
+  , mulq_mont_sparse_256_alias_ret_a_ov
+
+  , sqrq_mont_sparse_256_ov
+
+  , fromq_mont_256_ov
+
+  , redcq_mont_256_ov
+  , redcq_mont_256_alias_ret_a_ov
+  ];

--- a/proof/x86/mulq_mont_384.saw
+++ b/proof/x86/mulq_mont_384.saw
@@ -258,7 +258,7 @@ mulq_mont_384x_ov <- verify_x86_noadx "mul_mont_384x" mulq_mont_384x_spec;
 mulq_mont_384x_alias_ret_ret_ov <- verify_x86_noadx "mul_mont_384x" mulq_mont_384x_alias_ret_ret_spec;
 mulq_mont_384x_alias_ret_a_ret_ov <- verify_x86_noadx "mul_mont_384x" mulq_mont_384x_alias_ret_a_ret_spec;
 
-// sqrq_mont_384x - counterexample for internal var
+// sqrq_mont_384x
 sqrq_mont_384x_ov <- verify_x86_noadx "sqr_mont_384x" sqrq_mont_384x_spec;
 sqrq_mont_384x_alias_ov <- verify_x86_noadx "sqr_mont_384x" sqrq_mont_384x_alias_spec;
 
@@ -285,11 +285,11 @@ mulq_mont_384_ov <- verify_x86_noadx "mul_mont_384" mulq_mont_384_spec;
 mulq_mont_384_ret_ret_ov <- verify_x86_noadx "mul_mont_384" mulq_mont_384_ret_ret_spec;
 mulq_mont_384_ret_a_ret_ov <- verify_x86_noadx "mul_mont_384" mulq_mont_384_ret_a_ret_spec;
 
-// sqrq_mont_384 - counterexample for internal var
+// sqrq_mont_384
 sqrq_mont_384_ov <- verify_x86_noadx "sqr_mont_384" sqrq_mont_384_spec;
 sqrq_mont_384_alias_ov <- verify_x86_noadx "sqr_mont_384" sqrq_mont_384_alias_spec;
 
-// sqrq_n_mul_mont_383 - performance issue
+// sqrq_n_mul_mont_383
 sqrq_n_mul_mont_383_count1_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 1);
 sqrq_n_mul_mont_383_count2_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 2);
 sqrq_n_mul_mont_383_count3_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 3);
@@ -316,7 +316,7 @@ sqrq_n_mul_mont_383_alias_1_2_count10_ov <- verify_x86_noadx "sqr_n_mul_mont_383
 sqrq_n_mul_mont_383_alias_1_2_count11_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 11);
 sqrq_n_mul_mont_383_alias_1_2_count12_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 12);
 
-// sqrq_mont_382x - counterexample for internal var
+// sqrq_mont_382x
 sqrq_mont_382x_ov <- verify_x86_noadx "sqr_mont_382x" sqrq_mont_382x_spec;
 sqrq_mont_382x_alias_ov <- verify_x86_noadx "sqr_mont_382x" sqrq_mont_382x_alias_spec;
 

--- a/proof/x86/mulq_mont_384.saw
+++ b/proof/x86/mulq_mont_384.saw
@@ -43,7 +43,7 @@ let mulq_mont_384x_alias_ret_a_ret_spec = do {
 // sqrq_mont_384x
 let sqrq_mont_384x_spec = do {
   ret_ptr <- crucible_alloc vec384x_type;
-  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
   n0 <- crucible_fresh_var "n0" limb_type;
   crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
@@ -208,25 +208,23 @@ let sqrq_n_mul_mont_384_spec  = do {
 };
 
 // sqrq_n_mul_mont_383
-let sqrq_n_mul_mont_383_spec  = do {
+let sqrq_n_mul_mont_383_spec count = do {
   ret_ptr <- crucible_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  count <- crucible_fresh_var "count" size_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
   n0 <- crucible_fresh_var "n0" limb_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
+  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{ `count : [64] }}, p_ptr, crucible_term n0, b_ptr];
   new_sqr_n_mul_mont_383_ret <- crucible_fresh_var "new_sqr_n_mul_mont_383_ret" vec384_type;
   crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_383_ret);
 };
 
-let sqrq_n_mul_mont_383_alias_1_2_spec  = do {
+let sqrq_n_mul_mont_383_alias_1_2_spec count = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
-  count <- crucible_fresh_var "count" size_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
   n0 <- crucible_fresh_var "n0" limb_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
+  crucible_execute_func [ret_ptr, ret_ptr, crucible_term {{ `count : [64] }}, p_ptr, crucible_term n0, b_ptr];
   new_sqr_n_mul_mont_383_alias_1_2_ret <- crucible_fresh_var "new_sqr_n_mul_mont_383_alias_1_2_ret" vec384_type;
   crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_383_alias_1_2_ret);
 };
@@ -234,7 +232,7 @@ let sqrq_n_mul_mont_383_alias_1_2_spec  = do {
 // sqrq_mont_382x
 let sqrq_mont_382x_spec = do {
   ret_ptr <- crucible_alloc vec384x_type;
-  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
   n0 <- crucible_fresh_var "n0" limb_type;
   crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
@@ -261,10 +259,8 @@ mulq_mont_384x_alias_ret_ret_ov <- verify_x86_noadx "mul_mont_384x" mulq_mont_38
 mulq_mont_384x_alias_ret_a_ret_ov <- verify_x86_noadx "mul_mont_384x" mulq_mont_384x_alias_ret_a_ret_spec;
 
 // sqrq_mont_384x - counterexample for internal var
-let do_prove_x86 = false;
 sqrq_mont_384x_ov <- verify_x86_noadx "sqr_mont_384x" sqrq_mont_384x_spec;
 sqrq_mont_384x_alias_ov <- verify_x86_noadx "sqr_mont_384x" sqrq_mont_384x_alias_spec;
-let do_prove_x86 = true;
 
 // mulq_382x
 mulq_382x_ov <- verify_x86_noadx "mul_382x" mulq_382x_spec;
@@ -284,30 +280,45 @@ sgn0q_pty_mont_384_ov <- verify_x86_noadx "sgn0_pty_mont_384" sgn0q_pty_mont_384
 // sqn0x_pty_mont_384x
 sgn0q_pty_mont_384x_ov <- verify_x86_noadx "sgn0_pty_mont_384x" sgn0q_pty_mont_384x_spec;
 
-// mulq_mont_384 - counterexample for var_macaw_reg55
-let do_prove_x86 = false;
+// mulq_mont_384
 mulq_mont_384_ov <- verify_x86_noadx "mul_mont_384" mulq_mont_384_spec;
 mulq_mont_384_ret_ret_ov <- verify_x86_noadx "mul_mont_384" mulq_mont_384_ret_ret_spec;
 mulq_mont_384_ret_a_ret_ov <- verify_x86_noadx "mul_mont_384" mulq_mont_384_ret_a_ret_spec;
-let do_prove_x86 = true;
 
 // sqrq_mont_384 - counterexample for internal var
-let do_prove_x86 = false;
 sqrq_mont_384_ov <- verify_x86_noadx "sqr_mont_384" sqrq_mont_384_spec;
 sqrq_mont_384_alias_ov <- verify_x86_noadx "sqr_mont_384" sqrq_mont_384_alias_spec;
-let do_prove_x86 = true;
 
 // sqrq_n_mul_mont_383 - performance issue
-let do_prove_x86 = false;
-sqrq_n_mul_mont_383_ov <- verify_x86_noadx "sqr_n_mul_mont_383" sqrq_n_mul_mont_383_spec;
-sqrq_n_mul_mont_383_alias_1_2_ov <- verify_x86_noadx "sqr_n_mul_mont_383" sqrq_n_mul_mont_383_alias_1_2_spec;
-let do_prove_x86 = true;
+sqrq_n_mul_mont_383_count1_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 1);
+sqrq_n_mul_mont_383_count2_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 2);
+sqrq_n_mul_mont_383_count3_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 3);
+sqrq_n_mul_mont_383_count4_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 4);
+sqrq_n_mul_mont_383_count5_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 5);
+sqrq_n_mul_mont_383_count6_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 6);
+sqrq_n_mul_mont_383_count7_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 7);
+sqrq_n_mul_mont_383_count8_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 8);
+sqrq_n_mul_mont_383_count9_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 9);
+sqrq_n_mul_mont_383_count10_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 10);
+sqrq_n_mul_mont_383_count11_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 11);
+sqrq_n_mul_mont_383_count12_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_spec 12);
+
+sqrq_n_mul_mont_383_alias_1_2_count1_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 1);
+sqrq_n_mul_mont_383_alias_1_2_count2_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 2);
+sqrq_n_mul_mont_383_alias_1_2_count3_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 3);
+sqrq_n_mul_mont_383_alias_1_2_count4_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 4);
+sqrq_n_mul_mont_383_alias_1_2_count5_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 5);
+sqrq_n_mul_mont_383_alias_1_2_count6_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 6);
+sqrq_n_mul_mont_383_alias_1_2_count7_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 7);
+sqrq_n_mul_mont_383_alias_1_2_count8_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 8);
+sqrq_n_mul_mont_383_alias_1_2_count9_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 9);
+sqrq_n_mul_mont_383_alias_1_2_count10_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 10);
+sqrq_n_mul_mont_383_alias_1_2_count11_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 11);
+sqrq_n_mul_mont_383_alias_1_2_count12_ov <- verify_x86_noadx "sqr_n_mul_mont_383" (sqrq_n_mul_mont_383_alias_1_2_spec 12);
 
 // sqrq_mont_382x - counterexample for internal var
-let do_prove_x86 = false;
 sqrq_mont_382x_ov <- verify_x86_noadx "sqr_mont_382x" sqrq_mont_382x_spec;
 sqrq_mont_382x_alias_ov <- verify_x86_noadx "sqr_mont_382x" sqrq_mont_382x_alias_spec;
-let do_prove_x86 = true;
 
 let mulq_mont_384_overrides =
   [ mulq_mont_384x_ov
@@ -336,8 +347,31 @@ let mulq_mont_384_overrides =
   , sqrq_mont_384_ov
   , sqrq_mont_384_alias_ov
 
-  , sqrq_n_mul_mont_383_ov
-  , sqrq_n_mul_mont_383_alias_1_2_ov
+  , sqrq_n_mul_mont_383_count1_ov
+  , sqrq_n_mul_mont_383_count2_ov
+  , sqrq_n_mul_mont_383_count3_ov
+  , sqrq_n_mul_mont_383_count4_ov
+  , sqrq_n_mul_mont_383_count5_ov
+  , sqrq_n_mul_mont_383_count6_ov
+  , sqrq_n_mul_mont_383_count7_ov
+  , sqrq_n_mul_mont_383_count8_ov
+  , sqrq_n_mul_mont_383_count9_ov
+  , sqrq_n_mul_mont_383_count10_ov
+  , sqrq_n_mul_mont_383_count11_ov
+  , sqrq_n_mul_mont_383_count12_ov
+
+  , sqrq_n_mul_mont_383_alias_1_2_count1_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count2_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count3_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count4_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count5_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count6_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count7_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count8_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count9_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count10_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count11_ov
+  , sqrq_n_mul_mont_383_alias_1_2_count12_ov
 
   , sqrq_mont_382x_ov
   , sqrq_mont_382x_alias_ov

--- a/proof/x86/mulq_mont_384.saw
+++ b/proof/x86/mulq_mont_384.saw
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2020 Galois, Inc.
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+///////////////////////////////////////////////////////////////////////////////
+// Specifications
+///////////////////////////////////////////////////////////////////////////////
+
+// mulq_mont_384x
+let mulq_mont_384x_spec = do {
+  ret_ptr <- crucible_alloc vec384x_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term n0];
+  new_mul_mont_384x_ret <- crucible_fresh_var "new_mul_mont_384x_ret" vec384x_type;
+  crucible_points_to ret_ptr (crucible_term new_mul_mont_384x_ret);
+};
+
+let mulq_mont_384x_alias_ret_ret_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term n0];
+  new_mul_mont_384x_alias_ret <- crucible_fresh_var "new_mul_mont_384x_alias_ret" vec384x_type;
+  crucible_points_to ret_ptr (crucible_term new_mul_mont_384x_alias_ret);
+};
+
+let mulq_mont_384x_alias_ret_a_ret_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, crucible_term n0];
+  new_mul_mont_384x_alias_ret <- crucible_fresh_var "new_mul_mont_384x_alias_ret" vec384x_type;
+  crucible_points_to ret_ptr (crucible_term new_mul_mont_384x_alias_ret);
+};
+
+
+// sqrq_mont_384x
+let sqrq_mont_384x_spec = do {
+  ret_ptr <- crucible_alloc vec384x_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
+  new_sqr_mont_384x_ret <- crucible_fresh_var "new_sqr_mont_384x_ret" vec384x_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384x_ret);
+};
+
+let sqrq_mont_384x_alias_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term n0];
+  new_sqr_mont_384x_alias_ret <- crucible_fresh_var "new_sqr_mont_384x_alias_ret" vec384x_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384x_alias_ret);
+};
+
+// mulq_382x
+let mulq_382x_spec = do {
+  ret_ptr <- crucible_alloc vec768x_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_mul_382x_ret <- crucible_fresh_var "new_mul_382x_ret" vec768x_type;
+  crucible_points_to ret_ptr (crucible_term new_mul_382x_ret);
+};
+
+// sqrq_382x
+let sqrq_382x_spec = do {
+  ret_ptr <- crucible_alloc vec768x_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
+  new_sqr_382x_ret <- crucible_fresh_var "new_sqr_382x_ret" vec768x_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_382x_ret);
+};
+
+// mulq_384
+let mulq_384_spec = do {
+  ret_ptr <- crucible_alloc vec768_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
+  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
+  new_mul_384_ret <- crucible_fresh_var "new_mul_384_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_mul_384_ret);
+};
+
+// sqrq_384
+let sqrq_384_spec = do {
+  ret_ptr <- crucible_alloc vec768_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  crucible_execute_func [ret_ptr, a_ptr];
+  new_sqr_384_ret <- crucible_fresh_var "new_sqr_384_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_384_ret);
+};
+
+// redcq_mont_384
+let redcq_mont_384_spec = do {
+  ret_ptr <- crucible_alloc vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term n0];
+  new_redc_mont_384_ret <- crucible_fresh_var "new_redc_mont_384_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_redc_mont_384_ret);
+};
+
+// fromq_mont_384
+let fromq_mont_384_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
+  new_from_mont_384_ret <- crucible_fresh_var "new_from_mont_384_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_from_mont_384_ret);
+};
+
+// sqn0x_pty_mont_384
+let sgn0q_pty_mont_384_spec = do {
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [a_ptr, p_ptr, crucible_term n0];
+  ret <- crucible_fresh_var "ret" limb_type;
+  crucible_return (crucible_term ret);
+};
+
+// sqn0x_pty_mont_384x
+let sgn0q_pty_mont_384x_spec = do {
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [a_ptr, p_ptr, crucible_term n0];
+  ret <- crucible_fresh_var "ret" limb_type;
+  crucible_return (crucible_term ret);
+};
+
+// mulq_mont_384
+let mulq_mont_384_spec = do {
+  ret_ptr <- crucible_alloc vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term n0];
+  new_mul_mont_384_ret <- crucible_fresh_var "new_mul_mont_384_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_mul_mont_384_ret);
+};
+
+let mulq_mont_384_ret_ret_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term n0];
+  new_mul_mont_384_alias_ret <- crucible_fresh_var "new_mul_mont_384_alias_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_mul_mont_384_alias_ret);
+};
+
+let mulq_mont_384_ret_a_ret_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, crucible_term n0];
+  new_mul_mont_384_alias_ret <- crucible_fresh_var "new_mul_mont_384_alias_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_mul_mont_384_alias_ret);
+};
+
+// sqrq_mont_384
+let sqrq_mont_384_spec = do {
+  ret_ptr <- crucible_alloc vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
+  new_sqr_mont_384_ret <- crucible_fresh_var "new_sqr_mont_384_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384_ret);
+};
+
+let sqrq_mont_384_alias_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term n0];
+  new_sqr_mont_384_alias_ret <- crucible_fresh_var "new_sqr_mont_384_alias_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384_alias_ret);
+};
+
+// sqrq_n_mul_mont_384
+let sqrq_n_mul_mont_384_spec  = do {
+  ret_ptr <- crucible_alloc vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  count <- crucible_fresh_var "count" size_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
+  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
+  new_sqr_n_mul_mont_384_ret <- crucible_fresh_var "new_sqr_n_mul_mont_384_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_384_ret);
+};
+
+// sqrq_n_mul_mont_383
+let sqrq_n_mul_mont_383_spec  = do {
+  ret_ptr <- crucible_alloc vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  count <- crucible_fresh_var "count" size_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
+  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
+  new_sqr_n_mul_mont_383_ret <- crucible_fresh_var "new_sqr_n_mul_mont_383_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_383_ret);
+};
+
+let sqrq_n_mul_mont_383_alias_1_2_spec  = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
+  count <- crucible_fresh_var "count" size_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
+  crucible_execute_func [ret_ptr, ret_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
+  new_sqr_n_mul_mont_383_alias_1_2_ret <- crucible_fresh_var "new_sqr_n_mul_mont_383_alias_1_2_ret" vec384_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_383_alias_1_2_ret);
+};
+
+// sqrq_mont_382x
+let sqrq_mont_382x_spec = do {
+  ret_ptr <- crucible_alloc vec384x_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
+  new_sqr_mont_382x_ret <- crucible_fresh_var "new_sqr_mont_382x_ret" vec384x_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_mont_382x_ret);
+};
+
+let sqrq_mont_382x_alias_spec = do {
+  (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+  n0 <- crucible_fresh_var "n0" limb_type;
+  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term n0];
+  new_sqr_mont_382x_alias_ret <- crucible_fresh_var "new_sqr_mont_382x_alias_ret" vec384x_type;
+  crucible_points_to ret_ptr (crucible_term new_sqr_mont_382x_alias_ret);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Proofs
+///////////////////////////////////////////////////////////////////////////////
+
+// mulq_mont_384x
+mulq_mont_384x_ov <- verify_x86_noadx "mul_mont_384x" mulq_mont_384x_spec;
+mulq_mont_384x_alias_ret_ret_ov <- verify_x86_noadx "mul_mont_384x" mulq_mont_384x_alias_ret_ret_spec;
+mulq_mont_384x_alias_ret_a_ret_ov <- verify_x86_noadx "mul_mont_384x" mulq_mont_384x_alias_ret_a_ret_spec;
+
+// sqrq_mont_384x - counterexample for internal var
+let do_prove_x86 = false;
+sqrq_mont_384x_ov <- verify_x86_noadx "sqr_mont_384x" sqrq_mont_384x_spec;
+sqrq_mont_384x_alias_ov <- verify_x86_noadx "sqr_mont_384x" sqrq_mont_384x_alias_spec;
+let do_prove_x86 = true;
+
+// mulq_382x
+mulq_382x_ov <- verify_x86_noadx "mul_382x" mulq_382x_spec;
+
+// sqrq_382x
+sqrq_382x_ov <- verify_x86_noadx "sqr_382x" sqrq_382x_spec;
+
+// redcq_mont_384
+redcq_mont_384_ov <- verify_x86_noadx "redc_mont_384" redcq_mont_384_spec;
+
+// fromq_mont_384
+fromq_mont_384_ov <- verify_x86_noadx "from_mont_384" fromq_mont_384_spec;
+
+// sqn0x_pty_mont_384
+sgn0q_pty_mont_384_ov <- verify_x86_noadx "sgn0_pty_mont_384" sgn0q_pty_mont_384_spec;
+
+// sqn0x_pty_mont_384x
+sgn0q_pty_mont_384x_ov <- verify_x86_noadx "sgn0_pty_mont_384x" sgn0q_pty_mont_384x_spec;
+
+// mulq_mont_384 - counterexample for var_macaw_reg55
+let do_prove_x86 = false;
+mulq_mont_384_ov <- verify_x86_noadx "mul_mont_384" mulq_mont_384_spec;
+mulq_mont_384_ret_ret_ov <- verify_x86_noadx "mul_mont_384" mulq_mont_384_ret_ret_spec;
+mulq_mont_384_ret_a_ret_ov <- verify_x86_noadx "mul_mont_384" mulq_mont_384_ret_a_ret_spec;
+let do_prove_x86 = true;
+
+// sqrq_mont_384 - counterexample for internal var
+let do_prove_x86 = false;
+sqrq_mont_384_ov <- verify_x86_noadx "sqr_mont_384" sqrq_mont_384_spec;
+sqrq_mont_384_alias_ov <- verify_x86_noadx "sqr_mont_384" sqrq_mont_384_alias_spec;
+let do_prove_x86 = true;
+
+// sqrq_n_mul_mont_383 - performance issue
+let do_prove_x86 = false;
+sqrq_n_mul_mont_383_ov <- verify_x86_noadx "sqr_n_mul_mont_383" sqrq_n_mul_mont_383_spec;
+sqrq_n_mul_mont_383_alias_1_2_ov <- verify_x86_noadx "sqr_n_mul_mont_383" sqrq_n_mul_mont_383_alias_1_2_spec;
+let do_prove_x86 = true;
+
+// sqrq_mont_382x - counterexample for internal var
+let do_prove_x86 = false;
+sqrq_mont_382x_ov <- verify_x86_noadx "sqr_mont_382x" sqrq_mont_382x_spec;
+sqrq_mont_382x_alias_ov <- verify_x86_noadx "sqr_mont_382x" sqrq_mont_382x_alias_spec;
+let do_prove_x86 = true;
+
+let mulq_mont_384_overrides =
+  [ mulq_mont_384x_ov
+  , mulq_mont_384x_alias_ret_ret_ov
+  , mulq_mont_384x_alias_ret_a_ret_ov
+
+  , sqrq_mont_384x_ov
+  , sqrq_mont_384x_alias_ov
+
+  , mulq_382x_ov
+
+  , sqrq_382x_ov
+
+  , redcq_mont_384_ov
+
+  , fromq_mont_384_ov
+
+  , sgn0q_pty_mont_384_ov
+
+  , sgn0q_pty_mont_384x_ov
+
+  , mulq_mont_384_ov
+  , mulq_mont_384_ret_ret_ov
+  , mulq_mont_384_ret_a_ret_ov
+
+  , sqrq_mont_384_ov
+  , sqrq_mont_384_alias_ov
+
+  , sqrq_n_mul_mont_383_ov
+  , sqrq_n_mul_mont_383_alias_1_2_ov
+
+  , sqrq_mont_382x_ov
+  , sqrq_mont_382x_alias_ov
+  ];

--- a/proof/x86/mulx_mont_384.saw
+++ b/proof/x86/mulx_mont_384.saw
@@ -43,7 +43,7 @@ let mulx_mont_384x_alias_ret_a_ret_spec = do {
 // sqrx_mont_384x
 let sqrx_mont_384x_spec = do {
   ret_ptr <- crucible_alloc vec384x_type;
-  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
   n0 <- crucible_fresh_var "n0" limb_type;
   crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
@@ -195,38 +195,36 @@ let sqrx_mont_384_alias_spec = do {
 };
 
 // sqrx_n_mul_mont_384
-let sqrx_n_mul_mont_384_spec  = do {
-  ret_ptr <- crucible_alloc vec384_type;
-  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  count <- crucible_fresh_var "count" size_type;
-  (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
-  new_sqr_n_mul_mont_384_ret <- crucible_fresh_var "new_sqr_n_mul_mont_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_384_ret);
-};
+// let sqrx_n_mul_mont_384_spec  = do {
+//   ret_ptr <- crucible_alloc vec384_type;
+//   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+//   count <- crucible_fresh_var "count" size_type;
+//   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
+//   n0 <- crucible_fresh_var "n0" limb_type;
+//   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
+//   crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
+//   new_sqr_n_mul_mont_384_ret <- crucible_fresh_var "new_sqr_n_mul_mont_384_ret" vec384_type;
+//   crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_384_ret);
+// };
 
 // sqrx_n_mul_mont_383
-let sqrx_n_mul_mont_383_spec  = do {
+let sqrx_n_mul_mont_383_spec count = do {
   ret_ptr <- crucible_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  count <- crucible_fresh_var "count" size_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
   n0 <- crucible_fresh_var "n0" limb_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
+  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{ `count : [64] }}, p_ptr, crucible_term n0, b_ptr];
   new_sqr_n_mul_mont_383_ret <- crucible_fresh_var "new_sqr_n_mul_mont_383_ret" vec384_type;
   crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_383_ret);
 };
 
-let sqrx_n_mul_mont_383_alias_1_2_spec  = do {
+let sqrx_n_mul_mont_383_alias_1_2_spec count = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
-  count <- crucible_fresh_var "count" size_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
   n0 <- crucible_fresh_var "n0" limb_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
+  crucible_execute_func [ret_ptr, ret_ptr, crucible_term {{ `count : [64] }}, p_ptr, crucible_term n0, b_ptr];
   new_sqr_n_mul_mont_383_alias_1_2_ret <- crucible_fresh_var "new_sqr_n_mul_mont_383_alias_1_2_ret" vec384_type;
   crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_383_alias_1_2_ret);
 };
@@ -234,7 +232,7 @@ let sqrx_n_mul_mont_383_alias_1_2_spec  = do {
 // sqrx_mont_382x
 let sqrx_mont_382x_spec = do {
   ret_ptr <- crucible_alloc vec384x_type;
-  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
+  (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
   n0 <- crucible_fresh_var "n0" limb_type;
   crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
@@ -261,10 +259,8 @@ mulx_mont_384x_alias_ret_ret_ov <- verify_x86 "mulx_mont_384x" mulx_mont_384x_al
 mulx_mont_384x_alias_ret_a_ret_ov <- verify_x86 "mulx_mont_384x" mulx_mont_384x_alias_ret_a_ret_spec;
 
 // sqrx_mont_384x - counterexample for internal var
-let do_prove_x86 = false;
 sqrx_mont_384x_ov <- verify_x86 "sqrx_mont_384x" sqrx_mont_384x_spec;
 sqrx_mont_384x_alias_ov <- verify_x86 "sqrx_mont_384x" sqrx_mont_384x_alias_spec;
-let do_prove_x86 = true;
 
 // mulx_382x
 mulx_382x_ov <- verify_x86 "mulx_382x" mulx_382x_spec;
@@ -285,29 +281,48 @@ sgn0x_pty_mont_384_ov <- verify_x86 "sgn0x_pty_mont_384" sgn0x_pty_mont_384_spec
 sgn0x_pty_mont_384x_ov <- verify_x86 "sgn0x_pty_mont_384x" sgn0x_pty_mont_384x_spec;
 
 // mulx_mont_384 - counterexample for var_macaw_reg55
-let do_prove_x86 = false;
 mulx_mont_384_ov <- verify_x86 "mulx_mont_384" mulx_mont_384_spec;
 mulx_mont_384_ret_ret_ov <- verify_x86 "mulx_mont_384" mulx_mont_384_ret_ret_spec;
 mulx_mont_384_ret_a_ret_ov <- verify_x86 "mulx_mont_384" mulx_mont_384_ret_a_ret_spec;
-let do_prove_x86 = true;
 
 // sqrx_mont_384 - counterexample for internal var
-let do_prove_x86 = false;
 sqrx_mont_384_ov <- verify_x86 "sqrx_mont_384" sqrx_mont_384_spec;
 sqrx_mont_384_alias_ov <- verify_x86 "sqrx_mont_384" sqrx_mont_384_alias_spec;
-let do_prove_x86 = true;
 
-// sqrx_n_mul_mont_383 - performance issue
-let do_prove_x86 = false;
-sqrx_n_mul_mont_383_ov <- verify_x86 "sqrx_n_mul_mont_383" sqrx_n_mul_mont_383_spec;
-sqrx_n_mul_mont_383_alias_1_2_ov <- verify_x86 "sqrx_n_mul_mont_383" sqrx_n_mul_mont_383_alias_1_2_spec;
-let do_prove_x86 = true;
+// sqrx_n_mul_mont_384 - doesn't exist in bitcode, never called?
+// sqrx_n_mul_mont_384_ov <- verify_x86 "sqrx_n_mul_mont_384" sqrx_n_mul_mont_384_spec;
+// sqrx_n_mul_mont_384_alias_1_2_ov <- verify_x86 "sqrx_n_mul_mont_384" sqrx_n_mul_mont_384_alias_1_2_spec;
 
-// sqrx_mont_382x - counterexample for internal var
-let do_prove_x86 = false;
+// sqrx_n_mul_mont_383
+sqrx_n_mul_mont_383_count1_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 1);
+sqrx_n_mul_mont_383_count2_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 2);
+sqrx_n_mul_mont_383_count3_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 3);
+sqrx_n_mul_mont_383_count4_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 4);
+sqrx_n_mul_mont_383_count5_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 5);
+sqrx_n_mul_mont_383_count6_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 6);
+sqrx_n_mul_mont_383_count7_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 7);
+sqrx_n_mul_mont_383_count8_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 8);
+sqrx_n_mul_mont_383_count9_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 9);
+sqrx_n_mul_mont_383_count10_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 10);
+sqrx_n_mul_mont_383_count11_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 11);
+sqrx_n_mul_mont_383_count12_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 12);
+
+sqrx_n_mul_mont_383_alias_1_2_count1_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 1);
+sqrx_n_mul_mont_383_alias_1_2_count2_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 2);
+sqrx_n_mul_mont_383_alias_1_2_count3_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 3);
+sqrx_n_mul_mont_383_alias_1_2_count4_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 4);
+sqrx_n_mul_mont_383_alias_1_2_count5_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 5);
+sqrx_n_mul_mont_383_alias_1_2_count6_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 6);
+sqrx_n_mul_mont_383_alias_1_2_count7_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 7);
+sqrx_n_mul_mont_383_alias_1_2_count8_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 8);
+sqrx_n_mul_mont_383_alias_1_2_count9_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 9);
+sqrx_n_mul_mont_383_alias_1_2_count10_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 10);
+sqrx_n_mul_mont_383_alias_1_2_count11_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 11);
+sqrx_n_mul_mont_383_alias_1_2_count12_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_alias_1_2_spec 12);
+
+// sqrx_mont_382x
 sqrx_mont_382x_ov <- verify_x86 "sqrx_mont_382x" sqrx_mont_382x_spec;
 sqrx_mont_382x_alias_ov <- verify_x86 "sqrx_mont_382x" sqrx_mont_382x_alias_spec;
-let do_prove_x86 = true;
 
 let mulx_mont_384_overrides =
   [ mulx_mont_384x_ov
@@ -336,8 +351,31 @@ let mulx_mont_384_overrides =
   , sqrx_mont_384_ov
   , sqrx_mont_384_alias_ov
 
-  , sqrx_n_mul_mont_383_ov
-  , sqrx_n_mul_mont_383_alias_1_2_ov
+  , sqrx_n_mul_mont_383_count1_ov
+  , sqrx_n_mul_mont_383_count2_ov
+  , sqrx_n_mul_mont_383_count3_ov
+  , sqrx_n_mul_mont_383_count4_ov
+  , sqrx_n_mul_mont_383_count5_ov
+  , sqrx_n_mul_mont_383_count6_ov
+  , sqrx_n_mul_mont_383_count7_ov
+  , sqrx_n_mul_mont_383_count8_ov
+  , sqrx_n_mul_mont_383_count9_ov
+  , sqrx_n_mul_mont_383_count10_ov
+  , sqrx_n_mul_mont_383_count11_ov
+  , sqrx_n_mul_mont_383_count12_ov
+
+  , sqrx_n_mul_mont_383_alias_1_2_count1_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count2_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count3_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count4_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count5_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count6_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count7_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count8_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count9_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count10_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count11_ov
+  , sqrx_n_mul_mont_383_alias_1_2_count12_ov
 
   , sqrx_mont_382x_ov
   , sqrx_mont_382x_alias_ov

--- a/proof/x86/mulx_mont_384.saw
+++ b/proof/x86/mulx_mont_384.saw
@@ -194,19 +194,6 @@ let sqrx_mont_384_alias_spec = do {
   crucible_points_to ret_ptr (crucible_term new_sqr_mont_384_alias_ret);
 };
 
-// sqrx_n_mul_mont_384
-// let sqrx_n_mul_mont_384_spec  = do {
-//   ret_ptr <- crucible_alloc vec384_type;
-//   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-//   count <- crucible_fresh_var "count" size_type;
-//   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-//   n0 <- crucible_fresh_var "n0" limb_type;
-//   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-//   crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
-//   new_sqr_n_mul_mont_384_ret <- crucible_fresh_var "new_sqr_n_mul_mont_384_ret" vec384_type;
-//   crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_384_ret);
-// };
-
 // sqrx_n_mul_mont_383
 let sqrx_n_mul_mont_383_spec count = do {
   ret_ptr <- crucible_alloc vec384_type;
@@ -258,7 +245,7 @@ mulx_mont_384x_ov <- verify_x86 "mulx_mont_384x" mulx_mont_384x_spec;
 mulx_mont_384x_alias_ret_ret_ov <- verify_x86 "mulx_mont_384x" mulx_mont_384x_alias_ret_ret_spec;
 mulx_mont_384x_alias_ret_a_ret_ov <- verify_x86 "mulx_mont_384x" mulx_mont_384x_alias_ret_a_ret_spec;
 
-// sqrx_mont_384x - counterexample for internal var
+// sqrx_mont_384x
 sqrx_mont_384x_ov <- verify_x86 "sqrx_mont_384x" sqrx_mont_384x_spec;
 sqrx_mont_384x_alias_ov <- verify_x86 "sqrx_mont_384x" sqrx_mont_384x_alias_spec;
 
@@ -280,18 +267,14 @@ sgn0x_pty_mont_384_ov <- verify_x86 "sgn0x_pty_mont_384" sgn0x_pty_mont_384_spec
 // sqn0x_pty_mont_384x
 sgn0x_pty_mont_384x_ov <- verify_x86 "sgn0x_pty_mont_384x" sgn0x_pty_mont_384x_spec;
 
-// mulx_mont_384 - counterexample for var_macaw_reg55
+// mulx_mont_384
 mulx_mont_384_ov <- verify_x86 "mulx_mont_384" mulx_mont_384_spec;
 mulx_mont_384_ret_ret_ov <- verify_x86 "mulx_mont_384" mulx_mont_384_ret_ret_spec;
 mulx_mont_384_ret_a_ret_ov <- verify_x86 "mulx_mont_384" mulx_mont_384_ret_a_ret_spec;
 
-// sqrx_mont_384 - counterexample for internal var
+// sqrx_mont_384
 sqrx_mont_384_ov <- verify_x86 "sqrx_mont_384" sqrx_mont_384_spec;
 sqrx_mont_384_alias_ov <- verify_x86 "sqrx_mont_384" sqrx_mont_384_alias_spec;
-
-// sqrx_n_mul_mont_384 - doesn't exist in bitcode, never called?
-// sqrx_n_mul_mont_384_ov <- verify_x86 "sqrx_n_mul_mont_384" sqrx_n_mul_mont_384_spec;
-// sqrx_n_mul_mont_384_alias_1_2_ov <- verify_x86 "sqrx_n_mul_mont_384" sqrx_n_mul_mont_384_alias_1_2_spec;
 
 // sqrx_n_mul_mont_383
 sqrx_n_mul_mont_383_count1_ov <- verify_x86 "sqrx_n_mul_mont_383" (sqrx_n_mul_mont_383_spec 1);

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -1,40 +1,30 @@
 #!/bin/sh
 set -e
 
-(
-    mkdir -p build/llvm
-    rm -r build/llvm
-    cp -r blst build/llvm
-    cd build/llvm
+build () {
+    (
+        mkdir -p "build/$1"
+        rm -r "build/$1"
+        cp -r "$2" "build/$1"
+        cd "build/$1"
 
-    for p in /workdir/patches/*
-    do
-        patch -f -p1 -t < "$p" # -f to prevent patch from automatically enabling option -R when it things it should
-    done
+        if [ "$2" = blst ]; then
+            for p in ../../patches/*
+            do
+                patch -f -p1 -t < "$p" # -f to prevent patch from automatically enabling option -R when it things it should
+            done
+        fi
 
-    export CFLAGS='-g -fPIC -Wall -Wextra -Werror -D__ADX__'
-    export CC=wllvm
-    export LLVM_COMPILER=clang
-    sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
-    ./build.sh
-    extract-bc --bitcode libblst.a
-)
+        export CFLAGS="-g -fPIC -Wall -Wextra -Werror $3"
+        export CC=wllvm
+        export LLVM_COMPILER=clang
+        sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
+        ./build.sh
+        extract-bc --bitcode libblst.a
+    )
+}
 
-(
-    mkdir -p build/llvm_noadx
-    rm -r build/llvm_noadx
-    cp -r blst build/llvm_noadx
-    cd build/llvm_noadx
-
-    for p in /workdir/patches/*
-    do
-        patch -f -p1 -t < "$p"
-    done
-
-    export CFLAGS='-g -fPIC -Wall -Wextra -Werror'
-    export CC=wllvm
-    export LLVM_COMPILER=clang
-    sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
-    ./build.sh
-    extract-bc --bitcode libblst.a
-)
+build llvm blst '-D__ADX__'
+build llvm_noadx blst
+build llvm_patched blst_patched '-D__ADX__'
+build llvm_noadx_patched blst_patched

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -1,18 +1,40 @@
 #!/bin/sh
 set -e
 
-mkdir -p build/llvm
-rm -r build/llvm
-cp -r blst build/llvm
-cd build/llvm
+(
+    mkdir -p build/llvm
+    rm -r build/llvm
+    cp -r blst build/llvm
+    cd build/llvm
 
-for p in /workdir/patches/*
-do
-  patch -f -p1 -t < "$p" # -f to prevent patch from automatically enabling option -R when it things it should
-done
+    for p in /workdir/patches/*
+    do
+        patch -f -p1 -t < "$p" # -f to prevent patch from automatically enabling option -R when it things it should
+    done
 
-export CFLAGS='-g -fPIC -Wall -Wextra -Werror -D__ADX__'
-export CC=wllvm
-export LLVM_COMPILER=clang
-./build.sh
-extract-bc --bitcode libblst.a
+    export CFLAGS='-g -fPIC -Wall -Wextra -Werror -D__ADX__'
+    export CC=wllvm
+    export LLVM_COMPILER=clang
+    sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
+    ./build.sh
+    extract-bc --bitcode libblst.a
+)
+
+(
+    mkdir -p build/llvm_noadx
+    rm -r build/llvm_noadx
+    cp -r blst build/llvm_noadx
+    cd build/llvm_noadx
+
+    for p in /workdir/patches/*
+    do
+        patch -f -p1 -t < "$p"
+    done
+
+    export CFLAGS='-g -fPIC -Wall -Wextra -Werror'
+    export CC=wllvm
+    export LLVM_COMPILER=clang
+    sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
+    ./build.sh
+    extract-bc --bitcode libblst.a
+)

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -26,5 +26,5 @@ build () {
 
 build llvm blst '-D__ADX__'
 build llvm_noadx blst
-build llvm_patched blst_patched '-D__ADX__'
-build llvm_noadx_patched blst_patched
+build llvm_recent blst_recent '-D__ADX__'
+build llvm_noadx_recent blst_recent

--- a/scripts/build_x86.sh
+++ b/scripts/build_x86.sh
@@ -1,13 +1,28 @@
 #!/bin/sh
 set -e
 
-mkdir -p build/x86
-rm -r build/x86
-cp -r blst build/x86
-cd build/x86
+(
+    mkdir -p build/x86
+    rm -r build/x86
+    cp -r blst build/x86
+    cd build/x86
 
-export CFLAGS='-g -fPIC -Wall -Wextra -Werror -D__ADX__'
-export CC=clang
-sed -i'' 's/^trap/# trap/' build.sh
-sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
-./build.sh -shared
+    export CFLAGS='-g -fPIC -Wall -Wextra -Werror -D__ADX__'
+    export CC=clang
+    sed -i'' 's/^trap/# trap/' build.sh
+    sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
+    ./build.sh -shared
+)
+
+(
+    mkdir -p build/x86_noadx
+    rm -r build/x86_noadx
+    cp -r blst build/x86_noadx
+    cd build/x86_noadx
+
+    export CFLAGS='-g -fPIC -Wall -Wextra -Werror'
+    export CC=clang
+    sed -i'' 's/^trap/# trap/' build.sh
+    sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
+    ./build.sh -shared
+)

--- a/scripts/build_x86.sh
+++ b/scripts/build_x86.sh
@@ -1,32 +1,26 @@
 #!/bin/sh
 set -e
 
-(
-    mkdir -p build/x86
-    rm -r build/x86
-    cp -r blst build/x86
-    cd build/x86
+build () {
+    (
+        mkdir -p "build/$1"
+        rm -r "build/$1"
+        cp -r "$2" "build/$1"
+        cd "build/$1"
 
-    patch -f -p1 -t < ../../patches/noxmmptr.patch
+        if [ "$2" = blst ]; then
+            patch -f -p1 -t < ../../patches/noxmmptr.patch
+        fi
 
-    export CFLAGS='-g -fPIC -Wall -Wextra -Werror -D__ADX__'
-    export CC=clang
-    sed -i'' 's/^trap/# trap/' build.sh
-    sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
-    ./build.sh -shared
-)
+        export CFLAGS="-g -fPIC -Wall -Wextra -Werror $3"
+        export CC=clang
+        sed -i'' 's/^trap/# trap/' build.sh
+        sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
+        ./build.sh -shared
+    )
+}
 
-(
-    mkdir -p build/x86_noadx
-    rm -r build/x86_noadx
-    cp -r blst build/x86_noadx
-    cd build/x86_noadx
-
-    patch -f -p1 -t < ../../patches/noxmmptr.patch
-
-    export CFLAGS='-g -fPIC -Wall -Wextra -Werror'
-    export CC=clang
-    sed -i'' 's/^trap/# trap/' build.sh
-    sed -i'' 's/^CFLAGS=/# CFLAGS=/' build.sh
-    ./build.sh -shared
-)
+build x86 blst '-D__ADX__'
+build x86_noadx blst
+build x86_patched blst_patched '-D__ADX__'
+build x86_noadx_patched blst_patched

--- a/scripts/build_x86.sh
+++ b/scripts/build_x86.sh
@@ -22,5 +22,5 @@ build () {
 
 build x86 blst '-D__ADX__'
 build x86_noadx blst
-build x86_patched blst_patched '-D__ADX__'
-build x86_noadx_patched blst_patched
+build x86_recent blst_recent '-D__ADX__'
+build x86_noadx_recent blst_recent

--- a/scripts/build_x86.sh
+++ b/scripts/build_x86.sh
@@ -7,6 +7,8 @@ set -e
     cp -r blst build/x86
     cd build/x86
 
+    patch -f -p1 -t < ../../patches/noxmmptr.patch
+
     export CFLAGS='-g -fPIC -Wall -Wextra -Werror -D__ADX__'
     export CC=clang
     sed -i'' 's/^trap/# trap/' build.sh
@@ -19,6 +21,8 @@ set -e
     rm -r build/x86_noadx
     cp -r blst build/x86_noadx
     cd build/x86_noadx
+
+    patch -f -p1 -t < ../../patches/noxmmptr.patch
 
     export CFLAGS='-g -fPIC -Wall -Wextra -Werror'
     export CC=clang

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@ if [ $# -ne 0 ] && [ "$1" = "--latest" ]; then
   CRYPTOL_NIGHTLY=$(curl -s https://cryptol.net/builds/nightly/ | grep -oP "cryptol.*?${CRYPTOL_DATE}-Ubuntu.*?\.tar\.gz"  | head -n 1) # `curl -s` means silent; `grep -o` says print only the matched substring; `grep -P` says Perl syntax, which we use to get a lazy match (shortest) with .*?
   CRYPTOL_URL="https://cryptol.net/builds/nightly/${CRYPTOL_NIGHTLY}"
 else
-  SAW_URL="https://saw.galois.com/builds/nightly/saw-0.7.0.99-2021-01-06-Linux-x86_64.tar.gz"
+  SAW_URL="https://saw.galois.com/builds/nightly/saw-0.7.0.99-2021-03-11-Linux-x86_64.tar.gz"
   CRYPTOL_URL="https://github.com/GaloisInc/cryptol/releases/download/2.9.1/cryptol-2.9.1-Linux-x86_64.tar.gz"
 
 fi


### PR DESCRIPTION
These include:
- `sqrx_mont_384x`, `mulx_mont_384`, `sqrx_mont_384`, `sqrx_n_mul_mont_383`, and `sqrx_mont_382x`, which previously offloaded the "return value" pointer to an XMM register. A patch derived from supranational/blst@5e3d137 is included in `patches/noxmmptr.patch`.
- All `mulq` variants of the routines using `mulx`. Since use of `mulx` is controlled by the preprocessor, this involves building a separate LLVM bitcode file and shared library.
- `ctx_inverse_mod_383` and `ct_inverse_mod_383`. These were introduced in a more recent BLST commit than our `blst/` submodule. Rather than generating/maintaining a very large patch, I've added another submodule `blst_patched/` that points to a more recent commit - I'm unsure if this is the best approach here, feedback would be very welcome. I've modified `scripts/build_{x86,llvm}.sh` a bit to better handle the growing number of build configurations.

I've also updated the `README.md` in light of the changes above, and incremented the SAWScript nightly version used by the Docker container.