### PR TITLE
Add archives (with submodules) when releases are published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+on:
+  release:
+    types: [published]
+
+jobs:
+  proofs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - run: |
+          tar -czvf blst-verification.tar.gz *
+          zip -r blst-verification.zip * -x blst-verification.tar.gz
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            blst-verification.tar.gz
+            blst-verification.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, our GitHub releases only have the default "Source code" assets attached, which do not include submodules. This PR adds a GitHub Actions workflow that automatically creates and attaches `.zip`/`.tar.gz` archives, with submodules included, to every new release.