### PR TITLE
Make proof of `mul_to_fp_thm` work with `z3-4.8.10`.

### DIFF
--- a/proof/deserialize-p1.saw
+++ b/proof/deserialize-p1.saw
@@ -266,18 +266,34 @@ let sgn0_pty_mont_384_spec = do {
 // Proofs
 ////////////////////////////////////////////////////////////////////////////////
 
+// Lemmas for mul_to_fp_thm proof
+
+Vec384_less_thm <- prove_cryptol
+  {{ \(x:[384]) y -> (x < y) == (toInteger x < toInteger y) }}
+  [];
+fp_invariant_thm <- custom_prove_cryptol
+  {{ \x -> fp_invariant x == to_Fp (vec384_abs x) < `p }}
+  do {
+    unfolding ["fp_invariant"];
+    simplify (addsimp Vec384_less_thm empty_ss);
+    w4_unint_z3 [];
+  };
+
 // Starting with proofs that the as-implemented algorithm matches the reference specification
 // as-implemented has an additional check
 
 // We have a conditional property
 //  {{ \x -> fp_invariant x ==> Fp.mul (fp_abs x,  montgomery_factor_p) == to_Fp (vec384_abs x) }}
 // expressed as this conditional rewrite rule:
-mul_to_fp_thm <- prove_cryptol
+mul_to_fp_thm <- custom_prove_cryptol
   {{ \x -> Fp.mul (fp_abs x, montgomery_factor_p) ==
            if fp_invariant x
            then to_Fp (vec384_abs x)
            else apply Fp.mul (fp_abs x,  montgomery_factor_p) }}
-   [] ;
+  do {
+    simplify (addsimp fp_invariant_thm empty_ss);
+    w4_unint_z3 [];
+  };
 
 // "uncompress_OK" is the correct value in the non-infinity case
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-Z3_URL='https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip'
+Z3_URL='https://github.com/Z3Prover/z3/releases/download/z3-4.8.10/z3-4.8.10-x64-ubuntu-18.04.zip'
 YICES_URL='https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-linux-gnu-static-gmp.tar.gz'
 
 if [ $# -ne 0 ] && [ "$1" = "--latest" ]; then


### PR DESCRIPTION
There seems to be some performance regression for z3 on proof goals
involving the bv2nat operator, which caused the `mul_to_fp_thm`
proof to fail to terminate with `z3-4.8.10`.

The proof has now been refactored to use some lemmas as rewrite
rules, which makes it possible to solve with 4.8.10.