### PR TITLE
Fix `cryptol-specs` URL in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = git@github.com:supranational/blst.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
-	url = git://github.com/GaloisInc/cryptol-specs
+	url = git@github.com:GaloisInc/cryptol-specs.git
 [submodule "blst_patched"]
 	path = blst_recent
 	url = git@github.com:supranational/blst.git


### PR DESCRIPTION
GitHub no longer supports `git://` URLs, see GaloisInc/saw-script#1620.