### PR TITLE
Remove uses of the `eq` primitive, which is slated for removal.

### DIFF
--- a/proof/curve_operations.saw
+++ b/proof/curve_operations.saw
@@ -17,14 +17,14 @@ let print_goal_readably_fp = do {
 // rewrites that help bring the terms we need together.    We start with them:
 
 core_rewrites <- for
-  [ "EqTrue (eq Nat (intToNat (natToInt 0)) 0)"
-  , "EqTrue (eq Nat (intToNat (natToInt 1)) 1)"
+  [ "EqTrue (equalNat (intToNat (natToInt 0)) 0)"
+  , "EqTrue (equalNat (intToNat (natToInt 1)) 1)"
 
-  , "(x: (Vec 6 (Vec 64 Bool))) -> (y: (Vec 6 (Vec 64 Bool))) -> EqTrue (eq (Vec 6 (Vec 64 Bool)) (at 2 (Vec 6 (Vec 64 Bool)) [x,y] 0) x)"
-  , "(x: (Vec 6 (Vec 64 Bool))) -> (y: (Vec 6 (Vec 64 Bool))) -> EqTrue (eq (Vec 6 (Vec 64 Bool)) (at 2 (Vec 6 (Vec 64 Bool)) [x,y] 1) y)"
+  , "(x: (Vec 6 (Vec 64 Bool))) -> (y: (Vec 6 (Vec 64 Bool))) -> EqTrue ( vecEq 6 (Vec 64 Bool) (vecEq 64 Bool boolEq) (at 2 (Vec 6 (Vec 64 Bool)) [x,y] 0) x)"
+  , "(x: (Vec 6 (Vec 64 Bool))) -> (y: (Vec 6 (Vec 64 Bool))) -> EqTrue ( vecEq 6 (Vec 64 Bool) (vecEq 64 Bool boolEq) (at 2 (Vec 6 (Vec 64 Bool)) [x,y] 1) y)"
   
-  , "(b: Bool) -> (x: (Vec 2 (Vec 6 (Vec 64 Bool)))) -> (y: (Vec 2 (Vec 6 (Vec 64 Bool)))) -> EqTrue (eq (Vec 6 (Vec 64 Bool)) (at 2 (Vec 6 (Vec 64 Bool)) (ite (Vec 2 (Vec 6 (Vec 64 Bool))) b x y) 0) (ite (Vec 6 (Vec 64 Bool)) b (at 2 (Vec 6 (Vec 64 Bool)) x 0) (at 2 (Vec 6 (Vec 64 Bool)) y 0)))"
-  , "(b: Bool) -> (x: (Vec 2 (Vec 6 (Vec 64 Bool)))) -> (y: (Vec 2 (Vec 6 (Vec 64 Bool)))) -> EqTrue (eq (Vec 6 (Vec 64 Bool)) (at 2 (Vec 6 (Vec 64 Bool)) (ite (Vec 2 (Vec 6 (Vec 64 Bool))) b x y) 1) (ite (Vec 6 (Vec 64 Bool)) b (at 2 (Vec 6 (Vec 64 Bool)) x 1) (at 2 (Vec 6 (Vec 64 Bool)) y 1)))"
+  , "(b: Bool) -> (x: (Vec 2 (Vec 6 (Vec 64 Bool)))) -> (y: (Vec 2 (Vec 6 (Vec 64 Bool)))) -> EqTrue (vecEq 6 (Vec 64 Bool) (vecEq 64 Bool boolEq) (at 2 (Vec 6 (Vec 64 Bool)) (ite (Vec 2 (Vec 6 (Vec 64 Bool))) b x y) 0) (ite (Vec 6 (Vec 64 Bool)) b (at 2 (Vec 6 (Vec 64 Bool)) x 0) (at 2 (Vec 6 (Vec 64 Bool)) y 0)))"
+  , "(b: Bool) -> (x: (Vec 2 (Vec 6 (Vec 64 Bool)))) -> (y: (Vec 2 (Vec 6 (Vec 64 Bool)))) -> EqTrue (vecEq 6 (Vec 64 Bool) (vecEq 64 Bool boolEq) (at 2 (Vec 6 (Vec 64 Bool)) (ite (Vec 2 (Vec 6 (Vec 64 Bool))) b x y) 1) (ite (Vec 6 (Vec 64 Bool)) b (at 2 (Vec 6 (Vec 64 Bool)) x 1) (at 2 (Vec 6 (Vec 64 Bool)) y 1)))"
    ] (prove_core abc);
 
 more_rewrites <- for

--- a/proof/curve_operations_e2.saw
+++ b/proof/curve_operations_e2.saw
@@ -33,8 +33,8 @@ hoist_if_proj_int_2 <- prove_cryptol (rewrite (cryptol_ss ()) (unfold_term ["hoi
    //[];
 
 core_rewrites <- for
-  [ "EqTrue (eq Nat (intToNat (natToInt 0)) 0)"
-  , "EqTrue (eq Nat (intToNat (natToInt 1)) 1)"
+  [ "EqTrue (equalNat (intToNat (natToInt 0)) 0)"
+  , "EqTrue (equalNat (intToNat (natToInt 1)) 1)"
   //, "EqTrue (eq Bool (intLe (natToInt 0) (natToInt 0)) True)"
   //, "EqTrue (eq Bool (intLe (natToInt 0) (natToInt 1)) True)"
   ] (prove_core abc);

--- a/proof/e2_dadd_extract.saw
+++ b/proof/e2_dadd_extract.saw
@@ -54,8 +54,8 @@ hoist_if_3_int_1 <- prove_cryptol (rewrite (cryptol_ss ()) (unfold_term ["hoist_
 hoist_if_3_int_2 <- prove_cryptol (rewrite (cryptol_ss ()) (unfold_term ["hoist_if_2"] {{ hoist_if_2`{[2]Integer} }})) [];
 
 core_rewrites <- for // TODO: why are those needed? which rewrites do they enable?
-  [ "EqTrue (eq Nat (intToNat (natToInt 0)) 0)"
-  , "EqTrue (eq Nat (intToNat (natToInt 1)) 1)"
+  [ "EqTrue (equalNat (intToNat (natToInt 0)) 0)"
+  , "EqTrue (equalNat (intToNat (natToInt 1)) 1)"
   //, "EqTrue (eq Bool (intLe (natToInt 0) (natToInt 0)) True)"
   //, "EqTrue (eq Bool (intLe (natToInt 0) (natToInt 1)) True)"
   ] (prove_core abc);

--- a/proof/fp12.saw
+++ b/proof/fp12.saw
@@ -479,15 +479,15 @@ fp6_alg_thms <- for
 
 
 nest_fp2_thms <- for
-  [ {{ \ f (x:t_Fp_2) -> nest f x 1 == f x }}
-  , {{ \ f (x:t_Fp_2) -> nest f x 2 == f (f x) }}
-  , {{ \ f (x:t_Fp_2) -> nest f x 3 == f (f (f x)) }}
+  [ {{ \ x -> nest fp2_frobenius x 1 == fp2_frobenius x }}
+  , {{ \ x -> nest fp2_frobenius x 2 == fp2_frobenius (fp2_frobenius x) }}
+  , {{ \ x -> nest fp2_frobenius x 3 == fp2_frobenius (fp2_frobenius (fp2_frobenius x)) }}
   ] (\ t -> prove_cryptol (rewrite (cryptol_ss ()) t) []);
 
 nest_fp6_thms <- for
-  [ {{ \ f (x:t_Fp_6) -> nest f x 1 == f x }}
-  , {{ \ f (x:t_Fp_6) -> nest f x 2 == f (f x) }}
-  , {{ \ f (x:t_Fp_6) -> nest f x 3 == f (f (f x)) }}
+  [ {{ \ x -> nest fp6_frobenius x 1 == fp6_frobenius x }}
+  , {{ \ x -> nest fp6_frobenius x 2 == fp6_frobenius (fp6_frobenius x) }}
+  , {{ \ x -> nest fp6_frobenius x 3 == fp6_frobenius (fp6_frobenius (fp6_frobenius x)) }}
   ] (\ t -> prove_cryptol (rewrite (cryptol_ss ()) t) []);
 
 // borrowed from exp2.saw:
@@ -1257,15 +1257,17 @@ conjugate_fp12_ov <- custom_verify "conjugate_fp12"
 frobenius_map_fp2_1_ov <- custom_verify "frobenius_map_fp2"
     (concat fp_overrides fp2_overrides)
     (frobenius_map_fp2_spec 1)
-    do { unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
-         simplify (addsimps nest_fp2_thms fp_simpset);
+    do { rw_with nest_fp2_thms;
+         unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
+         simplify fp_simpset;
          w4_unint_z3 fp_unints;};
 
 frobenius_map_fp2_1_alias_ov <- custom_verify "frobenius_map_fp2"
     (concat fp_overrides fp2_overrides)
     (frobenius_map_fp2_alias_spec 1)
-    do { unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
-         simplify (addsimps nest_fp2_thms fp_simpset);
+    do { rw_with nest_fp2_thms;
+         unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
+         simplify fp_simpset;
          w4_unint_z3 fp_unints;};
 
 fp_rep_normalize_abs_thm <- admit_cryptol {{ \x -> fp_rep (Fp.normalize (fp_abs x)) == fp_normalize x }};
@@ -1273,7 +1275,8 @@ fp_rep_normalize_abs_thm <- admit_cryptol {{ \x -> fp_rep (Fp.normalize (fp_abs 
 frobenius_map_fp2_2_ov <- custom_verify "frobenius_map_fp2"
     (concat fp_overrides fp2_overrides)
     (frobenius_map_fp2_spec 2)
-    do { unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
+    do { rw_with nest_fp2_thms;
+         unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
          simplify (addsimp fp2_invariant_alt_thm (addsimps nest_fp2_thms fp_simpset));
          simplify (addsimps [fp_rep_normalize_abs_thm, fp_normalize_thm] (addsimps fp_alg_thms empty_ss));
          w4_unint_z3 fp_unints;};
@@ -1281,7 +1284,8 @@ frobenius_map_fp2_2_ov <- custom_verify "frobenius_map_fp2"
 frobenius_map_fp2_2_alias_ov <- custom_verify "frobenius_map_fp2"
     (concat fp_overrides fp2_overrides)
     (frobenius_map_fp2_alias_spec 2)
-    do { unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
+    do { rw_with nest_fp2_thms;
+         unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
          simplify (addsimp fp2_invariant_alt_thm (addsimps nest_fp2_thms fp_simpset));
          simplify (addsimps [fp_rep_normalize_abs_thm, fp_normalize_thm] (addsimps fp_alg_thms empty_ss));
          w4_unint_z3 fp_unints;};
@@ -1291,7 +1295,8 @@ fp_neg_normalize_thm <- prove_cryptol {{ \x -> Fp.neg (Fp.normalize x) == Fp.neg
 frobenius_map_fp2_3_ov <- custom_verify "frobenius_map_fp2"
     (concat fp_overrides fp2_overrides)
     (frobenius_map_fp2_spec 3)
-    do { unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
+    do { rw_with nest_fp2_thms;
+         unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
          simplify (addsimp fp2_invariant_alt_thm (addsimps nest_fp2_thms fp_simpset));
          simplify (addsimps [fp_rep_normalize_abs_thm, fp_normalize_thm, fp_neg_normalize_thm]
                             (addsimps fp_alg_thms empty_ss));
@@ -1300,7 +1305,8 @@ frobenius_map_fp2_3_ov <- custom_verify "frobenius_map_fp2"
 frobenius_map_fp2_3_alias_ov <- custom_verify "frobenius_map_fp2"
     (concat fp_overrides fp2_overrides)
     (frobenius_map_fp2_alias_spec 3)
-    do { unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
+    do { rw_with nest_fp2_thms;
+         unfolding ["fp2_rep", "fp2_frobenius", "fp2_conjugate", "f1", "fp2_abs"];
          simplify (addsimp fp2_invariant_alt_thm (addsimps nest_fp2_thms fp_simpset));
          simplify (addsimps [fp_rep_normalize_abs_thm, fp_normalize_thm, fp_neg_normalize_thm]
                             (addsimps fp_alg_thms empty_ss));

--- a/proof/hash_to_g1.saw
+++ b/proof/hash_to_g1.saw
@@ -5,27 +5,6 @@
 
 // Imports
 
-//include "helpers.saw";
-//include "list_utils.saw";
-//include "types.saw";
-
-//m <- llvm_load_module "../build/llvm/libblst.a.bc";
-
-//enable_experimental;
-
-//let do_prove = false;
-
-//include "proof-helpers.saw";
-//include "hash_to_field.saw";
-//include "fp_overrides.saw";
-//include "vect.saw";
-//include "curve_operations.saw";
-//include "ec_mult.saw";
-//include "exp.saw";
-//include "sgn0.saw";
-
-//let do_prove = true;
-
 import "../spec/Parameters.cry";
 import "../spec/ShortWeierstrassCurve.cry";
 import "../spec/HashToCurveE1.cry" (Z A' B' Curve_E' clear_cofactor iso_map hash_to_curve_opt map_to_curve_simple_swu sgn0);
@@ -242,6 +221,7 @@ map_to_isogenous_E1_impl_ov <- custom_verify
         print_goal;
         unfolding ["select"];
         simplify fp_simpset;
+        simplify basic_ss;
         w4;
       };
   });

--- a/proof/proof-helpers.saw
+++ b/proof/proof-helpers.saw
@@ -133,14 +133,10 @@ let rw_with_1 thm = simplify (addsimp thm (cryptol_ss ()));
 // useful things for proof development, to tidy up the goal formula before printing it.
 
 propositional_rewrites <- for
-  [ "(a:Bool) -> (b:Bool) -> EqTrue (eq Bool (ite Bool a True b) (or a b))"
-  , "(a:Bool) -> (b:Bool) -> EqTrue (eq Bool (ite Bool a b False) (and a b))"
-  , "(a:Bool) -> (b:Bool) -> EqTrue (eq Bool (not (and a b)) (or (not a) (not b)))"
-  , "(a:Bool) -> (b:Bool) -> EqTrue (eq Bool (not (or a b)) (and (not a) (not b)))"
-  , "(a:Bool) -> EqTrue (eq Bool (implies a False) (not a))"
-  , "(a:Bool) -> (b:Bool) -> (c:Bool) -> EqTrue (eq Bool (implies a (or b c)) (implies (and a (not b)) c))"
-  // , "(a:Bool) -> (b:Bool) -> (c:Bool) -> EqTrue (eq Bool (implies (and a b) c) (implies a (implies b c)))"
-  , "(a:Bool) -> (b:Bool) -> EqTrue (eq Bool (or (not a) b) (implies a b))"
+  [ "(a:Bool) -> (b:Bool) -> EqTrue (boolEq (ite Bool a True b) (or a b))"
+  , "(a:Bool) -> (b:Bool) -> EqTrue (boolEq (ite Bool a b False) (and a b))"
+  , "(a:Bool) -> (b:Bool) -> EqTrue (boolEq (not (and a b)) (or (not a) (not b)))"
+  , "(a:Bool) -> (b:Bool) -> EqTrue (boolEq (not (or a b)) (and (not a) (not b)))"
    ] (prove_core abc);
 
 let prop_simpset = add_prelude_eqs

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@ if [ $# -ne 0 ] && [ "$1" = "--latest" ]; then
   CRYPTOL_NIGHTLY=$(curl -s https://cryptol.net/builds/nightly/ | grep -oP "cryptol.*?${CRYPTOL_DATE}-Ubuntu.*?\.tar\.gz"  | head -n 1) # `curl -s` means silent; `grep -o` says print only the matched substring; `grep -P` says Perl syntax, which we use to get a lazy match (shortest) with .*?
   CRYPTOL_URL="https://cryptol.net/builds/nightly/${CRYPTOL_NIGHTLY}"
 else
-  SAW_URL="https://saw.galois.com/builds/nightly/saw-0.7.0.99-2021-03-11-Linux-x86_64.tar.gz"
+  SAW_URL="https://saw.galois.com/builds/nightly/saw-0.7.0.99-2021-03-24-Linux-x86_64.tar.gz"
   CRYPTOL_URL="https://github.com/GaloisInc/cryptol/releases/download/2.9.1/cryptol-2.9.1-Linux-x86_64.tar.gz"
 
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,7 @@ if [ $# -ne 0 ] && [ "$1" = "--latest" ]; then
   CRYPTOL_URL="https://cryptol.net/builds/nightly/${CRYPTOL_NIGHTLY}"
 else
   SAW_URL="https://saw.galois.com/builds/nightly/saw-0.7.0.99-2021-03-24-Linux-x86_64.tar.gz"
-  CRYPTOL_URL="https://github.com/GaloisInc/cryptol/releases/download/2.9.1/cryptol-2.9.1-Linux-x86_64.tar.gz"
+  CRYPTOL_URL="https://github.com/GaloisInc/cryptol/releases/download/2.11.0/cryptol-2.11.0-Linux-x86_64.tar.gz"
 
 fi
 


### PR DESCRIPTION
Minor changes made necessary by https://github.com/GaloisInc/saw-script/pull/1114.