### PR TITLE
Update away from deprecated SAWScript primitive names

### DIFF
--- a/patches/blst_bulk_addition_saw_cryptol/changes.patch
+++ b/patches/blst_bulk_addition_saw_cryptol/changes.patch
@@ -52,19 +52,19 @@ index 11a8077..290d125 100644
  
 -//let POINTonE1_type = llvm_type "{i384, i384, i384}" ;
 -//let POINTonE1_affine_type = llvm_type "{i384, i384}";
--let POINTonE1_type = llvm_struct "struct.POINTonE1";
--let POINTonE1_affine_type = llvm_struct "struct.POINTonE1_affine";
+-let POINTonE1_type = llvm_alias "struct.POINTonE1";
+-let POINTonE1_affine_type = llvm_alias "struct.POINTonE1_affine";
 +let POINTonE1_type = llvm_type "{i384, i384, i384}";
 +let POINTonE1_affine_type = llvm_type "{i384, i384}";
-+//let POINTonE1_type = llvm_struct "struct.POINTonE1";
-+//let POINTonE1_affine_type = llvm_struct "struct.POINTonE1_affine";
++//let POINTonE1_type = llvm_alias "struct.POINTonE1";
++//let POINTonE1_affine_type = llvm_alias "struct.POINTonE1_affine";
  
--let POINTonE2_type = llvm_struct "struct.POINTonE2";
--let POINTonE2_affine_type = llvm_struct "struct.POINTonE2_affine";
+-let POINTonE2_type = llvm_alias "struct.POINTonE2";
+-let POINTonE2_affine_type = llvm_alias "struct.POINTonE2_affine";
 +let POINTonE2_type = llvm_type "{[2 x i384], [2 x i384], [2 x i384]}";
 +let POINTonE2_affine_type = llvm_type "{[2 x i384], [2 x i384]}";
-+//let POINTonE2_type = llvm_struct "struct.POINTonE2";
-+//let POINTonE2_affine_type = llvm_struct "struct.POINTonE2_affine";
++//let POINTonE2_type = llvm_alias "struct.POINTonE2";
++//let POINTonE2_affine_type = llvm_alias "struct.POINTonE2_affine";
 diff --git a/spec/implementation/Types.cry b/spec/implementation/Types.cry
 index 4a08dee..edd5e17 100644
 --- a/spec/implementation/Types.cry

--- a/proof/384x384_ops.saw
+++ b/proof/384x384_ops.saw
@@ -54,10 +54,10 @@ let {{ // type shifted_p = p * 2^^384
     }};
 
 // Little-endian representation of `p` in 64-bit limbs
-let p_representation = crucible_term {{ [0xb9feffffffffaaab, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624,
+let p_representation = llvm_term {{ [0xb9feffffffffaaab, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624,
                                          0x64774b84f38512bf, 0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a] }};
 
-let p0_term = crucible_term {{ 0x89f3fffcfffcfffd }};
+let p0_term = llvm_term {{ 0x89f3fffcfffcfffd }};
 
 ////////////////////////////////////////////////////////////////
 //
@@ -66,15 +66,15 @@ let p0_term = crucible_term {{ 0x89f3fffcfffcfffd }};
 
 /*
 let add_mod_384x384_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec768_type;
-  p_ptr <- crucible_alloc_readonly vec384_type;
-  crucible_precond {{ fpx2_invariant a }};
-  crucible_precond {{ fpx2_invariant b }};
-  crucible_points_to p_ptr p_representation;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fpx2_rep (add_mod_384x384 (fpx2_abs a) (fpx2_abs b)) }});
+  p_ptr <- llvm_alloc_readonly vec384_type;
+  llvm_precond {{ fpx2_invariant a }};
+  llvm_precond {{ fpx2_invariant b }};
+  llvm_points_to p_ptr p_representation;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fpx2_rep (add_mod_384x384 (fpx2_abs a) (fpx2_abs b)) }});
 };
 */
 
@@ -88,12 +88,12 @@ let add_mod_384x384_spec a_aliased b_aliased ab_aliased = do {
   (b, b_ptr) <- if b_aliased then return (ret, ret_ptr)
                 else if ab_aliased then (a, a_ptr)
                      else ptr_to_fresh_readonly "b" vec768_type;
-  p_ptr <- crucible_alloc_readonly vec384_type;
-  crucible_precond {{ fpx2_invariant a }};
-  crucible_precond {{ fpx2_invariant b }};
-  crucible_points_to p_ptr p_representation;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fpx2_rep (add_mod_384x384 (fpx2_abs a) (fpx2_abs b)) }});
+  p_ptr <- llvm_alloc_readonly vec384_type;
+  llvm_precond {{ fpx2_invariant a }};
+  llvm_precond {{ fpx2_invariant b }};
+  llvm_points_to p_ptr p_representation;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fpx2_rep (add_mod_384x384 (fpx2_abs a) (fpx2_abs b)) }});
 };
 */
 
@@ -107,74 +107,74 @@ let either x y = if x then true else y; // logical `or`
 let add_mod_384x384_spec a_aliased b_aliased = do {
   (ret, ret_ptr) <- if either a_aliased b_aliased
                     then ptr_to_fresh "ret" vec768_type
-                    else do { ptr <- crucible_alloc vec768_type;
+                    else do { ptr <- llvm_alloc vec768_type;
                               return ({{zero: Vec768}}, ptr);
                             };
   (a, a_ptr) <- if a_aliased then return (ret, ret_ptr) else ptr_to_fresh_readonly "a" vec768_type;
   (b, b_ptr) <- if b_aliased then return (ret, ret_ptr) else ptr_to_fresh_readonly "b" vec768_type;
-  p_ptr <- crucible_alloc_readonly vec384_type;
-  crucible_precond {{ fpx2_invariant a }};
-  crucible_precond {{ fpx2_invariant b }};
-  crucible_points_to p_ptr p_representation;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fpx2_rep (add_mod_384x384 (fpx2_abs a) (fpx2_abs b)) }});
+  p_ptr <- llvm_alloc_readonly vec384_type;
+  llvm_precond {{ fpx2_invariant a }};
+  llvm_precond {{ fpx2_invariant b }};
+  llvm_points_to p_ptr p_representation;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fpx2_rep (add_mod_384x384 (fpx2_abs a) (fpx2_abs b)) }});
 };
 
 let sub_mod_384x384_spec a_aliased b_aliased = do {
   (ret, ret_ptr) <- if either a_aliased b_aliased
                     then ptr_to_fresh "ret" vec768_type
-                    else do { ptr <- crucible_alloc vec768_type;
+                    else do { ptr <- llvm_alloc vec768_type;
                               return ({{zero: Vec768}}, ptr);
                             };
   (a, a_ptr) <- if a_aliased then return (ret, ret_ptr) else ptr_to_fresh_readonly "a" vec768_type;
   (b, b_ptr) <- if b_aliased then return (ret, ret_ptr) else ptr_to_fresh_readonly "b" vec768_type;
-  p_ptr <- crucible_alloc_readonly vec384_type;
-  crucible_precond {{ fpx2_invariant a }};
-  crucible_precond {{ fpx2_invariant b }};
-  crucible_points_to p_ptr p_representation;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fpx2_rep (sub_mod_384x384 (fpx2_abs a) (fpx2_abs b)) }});
+  p_ptr <- llvm_alloc_readonly vec384_type;
+  llvm_precond {{ fpx2_invariant a }};
+  llvm_precond {{ fpx2_invariant b }};
+  llvm_points_to p_ptr p_representation;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fpx2_rep (sub_mod_384x384 (fpx2_abs a) (fpx2_abs b)) }});
 };
 
 let mul_382x_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
-  p_ptr <- crucible_alloc_readonly vec384_type;
-  crucible_precond {{ fp2_invariant a }}; // a is smallish
-  crucible_precond {{ fp2_invariant b }};
-  crucible_points_to p_ptr p_representation;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp2x2_rep (mul_382x (abs_384x a) (abs_384x b)) }});
+  p_ptr <- llvm_alloc_readonly vec384_type;
+  llvm_precond {{ fp2_invariant a }}; // a is smallish
+  llvm_precond {{ fp2_invariant b }};
+  llvm_points_to p_ptr p_representation;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp2x2_rep (mul_382x (abs_384x a) (abs_384x b)) }});
 };
 
 let redcx_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
-  p_ptr <- crucible_alloc vec384_type;
-  crucible_points_to p_ptr p_representation;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, p0_term];
-  crucible_points_to ret_ptr (crucible_term {{ rep_384 (redc_mont_384 (fpx2_abs a)) }});
+  p_ptr <- llvm_alloc vec384_type;
+  llvm_points_to p_ptr p_representation;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, p0_term];
+  llvm_points_to ret_ptr (llvm_term {{ rep_384 (redc_mont_384 (fpx2_abs a)) }});
 };
 
 let redcx_mont_384_alt_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_precond {{  b == vec384_rep `p }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p0_term];
-  crucible_points_to ret_ptr (crucible_term {{ rep_384 (redc_mont_384 (fpx2_abs a)) }});
+  llvm_precond {{  b == vec384_rep `p }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p0_term];
+  llvm_points_to ret_ptr (llvm_term {{ rep_384 (redc_mont_384 (fpx2_abs a)) }});
 };
 
 
 let sqr_382x_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
-  p_ptr <- crucible_alloc_readonly vec384_type;
-  crucible_precond {{ fp2_invariant a }}; // a is smallish
-  crucible_points_to p_ptr p_representation;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp2x2_rep (sqr_382x (abs_384x a)) }});
+  p_ptr <- llvm_alloc_readonly vec384_type;
+  llvm_precond {{ fp2_invariant a }}; // a is smallish
+  llvm_points_to p_ptr p_representation;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp2x2_rep (sqr_382x (abs_384x a)) }});
 };
 
 

--- a/proof/aggregate.saw
+++ b/proof/aggregate.saw
@@ -10,15 +10,15 @@ include "blst_error.saw";
 ///////////////////////////////////////////////////////////////////////////////
 
 let blst_pairing_init_spec DST_len = do {
-  ctx_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
-  hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
-  DST_ptr <- crucible_fresh_pointer (llvm_array DST_len (llvm_int 8));
-  crucible_execute_func [ctx_ptr, crucible_term hash_or_encode, DST_ptr, crucible_term {{`DST_len:[64]}}];
-  ctx_ctrl <- crucible_fresh_var "new_pairing_init_ctx_ctrl" (llvm_int 32);
-  crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term ctx_ctrl);
-  crucible_points_to (crucible_field ctx_ptr "nelems") (crucible_term {{0:[32]}});
-  crucible_points_to (crucible_field ctx_ptr "DST") DST_ptr;
-  crucible_points_to (crucible_field ctx_ptr "DST_len") (crucible_term {{`DST_len:[64]}});
+  ctx_ptr <- llvm_alloc (llvm_alias "struct.PAIRING");
+  hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);
+  DST_ptr <- llvm_fresh_pointer (llvm_array DST_len (llvm_int 8));
+  llvm_execute_func [ctx_ptr, llvm_term hash_or_encode, DST_ptr, llvm_term {{`DST_len:[64]}}];
+  ctx_ctrl <- llvm_fresh_var "new_pairing_init_ctx_ctrl" (llvm_int 32);
+  llvm_points_to (llvm_field ctx_ptr "ctrl") (llvm_term ctx_ctrl);
+  llvm_points_to (llvm_field ctx_ptr "nelems") (llvm_term {{0:[32]}});
+  llvm_points_to (llvm_field ctx_ptr "DST") DST_ptr;
+  llvm_points_to (llvm_field ctx_ptr "DST_len") (llvm_term {{`DST_len:[64]}});
 };
 
 // the enum for aggregate-operations errors
@@ -35,19 +35,19 @@ let N_MAX = 2; // NOTE: must match N_MAX defined in C code
 let {{ is_in_G1 (p : ([6][64], [6][64])) = (undefined:[64]) }}; // NOTE: the goal is to leave it uninterpreted
 let POINTonE1_in_G1_spec = do {
   (p, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE1_affine");
-  crucible_execute_func [p_ptr];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_postcond {{ ret == is_in_G1 p }};
-  crucible_return (crucible_term ret);
+  llvm_execute_func [p_ptr];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_postcond {{ ret == is_in_G1 p }};
+  llvm_return (llvm_term ret);
 };
 
 let {{ is_in_G2 (p : ([2][6][64], [2][6][64])) = (undefined:[64]) }}; // NOTE: the goal is to leave it uninterpreted
 let POINTonE2_in_G2_spec = do {
   (p, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE2_affine");
-  crucible_execute_func [p_ptr];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_postcond {{ ret == is_in_G2 p }};
-  crucible_return (crucible_term ret);
+  llvm_execute_func [p_ptr];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_postcond {{ ret == is_in_G2 p }};
+  llvm_return (llvm_term ret);
 };
 
 let blst_pairing_aggregate_pk_in_spec DST_len msg_len aug_len nelems null_sig min_sig = do {
@@ -60,210 +60,210 @@ let blst_pairing_aggregate_pk_in_spec DST_len msg_len aug_len nelems null_sig mi
   let group_test = if min_sig then {{is_in_G1}} else {{is_in_G2}};
   let null_sig_val = if min_sig then {{zero:([6][64], [6][64])}} else {{zero:([2][6][64], [2][6][64])}};
 
-  crucible_precond {{ `nelems < `N_MAX }};
+  llvm_precond {{ `nelems < `N_MAX }};
 
-  ctx_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
-  ctx_ctrl <- crucible_fresh_var (str_concat method_name "_ctx_ctrl") (llvm_int 32);
-  crucible_precond {{ ctx_ctrl && ~(AGGR_MIN_SIG || AGGR_SIGN_SET || AGGR_MIN_PK || AGGR_GT_SET || AGGR_HASH_OR_ENCODE) == zero }};
-  crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term ctx_ctrl);
+  ctx_ptr <- llvm_alloc (llvm_alias "struct.PAIRING");
+  ctx_ctrl <- llvm_fresh_var (str_concat method_name "_ctx_ctrl") (llvm_int 32);
+  llvm_precond {{ ctx_ctrl && ~(AGGR_MIN_SIG || AGGR_SIGN_SET || AGGR_MIN_PK || AGGR_GT_SET || AGGR_HASH_OR_ENCODE) == zero }};
+  llvm_points_to (llvm_field ctx_ptr "ctrl") (llvm_term ctx_ctrl);
 
-  crucible_points_to (crucible_field ctx_ptr "nelems") (crucible_term {{ `nelems:[32] }});
+  llvm_points_to (llvm_field ctx_ptr "nelems") (llvm_term {{ `nelems:[32] }});
 
-  ctx_Q <- crucible_fresh_var "pairing_aggregate_pk_in_g2_ctx_Q" (llvm_array nelems (llvm_alias "struct.POINTonE2_affine"));
-  crucible_points_to_untyped (crucible_field ctx_ptr "Q") (crucible_term ctx_Q);
-  ctx_P <- crucible_fresh_var "pairing_aggregate_pk_in_g2_ctx_P" (llvm_array nelems (llvm_alias "struct.POINTonE1_affine"));
-  crucible_points_to_untyped (crucible_field ctx_ptr "P") (crucible_term ctx_P);
+  ctx_Q <- llvm_fresh_var "pairing_aggregate_pk_in_g2_ctx_Q" (llvm_array nelems (llvm_alias "struct.POINTonE2_affine"));
+  llvm_points_to_untyped (llvm_field ctx_ptr "Q") (llvm_term ctx_Q);
+  ctx_P <- llvm_fresh_var "pairing_aggregate_pk_in_g2_ctx_P" (llvm_array nelems (llvm_alias "struct.POINTonE1_affine"));
+  llvm_points_to_untyped (llvm_field ctx_ptr "P") (llvm_term ctx_P);
 
-  ctx_GT <- crucible_fresh_var (str_concat method_name "_ctx_GT") vec384fp12_type;
-  crucible_conditional_points_to {{ (ctx_ctrl && AGGR_GT_SET) != zero }} (crucible_field ctx_ptr "GT") (crucible_term ctx_GT);
+  ctx_GT <- llvm_fresh_var (str_concat method_name "_ctx_GT") vec384fp12_type;
+  llvm_conditional_points_to {{ (ctx_ctrl && AGGR_GT_SET) != zero }} (llvm_field ctx_ptr "GT") (llvm_term ctx_GT);
 
-  ctx_AggrSign <- crucible_fresh_var (str_concat method_name "_ctx_AggrSign") sig_type;
-  crucible_conditional_points_to_untyped {{ (ctx_ctrl && AGGR_SIGN_SET) != zero }} (crucible_field ctx_ptr "AggrSign") (crucible_term ctx_AggrSign);
+  ctx_AggrSign <- llvm_fresh_var (str_concat method_name "_ctx_AggrSign") sig_type;
+  llvm_conditional_points_to_untyped {{ (ctx_ctrl && AGGR_SIGN_SET) != zero }} (llvm_field ctx_ptr "AggrSign") (llvm_term ctx_AggrSign);
 
   (_, DST_ptr) <- ptr_to_fresh_readonly "DST" (llvm_array DST_len (llvm_int 8));
-  crucible_points_to (crucible_field ctx_ptr "DST") DST_ptr;
-  crucible_points_to (crucible_field ctx_ptr "DST_len") (crucible_term {{`DST_len:[64]}});
+  llvm_points_to (llvm_field ctx_ptr "DST") DST_ptr;
+  llvm_points_to (llvm_field ctx_ptr "DST_len") (llvm_term {{`DST_len:[64]}});
 
   (PK, PK_ptr) <- ptr_to_fresh_readonly "PK" pk_type_affine;
   (sig, sig_ptr) <-
     if (eval_bool {{ (`null_sig:Bit) != False }})
-      then return (null_sig_val ,crucible_null)
+      then return (null_sig_val ,llvm_null)
       else (ptr_to_fresh_readonly "sig" sig_type_affine);
   (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));
-  aug <- crucible_fresh_var "aug" (llvm_array aug_len (llvm_int 8));
-  aug_ptr <- crucible_alloc_readonly_aligned aug_len (llvm_array aug_len (llvm_int 8));
-  crucible_points_to aug_ptr (crucible_term aug);
+  aug <- llvm_fresh_var "aug" (llvm_array aug_len (llvm_int 8));
+  aug_ptr <- llvm_alloc_readonly_aligned aug_len (llvm_array aug_len (llvm_int 8));
+  llvm_points_to aug_ptr (llvm_term aug);
 
-  crucible_execute_func [ctx_ptr, PK_ptr, sig_ptr, msg_ptr, crucible_term {{`msg_len:[64]}}, aug_ptr, crucible_term {{`aug_len:[64]}}];
+  llvm_execute_func [ctx_ptr, PK_ptr, sig_ptr, msg_ptr, llvm_term {{`msg_len:[64]}}, aug_ptr, llvm_term {{`aug_len:[64]}}];
 
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_postcond {{ ret == `BLST_AGGR_TYPE_MISMATCH \/ ret == `BLST_POINT_NOT_IN_GROUP \/ ret == `BLST_PK_IS_INFINITY \/ ret == `BLST_SUCCESS }};
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_postcond {{ ret == `BLST_AGGR_TYPE_MISMATCH \/ ret == `BLST_POINT_NOT_IN_GROUP \/ ret == `BLST_PK_IS_INFINITY \/ ret == `BLST_SUCCESS }};
   let cond1 = if min_sig then {{ctx_ctrl && AGGR_MIN_PK == zero}} else {{ctx_ctrl && AGGR_MIN_SIG == zero}} ;
-  crucible_postcond {{ ~cond1 ==> ret == `BLST_AGGR_TYPE_MISMATCH }};
-  crucible_postcond {{ cond1 /\ ((`null_sig:Bit) == False) /\ sig != zero /\ (group_test sig == zero) ==> ret == `BLST_POINT_NOT_IN_GROUP }};
-  crucible_postcond {{ cond1 /\ (((`null_sig:Bit) == True) \/ sig == zero \/ (group_test sig != zero)) /\ PK == zero ==> ret == `BLST_PK_IS_INFINITY }};
-  new_ctx_ctrl <- crucible_fresh_var (str_concat "new_" (str_concat method_name "_ctx_ctrl")) (llvm_int 32);
-  crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term new_ctx_ctrl);
+  llvm_postcond {{ ~cond1 ==> ret == `BLST_AGGR_TYPE_MISMATCH }};
+  llvm_postcond {{ cond1 /\ ((`null_sig:Bit) == False) /\ sig != zero /\ (group_test sig == zero) ==> ret == `BLST_POINT_NOT_IN_GROUP }};
+  llvm_postcond {{ cond1 /\ (((`null_sig:Bit) == True) \/ sig == zero \/ (group_test sig != zero)) /\ PK == zero ==> ret == `BLST_PK_IS_INFINITY }};
+  new_ctx_ctrl <- llvm_fresh_var (str_concat "new_" (str_concat method_name "_ctx_ctrl")) (llvm_int 32);
+  llvm_points_to (llvm_field ctx_ptr "ctrl") (llvm_term new_ctx_ctrl);
 
   if min_sig
     then
-      crucible_postcond {{ cond1 ==> new_ctx_ctrl && AGGR_MIN_SIG != zero }}
+      llvm_postcond {{ cond1 ==> new_ctx_ctrl && AGGR_MIN_SIG != zero }}
     else
-      crucible_postcond {{ cond1 ==> new_ctx_ctrl && AGGR_MIN_PK != zero }};
+      llvm_postcond {{ cond1 ==> new_ctx_ctrl && AGGR_MIN_PK != zero }};
 
-  new_nelems <- crucible_fresh_var (str_concat "new_" (str_concat method_name "_ctx_nelems")) (llvm_int 32);
-  crucible_points_to (crucible_field ctx_ptr "nelems") (crucible_term new_nelems);
-  crucible_postcond {{ ret == `BLST_SUCCESS /\ `nelems < `N_MAX-1 ==> new_nelems == ((`nelems+1):[32]) }};
-  crucible_postcond {{ ret == `BLST_SUCCESS /\ `nelems == `N_MAX-1 ==> new_nelems == (zero:[32]) }};
+  new_nelems <- llvm_fresh_var (str_concat "new_" (str_concat method_name "_ctx_nelems")) (llvm_int 32);
+  llvm_points_to (llvm_field ctx_ptr "nelems") (llvm_term new_nelems);
+  llvm_postcond {{ ret == `BLST_SUCCESS /\ `nelems < `N_MAX-1 ==> new_nelems == ((`nelems+1):[32]) }};
+  llvm_postcond {{ ret == `BLST_SUCCESS /\ `nelems == `N_MAX-1 ==> new_nelems == (zero:[32]) }};
 
-  crucible_postcond {{ (cond1 /\ (((`null_sig:Bit) == True) \/ sig == zero \/ (group_test sig != zero)) /\ PK != zero) == (ret == `BLST_SUCCESS) }};
-  new_ctx_Q <- crucible_fresh_var "new_pairing_aggregate_pk_in_g2_ctx_Q" (llvm_array (eval_size {| nelems+1 |}) (llvm_alias "struct.POINTonE2_affine"));
-  new_ctx_P <- crucible_fresh_var "new_pairing_aggregate_pk_in_g2_ctx_P" (llvm_array (eval_size {| nelems+1 |}) (llvm_alias "struct.POINTonE1_affine"));
-  crucible_conditional_points_to_untyped {{ ret == `BLST_SUCCESS }} (crucible_field ctx_ptr "Q") (crucible_term new_ctx_Q);
-  crucible_conditional_points_to_untyped {{ ret == `BLST_SUCCESS }} (crucible_field ctx_ptr "P") (crucible_term new_ctx_P);
+  llvm_postcond {{ (cond1 /\ (((`null_sig:Bit) == True) \/ sig == zero \/ (group_test sig != zero)) /\ PK != zero) == (ret == `BLST_SUCCESS) }};
+  new_ctx_Q <- llvm_fresh_var "new_pairing_aggregate_pk_in_g2_ctx_Q" (llvm_array (eval_size {| nelems+1 |}) (llvm_alias "struct.POINTonE2_affine"));
+  new_ctx_P <- llvm_fresh_var "new_pairing_aggregate_pk_in_g2_ctx_P" (llvm_array (eval_size {| nelems+1 |}) (llvm_alias "struct.POINTonE1_affine"));
+  llvm_conditional_points_to_untyped {{ ret == `BLST_SUCCESS }} (llvm_field ctx_ptr "Q") (llvm_term new_ctx_Q);
+  llvm_conditional_points_to_untyped {{ ret == `BLST_SUCCESS }} (llvm_field ctx_ptr "P") (llvm_term new_ctx_P);
 
-  crucible_postcond {{ ret == `BLST_SUCCESS /\ `nelems == (`N_MAX-1) ==> new_ctx_ctrl && AGGR_GT_SET != zero }};
-  new_ctx_GT <- crucible_fresh_var (str_concat "new_" (str_concat method_name "_ctx_GT")) vec384fp12_type;
-  crucible_conditional_points_to {{ ret == `BLST_SUCCESS /\ `nelems == (`N_MAX-1) }} (crucible_field ctx_ptr "GT") (crucible_term new_ctx_GT);
+  llvm_postcond {{ ret == `BLST_SUCCESS /\ `nelems == (`N_MAX-1) ==> new_ctx_ctrl && AGGR_GT_SET != zero }};
+  new_ctx_GT <- llvm_fresh_var (str_concat "new_" (str_concat method_name "_ctx_GT")) vec384fp12_type;
+  llvm_conditional_points_to {{ ret == `BLST_SUCCESS /\ `nelems == (`N_MAX-1) }} (llvm_field ctx_ptr "GT") (llvm_term new_ctx_GT);
 
-  crucible_postcond {{ (ctx_ctrl && AGGR_SIGN_SET) != zero \/ (cond1 /\ ((`null_sig:Bit) == False) /\ sig != zero /\ (group_test sig) != zero) ==> new_ctx_ctrl && AGGR_SIGN_SET != zero }};
-  new_ctx_AggrSign <- crucible_fresh_var (str_concat "new_" (str_concat method_name "_ctx_AggrSign")) sig_type;
-  crucible_conditional_points_to_untyped {{ (ctx_ctrl && AGGR_SIGN_SET) != zero \/ (cond1 /\ ((`null_sig:Bit) == False) /\ sig != zero /\ (group_test sig) != zero) }} (crucible_field ctx_ptr "AggrSign") (crucible_term new_ctx_AggrSign);
+  llvm_postcond {{ (ctx_ctrl && AGGR_SIGN_SET) != zero \/ (cond1 /\ ((`null_sig:Bit) == False) /\ sig != zero /\ (group_test sig) != zero) ==> new_ctx_ctrl && AGGR_SIGN_SET != zero }};
+  new_ctx_AggrSign <- llvm_fresh_var (str_concat "new_" (str_concat method_name "_ctx_AggrSign")) sig_type;
+  llvm_conditional_points_to_untyped {{ (ctx_ctrl && AGGR_SIGN_SET) != zero \/ (cond1 /\ ((`null_sig:Bit) == False) /\ sig != zero /\ (group_test sig) != zero) }} (llvm_field ctx_ptr "AggrSign") (llvm_term new_ctx_AggrSign);
 
-  crucible_return (crucible_term ret);
+  llvm_return (llvm_term ret);
 };
 
 let blst_pairing_commit_spec nelems = do {
-  ctx_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
+  ctx_ptr <- llvm_alloc (llvm_alias "struct.PAIRING");
 
-  ctx_ctrl <- crucible_fresh_var "new_pairing_commit_ctx_ctrl" (llvm_int 32);
-  crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term ctx_ctrl);
+  ctx_ctrl <- llvm_fresh_var "new_pairing_commit_ctx_ctrl" (llvm_int 32);
+  llvm_points_to (llvm_field ctx_ptr "ctrl") (llvm_term ctx_ctrl);
 
-  crucible_precond {{ `nelems <= `N_MAX }};
-  crucible_points_to (crucible_field ctx_ptr "nelems") (crucible_term {{`nelems:[32]}});
+  llvm_precond {{ `nelems <= `N_MAX }};
+  llvm_points_to (llvm_field ctx_ptr "nelems") (llvm_term {{`nelems:[32]}});
 
-  ctx_GT <- crucible_fresh_var "pairing_commit_ctx_GT" vec384fp12_type;
-  crucible_conditional_points_to {{ ctx_ctrl && AGGR_GT_SET != zero }} (crucible_field ctx_ptr "GT") (crucible_term ctx_GT);
+  ctx_GT <- llvm_fresh_var "pairing_commit_ctx_GT" vec384fp12_type;
+  llvm_conditional_points_to {{ ctx_ctrl && AGGR_GT_SET != zero }} (llvm_field ctx_ptr "GT") (llvm_term ctx_GT);
 
-  ctx_Q <- crucible_fresh_var "pairing_commit_ctx_Q" (llvm_array N_MAX (llvm_alias "struct.POINTonE2_affine"));
-  crucible_points_to_untyped (crucible_field ctx_ptr "Q") (crucible_term ctx_Q);
-  ctx_P <- crucible_fresh_var "pairing_commit_ctx_P" (llvm_array N_MAX (llvm_alias "struct.POINTonE1_affine"));
-  crucible_points_to_untyped (crucible_field ctx_ptr "P") (crucible_term ctx_P);
+  ctx_Q <- llvm_fresh_var "pairing_commit_ctx_Q" (llvm_array N_MAX (llvm_alias "struct.POINTonE2_affine"));
+  llvm_points_to_untyped (llvm_field ctx_ptr "Q") (llvm_term ctx_Q);
+  ctx_P <- llvm_fresh_var "pairing_commit_ctx_P" (llvm_array N_MAX (llvm_alias "struct.POINTonE1_affine"));
+  llvm_points_to_untyped (llvm_field ctx_ptr "P") (llvm_term ctx_P);
 
-  crucible_execute_func [ctx_ptr];
+  llvm_execute_func [ctx_ptr];
 
-  new_nelems <- crucible_fresh_var "new_pairing_commit_nelems" (llvm_int 32);
-  crucible_points_to (crucible_field ctx_ptr "nelems") (crucible_term new_nelems);
-  crucible_postcond {{ new_nelems == zero }};
+  new_nelems <- llvm_fresh_var "new_pairing_commit_nelems" (llvm_int 32);
+  llvm_points_to (llvm_field ctx_ptr "nelems") (llvm_term new_nelems);
+  llvm_postcond {{ new_nelems == zero }};
 
-  new_ctx_GT <- crucible_fresh_var "new_pairing_commit_ctx_GT" vec384fp12_type;
-  crucible_conditional_points_to {{ `nelems != zero }} (crucible_field ctx_ptr "GT") (crucible_term new_ctx_GT);
-  crucible_points_to (crucible_field ctx_ptr "nelems") (crucible_term {{ zero:[32] }});
+  new_ctx_GT <- llvm_fresh_var "new_pairing_commit_ctx_GT" vec384fp12_type;
+  llvm_conditional_points_to {{ `nelems != zero }} (llvm_field ctx_ptr "GT") (llvm_term new_ctx_GT);
+  llvm_points_to (llvm_field ctx_ptr "nelems") (llvm_term {{ zero:[32] }});
 
 };
 
 let blst_pairing_finalverify_spec null_GTsig min_sig sign_set = do {
-  ctx_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
+  ctx_ptr <- llvm_alloc (llvm_alias "struct.PAIRING");
 
-  ctx_ctrl <- crucible_fresh_var "pairing_final_verify_ctx_ctrl" (llvm_int 32);
-  crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term ctx_ctrl);
+  ctx_ctrl <- llvm_fresh_var "pairing_final_verify_ctx_ctrl" (llvm_int 32);
+  llvm_points_to (llvm_field ctx_ptr "ctrl") (llvm_term ctx_ctrl);
 
   (GTsig, GTsig_ptr) <-
     if null_GTsig
-      then return ({{ zero:[72][64] }},crucible_null)
+      then return ({{ zero:[72][64] }},llvm_null)
       else (ptr_to_fresh_readonly "GTsig" vec384fp12_type);
 
   if (eval_bool {{ `min_sig:Bit }})
-    then crucible_precond {{ (ctx_ctrl && AGGR_MIN_SIG) != zero /\ (ctx_ctrl && AGGR_MIN_PK) == zero}}
-    else crucible_precond {{ (ctx_ctrl && AGGR_MIN_PK) != zero /\ (ctx_ctrl && AGGR_MIN_SIG) == zero}};
+    then llvm_precond {{ (ctx_ctrl && AGGR_MIN_SIG) != zero /\ (ctx_ctrl && AGGR_MIN_PK) == zero}}
+    else llvm_precond {{ (ctx_ctrl && AGGR_MIN_PK) != zero /\ (ctx_ctrl && AGGR_MIN_SIG) == zero}};
 
   if (eval_bool {{ `sign_set:Bit }})
-    then crucible_precond {{ (ctx_ctrl && AGGR_SIGN_SET) != zero }}
-    else crucible_precond {{ (ctx_ctrl && AGGR_SIGN_SET) == zero }};
+    then llvm_precond {{ (ctx_ctrl && AGGR_SIGN_SET) != zero }}
+    else llvm_precond {{ (ctx_ctrl && AGGR_SIGN_SET) == zero }};
 
   ctx_AggrSign <- if (eval_bool {{ (`min_sig:Bit) /\ (`sign_set:Bit) }})
-      then (crucible_fresh_var "pairing_finalverify_ctx_AggrSign" (llvm_alias "struct.POINTonE1"))
-      else (crucible_fresh_var "pairing_finalverify_ctx_AggrSign" (llvm_alias "struct.POINTonE2"));
+      then (llvm_fresh_var "pairing_finalverify_ctx_AggrSign" (llvm_alias "struct.POINTonE1"))
+      else (llvm_fresh_var "pairing_finalverify_ctx_AggrSign" (llvm_alias "struct.POINTonE2"));
 
-  crucible_conditional_points_to_untyped {{ (ctx_ctrl && AGGR_SIGN_SET) != zero }} (crucible_field ctx_ptr "AggrSign") (crucible_term ctx_AggrSign);
+  llvm_conditional_points_to_untyped {{ (ctx_ctrl && AGGR_SIGN_SET) != zero }} (llvm_field ctx_ptr "AggrSign") (llvm_term ctx_AggrSign);
 
-  ctx_GT <- crucible_fresh_var "pairing_finalverify_ctx_GT" vec384fp12_type;
-  crucible_points_to (crucible_field ctx_ptr "GT") (crucible_term ctx_GT);
+  ctx_GT <- llvm_fresh_var "pairing_finalverify_ctx_GT" vec384fp12_type;
+  llvm_points_to (llvm_field ctx_ptr "GT") (llvm_term ctx_GT);
 
-  crucible_execute_func [ctx_ptr, GTsig_ptr];
-  ret <- crucible_fresh_var "ret" (llvm_int 64);
-  crucible_postcond {{ ((ctx_ctrl && AGGR_GT_SET) == zero) ==> ret == zero }};
+  llvm_execute_func [ctx_ptr, GTsig_ptr];
+  ret <- llvm_fresh_var "ret" (llvm_int 64);
+  llvm_postcond {{ ((ctx_ctrl && AGGR_GT_SET) == zero) ==> ret == zero }};
 
-  crucible_return (crucible_term ret);
+  llvm_return (llvm_term ret);
 };
 
 let blst_pairing_merge_spec min_sig = do {
-  ctx_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
-  ctx1_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
+  ctx_ptr <- llvm_alloc (llvm_alias "struct.PAIRING");
+  ctx1_ptr <- llvm_alloc (llvm_alias "struct.PAIRING");
 
-  ctx_ctrl <- crucible_fresh_var "pairing_merge_ctx_ctrl" (llvm_int 32);
-  crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term ctx_ctrl);
-  ctx1_ctrl <- crucible_fresh_var "pairing_merge_ctx1_ctrl" (llvm_int 32);
-  crucible_points_to (crucible_field ctx1_ptr "ctrl") (crucible_term ctx1_ctrl);
+  ctx_ctrl <- llvm_fresh_var "pairing_merge_ctx_ctrl" (llvm_int 32);
+  llvm_points_to (llvm_field ctx_ptr "ctrl") (llvm_term ctx_ctrl);
+  ctx1_ctrl <- llvm_fresh_var "pairing_merge_ctx1_ctrl" (llvm_int 32);
+  llvm_points_to (llvm_field ctx1_ptr "ctrl") (llvm_term ctx1_ctrl);
 
-  nelems <- crucible_fresh_var "pairing_merge_ctx_nelems" (llvm_int 32);
-  crucible_points_to (crucible_field ctx_ptr "nelems") (crucible_term nelems);
-  nelems1 <- crucible_fresh_var "pairing_merge_ctx1_nelems" (llvm_int 32);
-  crucible_points_to (crucible_field ctx1_ptr "nelems") (crucible_term nelems1);
+  nelems <- llvm_fresh_var "pairing_merge_ctx_nelems" (llvm_int 32);
+  llvm_points_to (llvm_field ctx_ptr "nelems") (llvm_term nelems);
+  nelems1 <- llvm_fresh_var "pairing_merge_ctx1_nelems" (llvm_int 32);
+  llvm_points_to (llvm_field ctx1_ptr "nelems") (llvm_term nelems1);
 
-  AggrSignE1 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE1" (llvm_alias "struct.POINTonE1");
-  AggrSignE1_1 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE1" (llvm_alias "struct.POINTonE1");
-  AggrSignE2 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE2" (llvm_alias "struct.POINTonE2");
-  AggrSignE2_1 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE2" (llvm_alias "struct.POINTonE2");
+  AggrSignE1 <- llvm_fresh_var "pairing_merge_ctx_AggrSignE1" (llvm_alias "struct.POINTonE1");
+  AggrSignE1_1 <- llvm_fresh_var "pairing_merge_ctx_AggrSignE1" (llvm_alias "struct.POINTonE1");
+  AggrSignE2 <- llvm_fresh_var "pairing_merge_ctx_AggrSignE2" (llvm_alias "struct.POINTonE2");
+  AggrSignE2_1 <- llvm_fresh_var "pairing_merge_ctx_AggrSignE2" (llvm_alias "struct.POINTonE2");
 
   if min_sig
     then do {
-      crucible_precond {{ ctx_ctrl && AGGR_MIN_SIG != zero }};
-      crucible_conditional_points_to_untyped {{ ctx_ctrl && AGGR_MIN_SIG != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET != zero }} (crucible_field ctx_ptr "AggrSign") (crucible_term AggrSignE1);
-      crucible_conditional_points_to_untyped {{ (ctx_ctrl && AGGR_MIN_SIG != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET != zero) \/ (ctx_ctrl && AGGR_MIN_SIG != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET == zero /\ ctx1_ctrl && AGGR_SIGN_SET != zero) }} (crucible_field ctx1_ptr "AggrSign") (crucible_term AggrSignE1_1);
+      llvm_precond {{ ctx_ctrl && AGGR_MIN_SIG != zero }};
+      llvm_conditional_points_to_untyped {{ ctx_ctrl && AGGR_MIN_SIG != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET != zero }} (llvm_field ctx_ptr "AggrSign") (llvm_term AggrSignE1);
+      llvm_conditional_points_to_untyped {{ (ctx_ctrl && AGGR_MIN_SIG != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET != zero) \/ (ctx_ctrl && AGGR_MIN_SIG != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET == zero /\ ctx1_ctrl && AGGR_SIGN_SET != zero) }} (llvm_field ctx1_ptr "AggrSign") (llvm_term AggrSignE1_1);
     }
     else do {
-      crucible_precond {{ ctx_ctrl && AGGR_MIN_PK != zero }};
-      crucible_conditional_points_to {{ ctx_ctrl && AGGR_MIN_PK != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET != zero }} (crucible_field ctx_ptr "AggrSign") (crucible_term AggrSignE2);
-      crucible_conditional_points_to {{ (ctx_ctrl && AGGR_MIN_PK != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET != zero) \/ (ctx_ctrl && AGGR_MIN_PK != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET == zero /\ ctx1_ctrl && AGGR_SIGN_SET != zero) }} (crucible_field ctx1_ptr "AggrSign") (crucible_term AggrSignE2_1);
+      llvm_precond {{ ctx_ctrl && AGGR_MIN_PK != zero }};
+      llvm_conditional_points_to {{ ctx_ctrl && AGGR_MIN_PK != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET != zero }} (llvm_field ctx_ptr "AggrSign") (llvm_term AggrSignE2);
+      llvm_conditional_points_to {{ (ctx_ctrl && AGGR_MIN_PK != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET != zero) \/ (ctx_ctrl && AGGR_MIN_PK != zero /\ ctx_ctrl && ctx1_ctrl && AGGR_SIGN_SET == zero /\ ctx1_ctrl && AGGR_SIGN_SET != zero) }} (llvm_field ctx1_ptr "AggrSign") (llvm_term AggrSignE2_1);
     };
 
-  ctx_GT <- crucible_fresh_var "pairing_merge_ctx_GT" vec384fp12_type;
-  crucible_conditional_points_to {{ ctx_ctrl && ctx1_ctrl && AGGR_GT_SET != zero }} (crucible_field ctx_ptr "GT") (crucible_term ctx_GT);
-  ctx1_GT <- crucible_fresh_var "pairing_merge_ctx1_GT" vec384fp12_type;
-  crucible_conditional_points_to {{ ctx1_ctrl && AGGR_GT_SET != zero }} (crucible_field ctx1_ptr "GT") (crucible_term ctx1_GT);
+  ctx_GT <- llvm_fresh_var "pairing_merge_ctx_GT" vec384fp12_type;
+  llvm_conditional_points_to {{ ctx_ctrl && ctx1_ctrl && AGGR_GT_SET != zero }} (llvm_field ctx_ptr "GT") (llvm_term ctx_GT);
+  ctx1_GT <- llvm_fresh_var "pairing_merge_ctx1_GT" vec384fp12_type;
+  llvm_conditional_points_to {{ ctx1_ctrl && AGGR_GT_SET != zero }} (llvm_field ctx1_ptr "GT") (llvm_term ctx1_GT);
 
-  crucible_execute_func [ctx_ptr, ctx1_ptr];
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
+  llvm_execute_func [ctx_ptr, ctx1_ptr];
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
 
-  crucible_postcond {{
+  llvm_postcond {{
     ctx_ctrl && MIN_SIG_OR_PK != zero /\ ctx_ctrl && ctx1_ctrl && MIN_SIG_OR_PK == zero
       ==> ret == `BLST_AGGR_TYPE_MISMATCH }};
-  crucible_postcond {{ (nelems != zero) || (nelems1 != zero) ==> ret == `BLST_AGGR_TYPE_MISMATCH }};
+  llvm_postcond {{ (nelems != zero) || (nelems1 != zero) ==> ret == `BLST_AGGR_TYPE_MISMATCH }};
 
-  new_ctx_ctrl <- crucible_fresh_var "new_merge_ctx_ctrl" (llvm_int 32);
-  crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term new_ctx_ctrl);
-  new_ctx1_ctrl <- crucible_fresh_var "new_merge_ctx1_ctrl" (llvm_int 32);
-  crucible_points_to (crucible_field ctx1_ptr "ctrl") (crucible_term new_ctx1_ctrl);
-  crucible_postcond {{ ~(ctx_ctrl && MIN_SIG_OR_PK != zero /\ ctx_ctrl && ctx1_ctrl && MIN_SIG_OR_PK == zero) /\ nelems == zero /\ nelems1 == zero /\ ctx1_ctrl && AGGR_SIGN_SET != zero /\ (ctx_ctrl && MIN_SIG_OR_PK == AGGR_MIN_SIG \/ ctx_ctrl && MIN_SIG_OR_PK == AGGR_MIN_PK) ==> new_ctx_ctrl && AGGR_SIGN_SET != zero }};
+  new_ctx_ctrl <- llvm_fresh_var "new_merge_ctx_ctrl" (llvm_int 32);
+  llvm_points_to (llvm_field ctx_ptr "ctrl") (llvm_term new_ctx_ctrl);
+  new_ctx1_ctrl <- llvm_fresh_var "new_merge_ctx1_ctrl" (llvm_int 32);
+  llvm_points_to (llvm_field ctx1_ptr "ctrl") (llvm_term new_ctx1_ctrl);
+  llvm_postcond {{ ~(ctx_ctrl && MIN_SIG_OR_PK != zero /\ ctx_ctrl && ctx1_ctrl && MIN_SIG_OR_PK == zero) /\ nelems == zero /\ nelems1 == zero /\ ctx1_ctrl && AGGR_SIGN_SET != zero /\ (ctx_ctrl && MIN_SIG_OR_PK == AGGR_MIN_SIG \/ ctx_ctrl && MIN_SIG_OR_PK == AGGR_MIN_PK) ==> new_ctx_ctrl && AGGR_SIGN_SET != zero }};
 
-  crucible_return (crucible_term ret);
+  llvm_return (llvm_term ret);
 };
 
 let blst_aggregated_in_g1_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, sig_ptr) <- ptr_to_fresh_readonly "aggregated_in_g1_sig" (llvm_alias "struct.POINTonE1_affine");
-  crucible_execute_func [ret_ptr, sig_ptr];
-  new_ret <- crucible_fresh_var "new_aggregated_in_g1_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, sig_ptr];
+  new_ret <- llvm_fresh_var "new_aggregated_in_g1_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let blst_aggregated_in_g2_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, sig_ptr) <- ptr_to_fresh_readonly "aggregated_in_g2_sig" (llvm_alias "struct.POINTonE2_affine");
-  crucible_execute_func [ret_ptr, sig_ptr];
-  new_ret <- crucible_fresh_var "new_aggregated_in_g2_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, sig_ptr];
+  new_ret <- llvm_fresh_var "new_aggregated_in_g2_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -275,9 +275,9 @@ POINTonE1_in_G1_ov <- admit "POINTonE1_in_G1" POINTonE1_in_G1_spec;
 // Also make sure this is memory safe (even if we don't use this override):
 let POINTonE1_in_G1_spec_ = do {
   (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE1_affine");
-  crucible_execute_func [p_ptr];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_return (crucible_term ret);
+  llvm_execute_func [p_ptr];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 POINTonE1_in_G1_ov_ <- verify "POINTonE1_in_G1" (concat ec_ops_overrides assembly_overrides) POINTonE1_in_G1_spec_;
 
@@ -286,9 +286,9 @@ POINTonE2_in_G2_ov <- admit "POINTonE2_in_G2" POINTonE2_in_G2_spec;
 // Also make sure this is memory safe (even if we don't use this override):
 let POINTonE2_in_G2_spec_ = do {
   (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE2_affine");
-  crucible_execute_func [p_ptr];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_return (crucible_term ret);
+  llvm_execute_func [p_ptr];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 POINTonE2_in_G2_ov_ <- verify "POINTonE2_in_G2" (concat ec_ops_overrides assembly_overrides) POINTonE2_in_G2_spec_;
 

--- a/proof/aggregate.saw
+++ b/proof/aggregate.saw
@@ -10,7 +10,7 @@ include "blst_error.saw";
 ///////////////////////////////////////////////////////////////////////////////
 
 let blst_pairing_init_spec DST_len = do {
-  ctx_ptr <- crucible_alloc (llvm_struct "struct.PAIRING");
+  ctx_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
   hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
   DST_ptr <- crucible_fresh_pointer (llvm_array DST_len (llvm_int 8));
   crucible_execute_func [ctx_ptr, crucible_term hash_or_encode, DST_ptr, crucible_term {{`DST_len:[64]}}];
@@ -34,7 +34,7 @@ let N_MAX = 2; // NOTE: must match N_MAX defined in C code
 
 let {{ is_in_G1 (p : ([6][64], [6][64])) = (undefined:[64]) }}; // NOTE: the goal is to leave it uninterpreted
 let POINTonE1_in_G1_spec = do {
-  (p, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_struct "struct.POINTonE1_affine");
+  (p, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE1_affine");
   crucible_execute_func [p_ptr];
   ret <- crucible_fresh_var "ret" limb_type;
   crucible_postcond {{ ret == is_in_G1 p }};
@@ -43,7 +43,7 @@ let POINTonE1_in_G1_spec = do {
 
 let {{ is_in_G2 (p : ([2][6][64], [2][6][64])) = (undefined:[64]) }}; // NOTE: the goal is to leave it uninterpreted
 let POINTonE2_in_G2_spec = do {
-  (p, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_struct "struct.POINTonE2_affine");
+  (p, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE2_affine");
   crucible_execute_func [p_ptr];
   ret <- crucible_fresh_var "ret" limb_type;
   crucible_postcond {{ ret == is_in_G2 p }};
@@ -52,26 +52,26 @@ let POINTonE2_in_G2_spec = do {
 
 let blst_pairing_aggregate_pk_in_spec DST_len msg_len aug_len nelems null_sig min_sig = do {
 
-  let sig_type = if min_sig then (llvm_struct "struct.POINTonE1") else (llvm_struct "struct.POINTonE2");
-  let pk_type = if min_sig then (llvm_struct "struct.POINTonE2") else (llvm_struct "struct.POINTonE1");
-  let sig_type_affine = if min_sig then (llvm_struct "struct.POINTonE1_affine") else (llvm_struct "struct.POINTonE2_affine");
-  let pk_type_affine = if min_sig then (llvm_struct "struct.POINTonE2_affine") else (llvm_struct "struct.POINTonE1_affine");
+  let sig_type = if min_sig then (llvm_alias "struct.POINTonE1") else (llvm_alias "struct.POINTonE2");
+  let pk_type = if min_sig then (llvm_alias "struct.POINTonE2") else (llvm_alias "struct.POINTonE1");
+  let sig_type_affine = if min_sig then (llvm_alias "struct.POINTonE1_affine") else (llvm_alias "struct.POINTonE2_affine");
+  let pk_type_affine = if min_sig then (llvm_alias "struct.POINTonE2_affine") else (llvm_alias "struct.POINTonE1_affine");
   let method_name = if min_sig then "pairing_aggregate_pk_in_g2" else "pairing_aggregate_pk_in_g1";
   let group_test = if min_sig then {{is_in_G1}} else {{is_in_G2}};
   let null_sig_val = if min_sig then {{zero:([6][64], [6][64])}} else {{zero:([2][6][64], [2][6][64])}};
 
   crucible_precond {{ `nelems < `N_MAX }};
 
-  ctx_ptr <- crucible_alloc (llvm_struct "struct.PAIRING");
+  ctx_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
   ctx_ctrl <- crucible_fresh_var (str_concat method_name "_ctx_ctrl") (llvm_int 32);
   crucible_precond {{ ctx_ctrl && ~(AGGR_MIN_SIG || AGGR_SIGN_SET || AGGR_MIN_PK || AGGR_GT_SET || AGGR_HASH_OR_ENCODE) == zero }};
   crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term ctx_ctrl);
 
   crucible_points_to (crucible_field ctx_ptr "nelems") (crucible_term {{ `nelems:[32] }});
 
-  ctx_Q <- crucible_fresh_var "pairing_aggregate_pk_in_g2_ctx_Q" (llvm_array nelems (llvm_struct "struct.POINTonE2_affine"));
+  ctx_Q <- crucible_fresh_var "pairing_aggregate_pk_in_g2_ctx_Q" (llvm_array nelems (llvm_alias "struct.POINTonE2_affine"));
   crucible_points_to_untyped (crucible_field ctx_ptr "Q") (crucible_term ctx_Q);
-  ctx_P <- crucible_fresh_var "pairing_aggregate_pk_in_g2_ctx_P" (llvm_array nelems (llvm_struct "struct.POINTonE1_affine"));
+  ctx_P <- crucible_fresh_var "pairing_aggregate_pk_in_g2_ctx_P" (llvm_array nelems (llvm_alias "struct.POINTonE1_affine"));
   crucible_points_to_untyped (crucible_field ctx_ptr "P") (crucible_term ctx_P);
 
   ctx_GT <- crucible_fresh_var (str_concat method_name "_ctx_GT") vec384fp12_type;
@@ -117,8 +117,8 @@ let blst_pairing_aggregate_pk_in_spec DST_len msg_len aug_len nelems null_sig mi
   crucible_postcond {{ ret == `BLST_SUCCESS /\ `nelems == `N_MAX-1 ==> new_nelems == (zero:[32]) }};
 
   crucible_postcond {{ (cond1 /\ (((`null_sig:Bit) == True) \/ sig == zero \/ (group_test sig != zero)) /\ PK != zero) == (ret == `BLST_SUCCESS) }};
-  new_ctx_Q <- crucible_fresh_var "new_pairing_aggregate_pk_in_g2_ctx_Q" (llvm_array (eval_size {| nelems+1 |}) (llvm_struct "struct.POINTonE2_affine"));
-  new_ctx_P <- crucible_fresh_var "new_pairing_aggregate_pk_in_g2_ctx_P" (llvm_array (eval_size {| nelems+1 |}) (llvm_struct "struct.POINTonE1_affine"));
+  new_ctx_Q <- crucible_fresh_var "new_pairing_aggregate_pk_in_g2_ctx_Q" (llvm_array (eval_size {| nelems+1 |}) (llvm_alias "struct.POINTonE2_affine"));
+  new_ctx_P <- crucible_fresh_var "new_pairing_aggregate_pk_in_g2_ctx_P" (llvm_array (eval_size {| nelems+1 |}) (llvm_alias "struct.POINTonE1_affine"));
   crucible_conditional_points_to_untyped {{ ret == `BLST_SUCCESS }} (crucible_field ctx_ptr "Q") (crucible_term new_ctx_Q);
   crucible_conditional_points_to_untyped {{ ret == `BLST_SUCCESS }} (crucible_field ctx_ptr "P") (crucible_term new_ctx_P);
 
@@ -134,7 +134,7 @@ let blst_pairing_aggregate_pk_in_spec DST_len msg_len aug_len nelems null_sig mi
 };
 
 let blst_pairing_commit_spec nelems = do {
-  ctx_ptr <- crucible_alloc (llvm_struct "struct.PAIRING");
+  ctx_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
 
   ctx_ctrl <- crucible_fresh_var "new_pairing_commit_ctx_ctrl" (llvm_int 32);
   crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term ctx_ctrl);
@@ -145,9 +145,9 @@ let blst_pairing_commit_spec nelems = do {
   ctx_GT <- crucible_fresh_var "pairing_commit_ctx_GT" vec384fp12_type;
   crucible_conditional_points_to {{ ctx_ctrl && AGGR_GT_SET != zero }} (crucible_field ctx_ptr "GT") (crucible_term ctx_GT);
 
-  ctx_Q <- crucible_fresh_var "pairing_commit_ctx_Q" (llvm_array N_MAX (llvm_struct "struct.POINTonE2_affine"));
+  ctx_Q <- crucible_fresh_var "pairing_commit_ctx_Q" (llvm_array N_MAX (llvm_alias "struct.POINTonE2_affine"));
   crucible_points_to_untyped (crucible_field ctx_ptr "Q") (crucible_term ctx_Q);
-  ctx_P <- crucible_fresh_var "pairing_commit_ctx_P" (llvm_array N_MAX (llvm_struct "struct.POINTonE1_affine"));
+  ctx_P <- crucible_fresh_var "pairing_commit_ctx_P" (llvm_array N_MAX (llvm_alias "struct.POINTonE1_affine"));
   crucible_points_to_untyped (crucible_field ctx_ptr "P") (crucible_term ctx_P);
 
   crucible_execute_func [ctx_ptr];
@@ -163,7 +163,7 @@ let blst_pairing_commit_spec nelems = do {
 };
 
 let blst_pairing_finalverify_spec null_GTsig min_sig sign_set = do {
-  ctx_ptr <- crucible_alloc (llvm_struct "struct.PAIRING");
+  ctx_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
 
   ctx_ctrl <- crucible_fresh_var "pairing_final_verify_ctx_ctrl" (llvm_int 32);
   crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term ctx_ctrl);
@@ -182,8 +182,8 @@ let blst_pairing_finalverify_spec null_GTsig min_sig sign_set = do {
     else crucible_precond {{ (ctx_ctrl && AGGR_SIGN_SET) == zero }};
 
   ctx_AggrSign <- if (eval_bool {{ (`min_sig:Bit) /\ (`sign_set:Bit) }})
-      then (crucible_fresh_var "pairing_finalverify_ctx_AggrSign" (llvm_struct "struct.POINTonE1"))
-      else (crucible_fresh_var "pairing_finalverify_ctx_AggrSign" (llvm_struct "struct.POINTonE2"));
+      then (crucible_fresh_var "pairing_finalverify_ctx_AggrSign" (llvm_alias "struct.POINTonE1"))
+      else (crucible_fresh_var "pairing_finalverify_ctx_AggrSign" (llvm_alias "struct.POINTonE2"));
 
   crucible_conditional_points_to_untyped {{ (ctx_ctrl && AGGR_SIGN_SET) != zero }} (crucible_field ctx_ptr "AggrSign") (crucible_term ctx_AggrSign);
 
@@ -198,8 +198,8 @@ let blst_pairing_finalverify_spec null_GTsig min_sig sign_set = do {
 };
 
 let blst_pairing_merge_spec min_sig = do {
-  ctx_ptr <- crucible_alloc (llvm_struct "struct.PAIRING");
-  ctx1_ptr <- crucible_alloc (llvm_struct "struct.PAIRING");
+  ctx_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
+  ctx1_ptr <- crucible_alloc (llvm_alias "struct.PAIRING");
 
   ctx_ctrl <- crucible_fresh_var "pairing_merge_ctx_ctrl" (llvm_int 32);
   crucible_points_to (crucible_field ctx_ptr "ctrl") (crucible_term ctx_ctrl);
@@ -211,10 +211,10 @@ let blst_pairing_merge_spec min_sig = do {
   nelems1 <- crucible_fresh_var "pairing_merge_ctx1_nelems" (llvm_int 32);
   crucible_points_to (crucible_field ctx1_ptr "nelems") (crucible_term nelems1);
 
-  AggrSignE1 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE1" (llvm_struct "struct.POINTonE1");
-  AggrSignE1_1 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE1" (llvm_struct "struct.POINTonE1");
-  AggrSignE2 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE2" (llvm_struct "struct.POINTonE2");
-  AggrSignE2_1 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE2" (llvm_struct "struct.POINTonE2");
+  AggrSignE1 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE1" (llvm_alias "struct.POINTonE1");
+  AggrSignE1_1 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE1" (llvm_alias "struct.POINTonE1");
+  AggrSignE2 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE2" (llvm_alias "struct.POINTonE2");
+  AggrSignE2_1 <- crucible_fresh_var "pairing_merge_ctx_AggrSignE2" (llvm_alias "struct.POINTonE2");
 
   if min_sig
     then do {
@@ -252,7 +252,7 @@ let blst_pairing_merge_spec min_sig = do {
 
 let blst_aggregated_in_g1_spec = do {
   ret_ptr <- crucible_alloc vec384fp12_type;
-  (_, sig_ptr) <- ptr_to_fresh_readonly "aggregated_in_g1_sig" (llvm_struct "struct.POINTonE1_affine");
+  (_, sig_ptr) <- ptr_to_fresh_readonly "aggregated_in_g1_sig" (llvm_alias "struct.POINTonE1_affine");
   crucible_execute_func [ret_ptr, sig_ptr];
   new_ret <- crucible_fresh_var "new_aggregated_in_g1_ret" vec384fp12_type;
   crucible_points_to ret_ptr (crucible_term new_ret);
@@ -260,7 +260,7 @@ let blst_aggregated_in_g1_spec = do {
 
 let blst_aggregated_in_g2_spec = do {
   ret_ptr <- crucible_alloc vec384fp12_type;
-  (_, sig_ptr) <- ptr_to_fresh_readonly "aggregated_in_g2_sig" (llvm_struct "struct.POINTonE2_affine");
+  (_, sig_ptr) <- ptr_to_fresh_readonly "aggregated_in_g2_sig" (llvm_alias "struct.POINTonE2_affine");
   crucible_execute_func [ret_ptr, sig_ptr];
   new_ret <- crucible_fresh_var "new_aggregated_in_g2_ret" vec384fp12_type;
   crucible_points_to ret_ptr (crucible_term new_ret);
@@ -274,7 +274,7 @@ POINTonE1_in_G1_ov <- admit "POINTonE1_in_G1" POINTonE1_in_G1_spec;
 
 // Also make sure this is memory safe (even if we don't use this override):
 let POINTonE1_in_G1_spec_ = do {
-  (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_struct "struct.POINTonE1_affine");
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE1_affine");
   crucible_execute_func [p_ptr];
   ret <- crucible_fresh_var "ret" limb_type;
   crucible_return (crucible_term ret);
@@ -285,7 +285,7 @@ POINTonE2_in_G2_ov <- admit "POINTonE2_in_G2" POINTonE2_in_G2_spec;
 
 // Also make sure this is memory safe (even if we don't use this override):
 let POINTonE2_in_G2_spec_ = do {
-  (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_struct "struct.POINTonE2_affine");
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE2_affine");
   crucible_execute_func [p_ptr];
   ret <- crucible_fresh_var "ret" limb_type;
   crucible_return (crucible_term ret);

--- a/proof/aggregate_in_g1.saw
+++ b/proof/aggregate_in_g1.saw
@@ -18,8 +18,8 @@ let {{
 
 // case in which the input is not null and we return BLST_SUCCESS:
 let blst_aggregate_in_g1_OK_nonnull_spec = do {
-  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g1_out" (llvm_struct "struct.POINTonE1");
-  (inp, inp_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g1_in" (llvm_struct "struct.POINTonE1");
+  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g1_out" (llvm_alias "struct.POINTonE1");
+  (inp, inp_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g1_in" (llvm_alias "struct.POINTonE1");
   (zwire, zwire_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g1_zwire" (llvm_array 48 (llvm_int 8));
   //
   llvm_precond {{ (zwire@0)@0 }}; // compressed
@@ -28,7 +28,7 @@ let blst_aggregate_in_g1_OK_nonnull_spec = do {
   //
   llvm_execute_func [out_ptr, inp_ptr, zwire_ptr];
   //
-  new_out <- llvm_fresh_var "new_out" (llvm_struct "struct.POINTonE1");
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE1");
   llvm_points_to out_ptr (llvm_term new_out);
   llvm_postcond {{ affinify E (POINTonE1_abs new_out) == if (zwire@0)@1 then affinify E (POINTonE1_abs out) else add E (affinify E (POINTonE1_abs inp)) (uncompress_E1_OK zwire) }};
   //
@@ -39,7 +39,7 @@ let blst_aggregate_in_g1_OK_nonnull_spec = do {
 
 let blst_aggregate_in_g1_null_spec = do {
   //
-  out_ptr <- llvm_alloc (llvm_struct "struct.POINTonE1");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   let inp_ptr = llvm_null;
   //
   (zwire, zwire_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g1_zwire" (llvm_array 48 (llvm_int 8));
@@ -48,7 +48,7 @@ let blst_aggregate_in_g1_null_spec = do {
   //
   llvm_execute_func [out_ptr, inp_ptr, zwire_ptr];
   //
-  new_out <- llvm_fresh_var "new_out" (llvm_struct "struct.POINTonE1");
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE1");
   llvm_points_to out_ptr (llvm_term new_out);
   llvm_postcond {{ affinify E (POINTonE1_abs new_out) ==
     if (zwire@0)@1
@@ -61,13 +61,13 @@ let blst_aggregate_in_g1_null_spec = do {
 
 // here we cover the error cases:
 let blst_aggregate_in_g1_error_spec = do {
-  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g1_out" (llvm_struct "struct.POINTonE1");
-  (inp, inp_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g1_in" (llvm_struct "struct.POINTonE1");
+  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g1_out" (llvm_alias "struct.POINTonE1");
+  (inp, inp_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g1_in" (llvm_alias "struct.POINTonE1");
   (zwire, zwire_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g1_zwire" (llvm_array 48 (llvm_int 8));
   llvm_precond {{ (zwire@0)@0 }}; // compressed
   llvm_precond {{ aggregate_in_g1_error_precond zwire }};
   llvm_execute_func [out_ptr, inp_ptr, zwire_ptr];
-  new_out <- llvm_fresh_var "new_out" (llvm_struct "struct.POINTonE1");
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE1");
   llvm_points_to out_ptr (llvm_term new_out);
   llvm_postcond {{ new_out == out }};
   ret <- llvm_fresh_var "blst_aggregate_in_g1_ret" (llvm_int 32);
@@ -77,13 +77,13 @@ let blst_aggregate_in_g1_error_spec = do {
 
 // the behavior in the error case does not depend on whether the input is null or not:
 let blst_aggregate_in_g1_null_error_spec = do {
-  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g1_out" (llvm_struct "struct.POINTonE1");
+  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g1_out" (llvm_alias "struct.POINTonE1");
   let inp_ptr = llvm_null;
   (zwire, zwire_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g1_zwire" (llvm_array 48 (llvm_int 8));
   llvm_precond {{ (zwire@0)@0 }}; // compressed
   llvm_precond {{ aggregate_in_g1_error_precond zwire }};
   llvm_execute_func [out_ptr, inp_ptr, zwire_ptr];
-  new_out <- llvm_fresh_var "new_out" (llvm_struct "struct.POINTonE1");
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE1");
   llvm_points_to out_ptr (llvm_term new_out);
   llvm_postcond {{ new_out == out }};
   ret <- llvm_fresh_var "blst_aggregate_in_g1_ret" (llvm_int 32);

--- a/proof/aggregate_in_g2.saw
+++ b/proof/aggregate_in_g2.saw
@@ -19,8 +19,8 @@ let {{
 // case in which the input is not null and we return BLST_SUCCESS:
 let blst_aggregate_in_g2_OK_nonnull_spec = do {
   //
-  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g2_out" (llvm_struct "struct.POINTonE2");
-  (inp, inp_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g2_in" (llvm_struct "struct.POINTonE2");
+  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g2_out" (llvm_alias "struct.POINTonE2");
+  (inp, inp_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g2_in" (llvm_alias "struct.POINTonE2");
   (zwire, zwire_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g2_zwire" (llvm_array 96 (llvm_int 8));
   //
   llvm_precond {{ (zwire@0)@0 }}; // compressed
@@ -29,7 +29,7 @@ let blst_aggregate_in_g2_OK_nonnull_spec = do {
   //
   llvm_execute_func [out_ptr, inp_ptr, zwire_ptr];
   //
-  new_out <- llvm_fresh_var "new_out" (llvm_struct "struct.POINTonE2");
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE2");
   llvm_points_to out_ptr (llvm_term new_out);
   llvm_postcond {{ affinify E' (POINTonE2_abs new_out) == if (zwire@0)@1 then affinify E' (POINTonE2_abs out) else add E' (affinify E' (POINTonE2_abs inp)) (uncompress_E2_OK zwire) }};
   //
@@ -40,7 +40,7 @@ let blst_aggregate_in_g2_OK_nonnull_spec = do {
 
 let blst_aggregate_in_g2_null_spec = do {
   //
-  out_ptr <- llvm_alloc (llvm_struct "struct.POINTonE2");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   let inp_ptr = llvm_null;
   //
   (zwire, zwire_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g2_zwire" (llvm_array 96 (llvm_int 8));
@@ -49,7 +49,7 @@ let blst_aggregate_in_g2_null_spec = do {
   //
   llvm_execute_func [out_ptr, inp_ptr, zwire_ptr];
   //
-  new_out <- llvm_fresh_var "new_out" (llvm_struct "struct.POINTonE2");
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE2");
   llvm_points_to out_ptr (llvm_term new_out);
   llvm_postcond {{ affinify E' (POINTonE2_abs new_out) ==
     if (zwire@0)@1
@@ -62,8 +62,8 @@ let blst_aggregate_in_g2_null_spec = do {
 
 // here we cover the error cases:
 let blst_aggregate_in_g2_error_spec = do {
-  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g2_out" (llvm_struct "struct.POINTonE2");
-  (inp, inp_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g2_in" (llvm_struct "struct.POINTonE2");
+  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g2_out" (llvm_alias "struct.POINTonE2");
+  (inp, inp_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g2_in" (llvm_alias "struct.POINTonE2");
   (zwire, zwire_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g2_zwire" (llvm_array 96 (llvm_int 8));
   llvm_precond {{ (zwire@0)@0 }}; // compressed
   llvm_precond {{ aggregate_in_g2_error_precond zwire }};
@@ -71,13 +71,13 @@ let blst_aggregate_in_g2_error_spec = do {
   ret <- llvm_fresh_var "blst_aggregate_in_g2_ret" (llvm_int 32);
   llvm_return (llvm_term ret);
   llvm_postcond {{ ret != `BLST_SUCCESS }};
-  new_out <- llvm_fresh_var "new_out" (llvm_struct "struct.POINTonE2");
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE2");
   llvm_points_to out_ptr (llvm_term new_out);
   llvm_postcond {{ new_out == out }};
 };
 
 let blst_aggregate_in_g2_null_error_spec = do {
-  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g2_out" (llvm_struct "struct.POINTonE2");
+  (out, out_ptr) <- ptr_to_fresh "blst_aggregate_in_g2_out" (llvm_alias "struct.POINTonE2");
   let inp_ptr = llvm_null;
   (zwire, zwire_ptr) <- ptr_to_fresh_readonly "blst_aggregate_in_g2_zwire" (llvm_array 96 (llvm_int 8));
   llvm_precond {{ (zwire@0)@0 }}; // compressed
@@ -86,7 +86,7 @@ let blst_aggregate_in_g2_null_error_spec = do {
   ret <- llvm_fresh_var "blst_aggregate_in_g2_ret" (llvm_int 32);
   llvm_return (llvm_term ret);
   llvm_postcond {{ ret != `BLST_SUCCESS }};
-  new_out <- llvm_fresh_var "new_out" (llvm_struct "struct.POINTonE2");
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE2");
   llvm_points_to out_ptr (llvm_term new_out);
   llvm_postcond {{ new_out == out }};
 };

--- a/proof/api-extra-for-release-2.saw
+++ b/proof/api-extra-for-release-2.saw
@@ -58,16 +58,16 @@ BLS12_381_G2_thms <- for
 let blst_sk_to_pk_in_g1_spec = do {
     let n_bytes = 32;
     let bits = 255;
-    ret_ptr <- crucible_alloc POINTonE1_type;
-    scalar_ptr <- crucible_alloc_readonly_aligned 8 (llvm_array n_bytes (llvm_int 8));
-    scalar <- crucible_fresh_var "scalar" (llvm_array n_bytes (llvm_int 8));
-    crucible_points_to scalar_ptr (crucible_term scalar);
+    ret_ptr <- llvm_alloc POINTonE1_type;
+    scalar_ptr <- llvm_alloc_readonly_aligned 8 (llvm_array n_bytes (llvm_int 8));
+    scalar <- llvm_fresh_var "scalar" (llvm_array n_bytes (llvm_int 8));
+    llvm_points_to scalar_ptr (llvm_term scalar);
     // extra precondition from POINTonE1_mult_w5
-    crucible_precond {{ e1_order BP > scalar_value`{bits,n_bytes} scalar + shift }};
-    crucible_execute_func [ret_ptr, scalar_ptr];
-    ret <- crucible_fresh_var "ret" POINTonE1_type;
-    crucible_points_to ret_ptr (crucible_term ret);
-    crucible_postcond {{ affinify E (POINTonE1_abs ret) ==
+    llvm_precond {{ e1_order BP > scalar_value`{bits,n_bytes} scalar + shift }};
+    llvm_execute_func [ret_ptr, scalar_ptr];
+    ret <- llvm_fresh_var "ret" POINTonE1_type;
+    llvm_points_to ret_ptr (llvm_term ret);
+    llvm_postcond {{ affinify E (POINTonE1_abs ret) ==
                           e1_scalar_mult (scalar_value`{bits,n_bytes} scalar) BP }} ;
     };
 
@@ -84,16 +84,16 @@ blst_sk_to_pk_in_g1_ov <- custom_verify "blst_sk_to_pk_in_g1"
 let blst_sk_to_pk_in_g2_spec = do {
     let n_bytes = 32;
     let bits = 255;
-    ret_ptr <- crucible_alloc POINTonE2_type;
-    scalar_ptr <- crucible_alloc_readonly_aligned 8 (llvm_array n_bytes (llvm_int 8));
-    scalar <- crucible_fresh_var "scalar" (llvm_array n_bytes (llvm_int 8));
-    crucible_points_to scalar_ptr (crucible_term scalar);
+    ret_ptr <- llvm_alloc POINTonE2_type;
+    scalar_ptr <- llvm_alloc_readonly_aligned 8 (llvm_array n_bytes (llvm_int 8));
+    scalar <- llvm_fresh_var "scalar" (llvm_array n_bytes (llvm_int 8));
+    llvm_points_to scalar_ptr (llvm_term scalar);
     // extra precondition from POINTonE2_mult_w5
-    crucible_precond {{ e2_order BP' > scalar_value`{bits,n_bytes} scalar + shift }};
-    crucible_execute_func [ret_ptr, scalar_ptr];
-    ret <- crucible_fresh_var "ret" POINTonE2_type;
-    crucible_points_to ret_ptr (crucible_term ret);
-    crucible_postcond {{ affinify E' (POINTonE2_abs ret) ==
+    llvm_precond {{ e2_order BP' > scalar_value`{bits,n_bytes} scalar + shift }};
+    llvm_execute_func [ret_ptr, scalar_ptr];
+    ret <- llvm_fresh_var "ret" POINTonE2_type;
+    llvm_points_to ret_ptr (llvm_term ret);
+    llvm_postcond {{ affinify E' (POINTonE2_abs ret) ==
                           e2_scalar_mult (scalar_value`{bits,n_bytes} scalar) BP' }} ;
     };
 

--- a/proof/bls_operations/aggregate_verify_a.saw
+++ b/proof/bls_operations/aggregate_verify_a.saw
@@ -54,7 +54,7 @@ all_distinct_3_ov <- admit "all_distinct" (all_distinct_spec 3);
 all_distinct_4_ov <- admit "all_distinct" (all_distinct_spec 4);
 
 let blst_pairing_finalverify_A_spec = do {
-  ctx_ptr <- llvm_alloc_readonly (llvm_struct "struct.blst_pairing_st");
+  ctx_ptr <- llvm_alloc_readonly (llvm_alias "struct.blst_pairing_st");
   GT <- llvm_fresh_var "GT" vec384fp12_type;
   llvm_precond {{ fp12_invariant GT }};
   AggrSign <- llvm_fresh_var "AggrSign" POINTonE1_type;
@@ -76,7 +76,7 @@ let blst_pairing_finalverify_A_spec = do {
 };
 
 let blst_pairing_aggregate_pk_in_g2_null_sig_spec ctx_nelems aggr_gt_set = do {
-  ctx_ptr <- llvm_alloc (llvm_struct "struct.blst_pairing_st");
+  ctx_ptr <- llvm_alloc (llvm_alias "struct.blst_pairing_st");
 
   // ctx->ctrl must have AGGR_HASH_OR_ENCODE set and AGGR_MIN_PK unset, but we
   // leave the rest uninterpreted
@@ -268,7 +268,7 @@ blst_pairing_aggregate_pk_in_g2_null_sig_1_nth_commit_ov <- custom_verify
   prove_blst_pairing_aggregate_pk_in_g2_null_sig;
 
 let blst_pairing_aggregate_pk_in_g2_sig_spec = do {
-  ctx_ptr <- llvm_alloc (llvm_struct "struct.blst_pairing_st");
+  ctx_ptr <- llvm_alloc (llvm_alias "struct.blst_pairing_st");
 
   // ctx->ctrl must have AGGR_HASH_OR_ENCODE set and AGGR_MIN_PK unset, but we
   // leave the rest uninterpreted

--- a/proof/bls_operations/aggregate_verify_a.saw
+++ b/proof/bls_operations/aggregate_verify_a.saw
@@ -59,8 +59,8 @@ let blst_pairing_finalverify_A_spec = do {
   llvm_precond {{ fp12_invariant GT }};
   AggrSign <- llvm_fresh_var "AggrSign" POINTonE1_type;
   llvm_precond {{ POINTonE1_invariant AggrSign }};
-  crucible_precond {{ is_point_projective E (POINTonE1_abs AggrSign) }}; // on the curve
-  crucible_precond {{ ~(Fp.is_equal ((fp_abs (AggrSign.2)), Fp.field_zero)) }};
+  llvm_precond {{ is_point_projective E (POINTonE1_abs AggrSign) }}; // on the curve
+  llvm_precond {{ ~(Fp.is_equal ((fp_abs (AggrSign.2)), Fp.field_zero)) }};
   llvm_points_to (llvm_elem ctx_ptr 0)
                  (llvm_term {{ AGGR_HASH_OR_ENCODE
                             || AGGR_MIN_SIG
@@ -465,13 +465,13 @@ is_point_projective_E_affine_thm <- prove_cryptol (rewrite (cryptol_ss())
 // For vec_is_zero(GT[0][1], sizeof(GT) - sizeof(GT[0][0])) in final verify
 let vec_is_zero_5fp2_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array 5 vec384x_type);
-  crucible_precond {{ (  fp2_invariant a0
+  llvm_precond {{ (  fp2_invariant a0
                       /\ fp2_invariant a1
                       /\ fp2_invariant a2
                       /\ fp2_invariant a3
                       /\ fp2_invariant a4 ) where [a0,a1,a2,a3,a4] = a }};
-  crucible_execute_func [a_ptr, crucible_term {{ (480:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{
+  llvm_execute_func [a_ptr, llvm_term {{ (480:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{
     (if (  (Fp_2.is_equal (fp2_abs a0, Fp_2.field_zero))
         /\ (Fp_2.is_equal (fp2_abs a1, Fp_2.field_zero))
         /\ (Fp_2.is_equal (fp2_abs a2, Fp_2.field_zero))

--- a/proof/bls_operations/aggregate_verify_b.saw
+++ b/proof/bls_operations/aggregate_verify_b.saw
@@ -28,8 +28,8 @@ let blst_pairing_finalverify_B_spec = do {
 
   AggrSign <- llvm_fresh_var "AggrSign" POINTonE2_type;
   llvm_precond {{ POINTonE2_invariant AggrSign }};
-  crucible_precond {{ is_point_projective E' (POINTonE2_abs AggrSign) }}; // on the curve
-  crucible_precond {{ ~(Fp_2.is_equal ((fp2_abs (AggrSign.2)), Fp_2.field_zero)) }};
+  llvm_precond {{ is_point_projective E' (POINTonE2_abs AggrSign) }}; // on the curve
+  llvm_precond {{ ~(Fp_2.is_equal ((fp2_abs (AggrSign.2)), Fp_2.field_zero)) }};
 
   llvm_points_to (llvm_elem ctx_ptr 0)
                  (llvm_term {{ AGGR_HASH_OR_ENCODE

--- a/proof/bls_operations/aggregate_verify_b.saw
+++ b/proof/bls_operations/aggregate_verify_b.saw
@@ -21,7 +21,7 @@ let {{
 }};
 
 let blst_pairing_finalverify_B_spec = do {
-  ctx_ptr <- llvm_alloc_readonly (llvm_struct "struct.blst_pairing_st");
+  ctx_ptr <- llvm_alloc_readonly (llvm_alias "struct.blst_pairing_st");
 
   GT <- llvm_fresh_var "GT" vec384fp12_type;
   llvm_precond {{ fp12_invariant GT }};
@@ -46,7 +46,7 @@ let blst_pairing_finalverify_B_spec = do {
 };
 
 let blst_pairing_aggregate_pk_in_g1_null_sig_spec ctx_nelems aggr_gt_set = do {
-  ctx_ptr <- llvm_alloc (llvm_struct "struct.blst_pairing_st");
+  ctx_ptr <- llvm_alloc (llvm_alias "struct.blst_pairing_st");
 
   // ctx->ctrl must have AGGR_HASH_OR_ENCODE set and AGGR_MIN_SIG unset, but we
   // leave the rest uninterpreted
@@ -224,7 +224,7 @@ blst_pairing_aggregate_pk_in_g1_null_sig_1_nth_commit_ov <- custom_verify
   prove_blst_pairing_aggregate_pk_in_g1_null_sig;
 
 let blst_pairing_aggregate_pk_in_g1_sig_spec = do {
-  ctx_ptr <- llvm_alloc (llvm_struct "struct.blst_pairing_st");
+  ctx_ptr <- llvm_alloc (llvm_alias "struct.blst_pairing_st");
 
   // Set up ctx->ctrl flags
   ctx_ctrl <- llvm_fresh_var "ctx.ctrl" (llvm_int 32);

--- a/proof/bls_operations/basic_verify_b.saw
+++ b/proof/bls_operations/basic_verify_b.saw
@@ -52,9 +52,9 @@ hoist_POINTonE1_affine_abs_thm <- prove_cryptol
 
 let verify_B_sig_preconds sig = do {
   // Uncompression succeeds
-  crucible_precond {{ uncompress_E2_imp sig != nothing }};
+  llvm_precond {{ uncompress_E2_imp sig != nothing }};
   // sig does not have infinity bit set
-  crucible_precond {{ ~((sig@0)@1) }};
+  llvm_precond {{ ~((sig@0)@1) }};
   // Uncompressed sig is not point_O
   llvm_precond {{ ~(is_point_O E' (uncompress_E2_OK sig)) }};
   // Uncompression produces a point on the curve.  This is unnecessary to state

--- a/proof/bls_operations/key_validate_b.saw
+++ b/proof/bls_operations/key_validate_b.saw
@@ -60,7 +60,7 @@ is_point_O_E_affine_rev_thm <- prove_cryptol (rewrite (cryptol_ss())
 
 let demo_KeyValidate_B_spec = do {
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" compressed_E1_rep_type;
-  crucible_precond {{ verify_B_pk_precond inp }};
+  llvm_precond {{ verify_B_pk_precond inp }};
   llvm_execute_func [ in_ptr ];
   llvm_return (llvm_term {{ bool_to_limb (BMPKS::KeyValidate (join inp)) }});
 };

--- a/proof/compress-p1.saw
+++ b/proof/compress-p1.saw
@@ -5,15 +5,15 @@
 
 // fromx_mont_384 converts a vector from the montgomery domain
 let fromx_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- alloc_init_readonly vec384_type (llvm_term {{ vec384_rep (from_Fp `p) }});
 
   llvm_precond {{ fp_invariant a }};
 
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term {{ 0x89f3fffcfffcfffd }}];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term {{ 0x89f3fffcfffcfffd }}];
 
-  crucible_points_to ret_ptr (crucible_term {{ vec384_rep (from_Fp (fp_abs a)) }});
+  llvm_points_to ret_ptr (llvm_term {{ vec384_rep (from_Fp (fp_abs a)) }});
 };
 
 // TODO: prove
@@ -25,15 +25,15 @@ let {{ I2OSP48 = I2OSP`{48, t_Fp} }};
 
 // POINTonE1_affine_Compress_BE compresses X and returns the sign for Y
 let POINTonE1_affine_Compress_BE_spec = do {
-  out_ptr <- crucible_alloc (llvm_array 48 (llvm_int 8));
+  out_ptr <- llvm_alloc (llvm_array 48 (llvm_int 8));
   (inp, inp_ptr) <- ptr_to_fresh_readonly "in" POINTonE1_affine_type;
 
-  crucible_precond {{ POINTonE1_affine_invariant inp }};
+  llvm_precond {{ POINTonE1_affine_invariant inp }};
 
-  crucible_execute_func [out_ptr, inp_ptr];
+  llvm_execute_func [out_ptr, inp_ptr];
 
-  crucible_points_to out_ptr (crucible_term {{ I2OSP48 ((POINTonE1_affine_abs inp ).0) }});
-  crucible_return (crucible_term {{ (zext [sign_F_p (fp_abs inp.1), HE1::sgn0 (fp_abs inp.1)]):[64] }});
+  llvm_points_to out_ptr (llvm_term {{ I2OSP48 ((POINTonE1_affine_abs inp ).0) }});
+  llvm_return (llvm_term {{ (zext [sign_F_p (fp_abs inp.1), HE1::sgn0 (fp_abs inp.1)]):[64] }});
 };
 
 POINTonE1_affine_Compress_BE_ov <- custom_verify "POINTonE1_affine_Compress_BE"
@@ -43,40 +43,40 @@ POINTonE1_affine_Compress_BE_ov <- custom_verify "POINTonE1_affine_Compress_BE"
 
 // POINTonE1_from_Jacobian affinifies a projective point
 let POINTonE1_from_Jacobian_spec = do {
-  out_ptr <- crucible_alloc POINTonE1_type;
+  out_ptr <- llvm_alloc POINTonE1_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "in" POINTonE1_type;
 
-  crucible_precond {{ POINTonE1_invariant inp }};
-  crucible_precond {{ is_point_projective E (POINTonE1_abs inp) }}; // on the curve
-  crucible_precond {{ ~(Fp.is_equal ((fp_abs (inp.2)), Fp.field_zero)) }};
+  llvm_precond {{ POINTonE1_invariant inp }};
+  llvm_precond {{ is_point_projective E (POINTonE1_abs inp) }}; // on the curve
+  llvm_precond {{ ~(Fp.is_equal ((fp_abs (inp.2)), Fp.field_zero)) }};
 
-  crucible_execute_func [out_ptr, inp_ptr];
+  llvm_execute_func [out_ptr, inp_ptr];
 
   let out = {{ POINTonE1_affine_rep (affinify E (POINTonE1_abs inp)) }};
-  crucible_postcond {{ POINTonE1_affine_invariant out }};
+  llvm_postcond {{ POINTonE1_affine_invariant out }};
 
   // Use points_to_untyped because out_ptr is a POINTonE1 that the caller
   // immediately casts to a POINTonE1_affine.  Therefore, we can treat out_ptr
   // as a POINTonE1_affine and ignore Z.
-  crucible_points_to_untyped out_ptr (crucible_term out);
+  llvm_points_to_untyped out_ptr (llvm_term out);
 };
 
 let POINTonE1_from_Jacobian_alias_spec = do {
   (inp, inp_ptr) <- ptr_to_fresh "in" POINTonE1_type;
 
-  crucible_precond {{ POINTonE1_invariant inp }};
-  crucible_precond {{ is_point_projective E (POINTonE1_abs inp) }}; // on the curve
-  crucible_precond {{ ~(Fp.is_equal ((fp_abs (inp.2)), Fp.field_zero)) }};
+  llvm_precond {{ POINTonE1_invariant inp }};
+  llvm_precond {{ is_point_projective E (POINTonE1_abs inp) }}; // on the curve
+  llvm_precond {{ ~(Fp.is_equal ((fp_abs (inp.2)), Fp.field_zero)) }};
 
-  crucible_execute_func [inp_ptr, inp_ptr];
+  llvm_execute_func [inp_ptr, inp_ptr];
 
   let out = {{ POINTonE1_affine_rep (affinify E (POINTonE1_abs inp)) }};
-  crucible_postcond {{ POINTonE1_affine_invariant out }};
+  llvm_postcond {{ POINTonE1_affine_invariant out }};
 
   // Use points_to_untyped because out_ptr is a POINTonE1 that the caller
   // immediately casts to a POINTonE1_affine.  Therefore, we can treat out_ptr
   // as a POINTonE1_affine and ignore Z.
-  crucible_points_to_untyped inp_ptr (crucible_term out);
+  llvm_points_to_untyped inp_ptr (llvm_term out);
 };
 
 // commute mul once -- use with caution!
@@ -105,35 +105,35 @@ POINTonE1_from_Jacobian_alias_ov <- custom_verify "POINTonE1_from_Jacobian"
 // POINTonE1_Compress_BE compresses X and returns the sign of Y.  It supports
 // both affine points (indicated by Z == 1) and projective points (Z != 1).
 let POINTonE1_Compress_BE_spec is_point_affine = do {
-  out_ptr <- crucible_alloc (llvm_array 48 (llvm_int 8));
+  out_ptr <- llvm_alloc (llvm_array 48 (llvm_int 8));
   (inp, inp_ptr) <- ptr_to_fresh_readonly "in" POINTonE1_type;
 
-  crucible_precond {{ POINTonE1_invariant inp }};
+  llvm_precond {{ POINTonE1_invariant inp }};
   if is_point_affine then do {
     // Point is affine, so Z must be 1
-    crucible_precond {{ (fp_abs (inp.2)) == Fp.field_unit }};
+    llvm_precond {{ (fp_abs (inp.2)) == Fp.field_unit }};
   } else do {
     // Point is projective, so Z must not be 1
-    crucible_precond {{ (fp_abs (inp.2)) != Fp.field_unit }};
-  crucible_precond {{ ~(Fp.is_equal ((fp_abs (inp.2)), Fp.field_zero)) }};
-    crucible_precond {{ is_point_projective E (POINTonE1_abs inp) }}; // on the curve
+    llvm_precond {{ (fp_abs (inp.2)) != Fp.field_unit }};
+  llvm_precond {{ ~(Fp.is_equal ((fp_abs (inp.2)), Fp.field_zero)) }};
+    llvm_precond {{ is_point_projective E (POINTonE1_abs inp) }}; // on the curve
   };
 
-  crucible_execute_func [out_ptr, inp_ptr];
+  llvm_execute_func [out_ptr, inp_ptr];
 
   if is_point_affine then do {
-    crucible_points_to out_ptr (crucible_term {{ I2OSP48 (fp_abs inp.0) }});
-    crucible_return (crucible_term {{ (zext [sign_F_p (fp_abs inp.1), HE1::sgn0 (fp_abs inp.1)]):[64] }});
+    llvm_points_to out_ptr (llvm_term {{ I2OSP48 (fp_abs inp.0) }});
+    llvm_return (llvm_term {{ (zext [sign_F_p (fp_abs inp.1), HE1::sgn0 (fp_abs inp.1)]):[64] }});
   } else do {
     // Point is not already in affine coordinates, so must affinify first
     let affinified = {{ affinify E (POINTonE1_abs inp) }};
-    crucible_points_to out_ptr (crucible_term {{ I2OSP48 (affinified.0) }});
+    llvm_points_to out_ptr (llvm_term {{ I2OSP48 (affinified.0) }});
 
     // SAW struggles to reason about `sgn0 (affinified.1)`, but we don't
     // need it anyway so this spec only specifies the sign_F_p bit.
-    ret <- crucible_fresh_var "ret" limb_type;
-    crucible_postcond {{ (ret!1) == (sign_F_p affinified.1) }};
-    crucible_return (crucible_term ret);
+    ret <- llvm_fresh_var "ret" limb_type;
+    llvm_postcond {{ (ret!1) == (sign_F_p affinified.1) }};
+    llvm_return (llvm_term ret);
   };
 };
 
@@ -158,29 +158,29 @@ POINTonE1_Compress_BE_affine_ov <- custom_verify "POINTonE1_Compress_BE"
 
 
 let blst_p1_compress_spec is_point_affine = do {
-  out_ptr <- crucible_alloc (llvm_array 48 (llvm_int 8));
+  out_ptr <- llvm_alloc (llvm_array 48 (llvm_int 8));
   (inp, inp_ptr) <- ptr_to_fresh_readonly "in" POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant inp }};
+  llvm_precond {{ POINTonE1_invariant inp }};
 
   if is_point_affine then do {
     // Point is affine, so Z must be 1
-    crucible_precond {{ (fp_abs (inp.2)) == Fp.field_unit }};
+    llvm_precond {{ (fp_abs (inp.2)) == Fp.field_unit }};
 
     // Have the "Z=0 <=> infinity" issue again; see the notes in `map_to_g1.saw`.
     // So, passing in a value (0,0,1) would give a result not agreeing with
     // the specification.
-    crucible_precond {{ ~(is_point_O E (fp_abs inp.0, fp_abs inp.1)) }};
+    llvm_precond {{ ~(is_point_O E (fp_abs inp.0, fp_abs inp.1)) }};
   } else do {
     // Point is projective, so Z must not be 1
-    crucible_precond {{ (fp_abs (inp.2)) != Fp.field_unit }};
-    crucible_precond {{ is_point_projective E (POINTonE1_abs inp) }}; // on the curve
+    llvm_precond {{ (fp_abs (inp.2)) != Fp.field_unit }};
+    llvm_precond {{ is_point_projective E (POINTonE1_abs inp) }}; // on the curve
   };
 
-  crucible_execute_func [out_ptr, inp_ptr];
+  llvm_execute_func [out_ptr, inp_ptr];
   if is_point_affine then do {
-    crucible_points_to out_ptr (crucible_term {{ serialize_E1 (fp_abs inp.0, fp_abs inp.1) }});
+    llvm_points_to out_ptr (llvm_term {{ serialize_E1 (fp_abs inp.0, fp_abs inp.1) }});
   } else do {
-    crucible_points_to out_ptr (crucible_term {{ serialize_E1 (affinify E (POINTonE1_abs inp)) }});
+    llvm_points_to out_ptr (llvm_term {{ serialize_E1 (affinify E (POINTonE1_abs inp)) }});
   };
 };
 

--- a/proof/compress-p2.saw
+++ b/proof/compress-p2.saw
@@ -5,18 +5,18 @@
 
 // POINTonE2_affine_Compress_BE compresses X and returns the sign for Y
 let POINTonE2_affine_Compress_BE_spec = do {
-  out_ptr <- crucible_alloc (llvm_array 96 (llvm_int 8));
+  out_ptr <- llvm_alloc (llvm_array 96 (llvm_int 8));
   (inp, inp_ptr) <- ptr_to_fresh_readonly "in" POINTonE2_affine_type;
 
-  crucible_precond {{ POINTonE2_affine_invariant inp }};
+  llvm_precond {{ POINTonE2_affine_invariant inp }};
 
-  crucible_execute_func [out_ptr, inp_ptr];
+  llvm_execute_func [out_ptr, inp_ptr];
 
   let x = {{ (POINTonE2_affine_abs inp).0 }};
 
-  crucible_points_to out_ptr (crucible_term {{ (I2OSP48 (x@0)) # (I2OSP48 (x@1)) }});
+  llvm_points_to out_ptr (llvm_term {{ (I2OSP48 (x@0)) # (I2OSP48 (x@1)) }});
 
-  crucible_return (crucible_term {{ (zext [sign_F_p_2 (fp2_abs inp.1), HE2::sgn0 (fp2_abs inp.1)]):[64] }});
+  llvm_return (llvm_term {{ (zext [sign_F_p_2 (fp2_abs inp.1), HE2::sgn0 (fp2_abs inp.1)]):[64] }});
 };
 
 POINTonE2_affine_Compress_BE_ov <- verify "POINTonE2_affine_Compress_BE"
@@ -25,40 +25,40 @@ POINTonE2_affine_Compress_BE_ov <- verify "POINTonE2_affine_Compress_BE"
 
 // POINTonE2_from_Jacobian affinifies a projective point
 let POINTonE2_from_Jacobian_spec = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "in" POINTonE2_type;
 
-  crucible_precond {{ POINTonE2_invariant inp }};
-  crucible_precond {{ is_point_projective E' (POINTonE2_abs inp) }}; // on the curve
-  crucible_precond {{ ~(Fp_2.is_equal ((fp2_abs (inp.2)), Fp_2.field_zero)) }};
+  llvm_precond {{ POINTonE2_invariant inp }};
+  llvm_precond {{ is_point_projective E' (POINTonE2_abs inp) }}; // on the curve
+  llvm_precond {{ ~(Fp_2.is_equal ((fp2_abs (inp.2)), Fp_2.field_zero)) }};
 
-  crucible_execute_func [out_ptr, inp_ptr];
+  llvm_execute_func [out_ptr, inp_ptr];
 
   let out = {{ POINTonE2_affine_rep (affinify E' (POINTonE2_abs inp)) }};
-  crucible_postcond {{ POINTonE2_affine_invariant out }};
+  llvm_postcond {{ POINTonE2_affine_invariant out }};
 
   // Use points_to_untyped because out_ptr is a POINTonE2 that the caller
   // immediately casts to a POINTonE2_affine.  Therefore, we can treat out_ptr
   // as a POINTonE2_affine and ignore Z.
-  crucible_points_to_untyped out_ptr (crucible_term out);
+  llvm_points_to_untyped out_ptr (llvm_term out);
 };
 
 let POINTonE2_from_Jacobian_alias_spec = do {
   (out, out_ptr) <- ptr_to_fresh "out" POINTonE2_type;
 
-  crucible_precond {{ POINTonE2_invariant out }};
-  crucible_precond {{ is_point_projective E' (POINTonE2_abs out) }}; // on the curve
-  crucible_precond {{ ~(Fp_2.is_equal ((fp2_abs (out.2)), Fp_2.field_zero)) }};
+  llvm_precond {{ POINTonE2_invariant out }};
+  llvm_precond {{ is_point_projective E' (POINTonE2_abs out) }}; // on the curve
+  llvm_precond {{ ~(Fp_2.is_equal ((fp2_abs (out.2)), Fp_2.field_zero)) }};
 
-  crucible_execute_func [out_ptr, out_ptr];
+  llvm_execute_func [out_ptr, out_ptr];
 
   let new_out = {{ POINTonE2_affine_rep (affinify E' (POINTonE2_abs out)) }};
-  crucible_postcond {{ POINTonE2_affine_invariant new_out }};
+  llvm_postcond {{ POINTonE2_affine_invariant new_out }};
 
   // Use points_to_untyped because out_ptr is a POINTonE2 that the caller
   // immediately casts to a POINTonE2_affine.  Therefore, we can treat out_ptr
   // as a POINTonE2_affine and ignore Z.
-  crucible_points_to_untyped out_ptr (crucible_term new_out);
+  llvm_points_to_untyped out_ptr (llvm_term new_out);
 };
 
 // commute mul once -- use with caution!
@@ -87,37 +87,37 @@ POINTonE2_from_Jacobian_alias_ov <- custom_verify "POINTonE2_from_Jacobian"
 // POINTonE2_Compress_BE compresses X and returns the sign of Y.  It supports
 // both affine points (indicated by Z == 1) and projective points (Z != 1).
 let POINTonE2_Compress_BE_spec is_point_affine = do {
-  out_ptr <- crucible_alloc (llvm_array 96 (llvm_int 8));
+  out_ptr <- llvm_alloc (llvm_array 96 (llvm_int 8));
   (inp, inp_ptr) <- ptr_to_fresh_readonly "in" POINTonE2_type;
 
-  crucible_precond {{ POINTonE2_invariant inp }};
+  llvm_precond {{ POINTonE2_invariant inp }};
   if is_point_affine then do {
     // Point is affine, so Z must be 1
-    crucible_precond {{ (fp2_abs (inp.2)) == Fp_2.field_unit }};
+    llvm_precond {{ (fp2_abs (inp.2)) == Fp_2.field_unit }};
   } else do {
     // Point is projective, so Z must not be 1
-    crucible_precond {{ (fp2_abs (inp.2)) != Fp_2.field_unit }};
-    crucible_precond {{ ~(Fp_2.is_equal ((fp2_abs (inp.2)), Fp_2.field_zero)) }};
-    crucible_precond {{ is_point_projective E' (POINTonE2_abs inp) }}; // on the curve
+    llvm_precond {{ (fp2_abs (inp.2)) != Fp_2.field_unit }};
+    llvm_precond {{ ~(Fp_2.is_equal ((fp2_abs (inp.2)), Fp_2.field_zero)) }};
+    llvm_precond {{ is_point_projective E' (POINTonE2_abs inp) }}; // on the curve
   };
 
-  crucible_execute_func [out_ptr, inp_ptr];
+  llvm_execute_func [out_ptr, inp_ptr];
 
   if is_point_affine then do {
     let x = {{ fp2_abs (inp.0) }};
-    crucible_points_to out_ptr (crucible_term {{ I2OSP48 (x@0) # I2OSP48 (x@1) }});
-    crucible_return (crucible_term {{ (zext [sign_F_p_2 (fp2_abs inp.1), HE2::sgn0 (fp2_abs inp.1)]):[64] }});
+    llvm_points_to out_ptr (llvm_term {{ I2OSP48 (x@0) # I2OSP48 (x@1) }});
+    llvm_return (llvm_term {{ (zext [sign_F_p_2 (fp2_abs inp.1), HE2::sgn0 (fp2_abs inp.1)]):[64] }});
   } else do {
     // Point is not already in affine coordinates, so must affinify first
     let affinified = {{ affinify E' (POINTonE2_abs inp) }};
     let x = {{ affinified.0 }};
-    crucible_points_to out_ptr (crucible_term {{ I2OSP48 (x@0) # I2OSP48 (x@1) }});
+    llvm_points_to out_ptr (llvm_term {{ I2OSP48 (x@0) # I2OSP48 (x@1) }});
 
     // SAW struggles to reason about `sgn0 (affinified.1)`, but we don't
     // need it anyway so this spec only specifies the sign_F_p_2 bit.
-    ret <- crucible_fresh_var "ret" limb_type;
-    crucible_postcond {{ (ret!1) == (sign_F_p_2 affinified.1) }};
-    crucible_return (crucible_term ret);
+    ret <- llvm_fresh_var "ret" limb_type;
+    llvm_postcond {{ (ret!1) == (sign_F_p_2 affinified.1) }};
+    llvm_return (llvm_term ret);
   };
 };
 
@@ -180,29 +180,29 @@ POINTonE2_Compress_BE_affine_ov <- custom_verify "POINTonE2_Compress_BE"
   };
 
 let blst_p2_compress_spec is_point_affine = do {
-  out_ptr <- crucible_alloc (llvm_array 96 (llvm_int 8));
+  out_ptr <- llvm_alloc (llvm_array 96 (llvm_int 8));
   (inp, inp_ptr) <- ptr_to_fresh_readonly "in" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant inp }};
+  llvm_precond {{ POINTonE2_invariant inp }};
 
   if is_point_affine then do {
     // Point is affine, so Z must be 1
-    crucible_precond {{ (fp2_abs (inp.2)) == Fp_2.field_unit }};
+    llvm_precond {{ (fp2_abs (inp.2)) == Fp_2.field_unit }};
 
     // Have the "Z=0 <=> infinity" issue again; see the notes in `map_to_g1.saw`.
     // So, passing in a value (0,0,1) would give a result not agreeing with
     // the specification.
-    crucible_precond {{ ~(is_point_O E' (fp2_abs inp.0, fp2_abs inp.1)) }};
+    llvm_precond {{ ~(is_point_O E' (fp2_abs inp.0, fp2_abs inp.1)) }};
   } else do {
     // Point is projective, so Z must not be 1
-    crucible_precond {{ (fp2_abs (inp.2)) != Fp_2.field_unit }};
-    crucible_precond {{ is_point_projective E' (POINTonE2_abs inp) }}; // on the curve
+    llvm_precond {{ (fp2_abs (inp.2)) != Fp_2.field_unit }};
+    llvm_precond {{ is_point_projective E' (POINTonE2_abs inp) }}; // on the curve
   };
 
-  crucible_execute_func [out_ptr, inp_ptr];
+  llvm_execute_func [out_ptr, inp_ptr];
   if is_point_affine then do {
-    crucible_points_to out_ptr (crucible_term {{ serialize_E2 (fp2_abs inp.0, fp2_abs inp.1) }});
+    llvm_points_to out_ptr (llvm_term {{ serialize_E2 (fp2_abs inp.0, fp2_abs inp.1) }});
   } else do {
-    crucible_points_to out_ptr (crucible_term {{ serialize_E2 (affinify E' (POINTonE2_abs inp)) }});
+    llvm_points_to out_ptr (llvm_term {{ serialize_E2 (affinify E' (POINTonE2_abs inp)) }});
   };
 };
 

--- a/proof/core_verify.saw
+++ b/proof/core_verify.saw
@@ -8,175 +8,175 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 let map_to_g2_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   (_, u_ptr) <- ptr_to_fresh_readonly "u" vec384x_type;
   (_, v_ptr) <- ptr_to_fresh_readonly "v" vec384x_type;
-  crucible_execute_func [out_ptr, u_ptr, v_ptr];
-  new_map_to_g2_out <- crucible_fresh_var "new_map_to_g2_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_map_to_g2_out);
+  llvm_execute_func [out_ptr, u_ptr, v_ptr];
+  new_map_to_g2_out <- llvm_fresh_var "new_map_to_g2_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_map_to_g2_out);
 };
 
 let map_to_g2_v_null_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   (_, u_ptr) <- ptr_to_fresh_readonly "u" vec384x_type;
-  crucible_execute_func [out_ptr, u_ptr, crucible_null];
-  new_map_to_g2_out <- crucible_fresh_var "new_map_to_g2_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_map_to_g2_out);
+  llvm_execute_func [out_ptr, u_ptr, llvm_null];
+  new_map_to_g2_out <- llvm_fresh_var "new_map_to_g2_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_map_to_g2_out);
 };
 
 let map_to_g1_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, u_ptr) <- ptr_to_fresh_readonly "u" vec384_type;
   (_, v_ptr) <- ptr_to_fresh_readonly "v" vec384_type;
-  crucible_execute_func [out_ptr, u_ptr, v_ptr];
-  new_map_to_g1_out <- crucible_fresh_var "new_map_to_g1_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_map_to_g1_out);
+  llvm_execute_func [out_ptr, u_ptr, v_ptr];
+  new_map_to_g1_out <- llvm_fresh_var "new_map_to_g1_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_map_to_g1_out);
 };
 
 let map_to_g1_v_null_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, u_ptr) <- ptr_to_fresh_readonly "u" vec384_type;
-  crucible_execute_func [out_ptr, u_ptr, crucible_null];
-  new_map_to_g1_out <- crucible_fresh_var "new_map_to_g1_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_map_to_g1_out);
+  llvm_execute_func [out_ptr, u_ptr, llvm_null];
+  new_map_to_g1_out <- llvm_fresh_var "new_map_to_g1_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_map_to_g1_out);
 };
 
 let miller_loop_n_spec n = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, Q_ptr) <- ptr_to_fresh_readonly "Q" (llvm_array n (llvm_alias "struct.POINTonE2_affine"));
   (_, P_ptr) <- ptr_to_fresh_readonly "P" (llvm_array n (llvm_alias "struct.POINTonE1_affine"));
-  crucible_execute_func [ret_ptr, Q_ptr, P_ptr, crucible_term {{ `n:[64] }}];
-  new_miller_loop_n_ret <- crucible_fresh_var "new_miller_loop_n_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_miller_loop_n_ret);
+  llvm_execute_func [ret_ptr, Q_ptr, P_ptr, llvm_term {{ `n:[64] }}];
+  new_miller_loop_n_ret <- llvm_fresh_var "new_miller_loop_n_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_miller_loop_n_ret);
 };
 
 let miller_loop_n_alias_spec n = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, Q_ptr) <- ptr_to_fresh_readonly "Q" (llvm_array n (llvm_alias "struct.POINTonE2_affine"));
   (_, P_ptr) <- ptr_to_fresh_readonly "P" (llvm_array n (llvm_alias "struct.POINTonE1_affine"));
-  crucible_execute_func [ret_ptr, Q_ptr, P_ptr, crucible_term {{ `n:[64] }}];
-  new_miller_loop_n_ret <- crucible_fresh_var "new_miller_loop_n_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_miller_loop_n_ret);
+  llvm_execute_func [ret_ptr, Q_ptr, P_ptr, llvm_term {{ `n:[64] }}];
+  new_miller_loop_n_ret <- llvm_fresh_var "new_miller_loop_n_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_miller_loop_n_ret);
 };
 
 
 let start_dbl_n_spec n = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   //(_, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
-  //T_ptr <- crucible_alloc (llvm_array n (llvm_alias "struct.POINTonE2"));
+  //T_ptr <- llvm_alloc (llvm_array n (llvm_alias "struct.POINTonE2"));
   (_, T_ptr) <- ptr_to_fresh "T" (llvm_array n (llvm_alias "struct.POINTonE2"));
   (_, Px2_ptr) <- ptr_to_fresh_readonly "Px2" (llvm_array n (llvm_alias "struct.POINTonE1_affine"));
-  crucible_execute_func [ret_ptr, T_ptr, Px2_ptr, crucible_term {{ `n:[64] }}];
-  new_start_dbl_n_ret <- crucible_fresh_var "new_start_dbl_n_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_start_dbl_n_ret);
-  new_start_dbl_n_T <- crucible_fresh_var "new_start_dbl_n_T" (llvm_array n (llvm_alias "struct.POINTonE2"));
-  crucible_points_to T_ptr (crucible_term new_start_dbl_n_T);
+  llvm_execute_func [ret_ptr, T_ptr, Px2_ptr, llvm_term {{ `n:[64] }}];
+  new_start_dbl_n_ret <- llvm_fresh_var "new_start_dbl_n_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_start_dbl_n_ret);
+  new_start_dbl_n_T <- llvm_fresh_var "new_start_dbl_n_T" (llvm_array n (llvm_alias "struct.POINTonE2"));
+  llvm_points_to T_ptr (llvm_term new_start_dbl_n_T);
 };
 
 let add_n_dbl_n_spec n k = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
-  //T_ptr <- crucible_alloc (llvm_array n (llvm_alias "struct.POINTonE2"));
+  //T_ptr <- llvm_alloc (llvm_array n (llvm_alias "struct.POINTonE2"));
   (_, T_ptr) <- ptr_to_fresh "T" (llvm_array n (llvm_alias "struct.POINTonE2"));
   (_, Q_ptr) <- ptr_to_fresh_readonly "Q" (llvm_array n (llvm_alias "struct.POINTonE2_affine"));
   (_, Px2_ptr) <- ptr_to_fresh_readonly "Px2" (llvm_array n (llvm_alias "struct.POINTonE1_affine"));
-  crucible_execute_func [ret_ptr, T_ptr, Q_ptr, Px2_ptr, crucible_term {{ `n:[64] }}, crucible_term {{ `k:[64] }}];
-  new_add_n_dbl_n_ret <- crucible_fresh_var "new_add_n_dbl_n_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_add_n_dbl_n_ret);
-  new_add_n_dbl_n_T <- crucible_fresh_var "new_add_n_dbl_n_T" (llvm_array n (llvm_alias "struct.POINTonE2"));
-  crucible_points_to T_ptr (crucible_term new_add_n_dbl_n_T);
+  llvm_execute_func [ret_ptr, T_ptr, Q_ptr, Px2_ptr, llvm_term {{ `n:[64] }}, llvm_term {{ `k:[64] }}];
+  new_add_n_dbl_n_ret <- llvm_fresh_var "new_add_n_dbl_n_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_add_n_dbl_n_ret);
+  new_add_n_dbl_n_T <- llvm_fresh_var "new_add_n_dbl_n_T" (llvm_array n (llvm_alias "struct.POINTonE2"));
+  llvm_points_to T_ptr (llvm_term new_add_n_dbl_n_T);
 };
 
 let final_exp_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, f_ptr) <- ptr_to_fresh_readonly "f" vec384fp12_type;
-  crucible_execute_func [ret_ptr, f_ptr];
-  new_ret <- crucible_fresh_var "new_final_exp_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, f_ptr];
+  new_ret <- llvm_fresh_var "new_final_exp_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let final_exp_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "f" vec384fp12_type;
-  crucible_execute_func [ret_ptr, ret_ptr];
-  new_ret <- crucible_fresh_var "new_final_exp_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr];
+  new_ret <- llvm_fresh_var "new_final_exp_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let mul_n_sqr_spec n = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{`n:[64]}}];
-  new_ret <- crucible_fresh_var "new_mul_n_sqr_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term {{`n:[64]}}];
+  new_ret <- llvm_fresh_var "new_mul_n_sqr_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let line_dbl_spec = do {
-  line_ptr <- crucible_alloc vec384fp6_type;
+  line_ptr <- llvm_alloc vec384fp6_type;
   (_, T_ptr) <- ptr_to_fresh "line_dbl_T" (llvm_alias "struct.POINTonE2");
   (_, Q_ptr) <- ptr_to_fresh_readonly "line_dbl_Q" (llvm_alias "struct.POINTonE2");
-  crucible_execute_func [line_ptr, T_ptr, Q_ptr];
-  new_T <- crucible_fresh_var "new_line_dbl_T" (llvm_alias "struct.POINTonE2");
-  crucible_points_to T_ptr (crucible_term new_T);
-  new_line <- crucible_fresh_var "new_line_dbl_line" vec384fp6_type;
-  crucible_points_to line_ptr (crucible_term new_line);
+  llvm_execute_func [line_ptr, T_ptr, Q_ptr];
+  new_T <- llvm_fresh_var "new_line_dbl_T" (llvm_alias "struct.POINTonE2");
+  llvm_points_to T_ptr (llvm_term new_T);
+  new_line <- llvm_fresh_var "new_line_dbl_line" vec384fp6_type;
+  llvm_points_to line_ptr (llvm_term new_line);
 };
 
 let line_dbl_alias_spec = do {
-  line_ptr <- crucible_alloc vec384fp6_type;
+  line_ptr <- llvm_alloc vec384fp6_type;
   (_, T_ptr) <- ptr_to_fresh "line_dbl_T" (llvm_alias "struct.POINTonE2");
-  crucible_execute_func [line_ptr, T_ptr, T_ptr];
-  new_T <- crucible_fresh_var "new_line_dbl_T" (llvm_alias "struct.POINTonE2");
-  crucible_points_to T_ptr (crucible_term new_T);
-  new_line <- crucible_fresh_var "new_line_dbl_line" vec384fp6_type;
-  crucible_points_to line_ptr (crucible_term new_line);
+  llvm_execute_func [line_ptr, T_ptr, T_ptr];
+  new_T <- llvm_fresh_var "new_line_dbl_T" (llvm_alias "struct.POINTonE2");
+  llvm_points_to T_ptr (llvm_term new_T);
+  new_line <- llvm_fresh_var "new_line_dbl_line" vec384fp6_type;
+  llvm_points_to line_ptr (llvm_term new_line);
 };
 
 let line_add_spec = do {
-  line_ptr <- crucible_alloc vec384fp6_type;
+  line_ptr <- llvm_alloc vec384fp6_type;
   (_, T_ptr) <- ptr_to_fresh "line_add_T" (llvm_alias "struct.POINTonE2");
   (_, R_ptr) <- ptr_to_fresh_readonly "line_add_R" (llvm_alias "struct.POINTonE2");
   (_, Q_ptr) <- ptr_to_fresh_readonly "line_add_Q" (llvm_alias "struct.POINTonE2_affine");
-  crucible_execute_func [line_ptr, T_ptr, R_ptr, Q_ptr];
-  new_T <- crucible_fresh_var "new_line_add_T" (llvm_alias "struct.POINTonE2");
-  crucible_points_to T_ptr (crucible_term new_T);
-  new_line <- crucible_fresh_var "new_line_add_line" vec384fp6_type;
-  crucible_points_to line_ptr (crucible_term new_line);
+  llvm_execute_func [line_ptr, T_ptr, R_ptr, Q_ptr];
+  new_T <- llvm_fresh_var "new_line_add_T" (llvm_alias "struct.POINTonE2");
+  llvm_points_to T_ptr (llvm_term new_T);
+  new_line <- llvm_fresh_var "new_line_add_line" vec384fp6_type;
+  llvm_points_to line_ptr (llvm_term new_line);
 };
 
 let line_add_alias_spec = do {
-  line_ptr <- crucible_alloc vec384fp6_type;
+  line_ptr <- llvm_alloc vec384fp6_type;
   (_, T_ptr) <- ptr_to_fresh "line_add_T" (llvm_alias "struct.POINTonE2");
   (_, Q_ptr) <- ptr_to_fresh_readonly "line_add_Q" (llvm_alias "struct.POINTonE2_affine");
-  crucible_execute_func [line_ptr, T_ptr, T_ptr, Q_ptr];
-  new_T <- crucible_fresh_var "new_line_add_T" (llvm_alias "struct.POINTonE2");
-  crucible_points_to T_ptr (crucible_term new_T);
-  new_line <- crucible_fresh_var "new_line_add_line" vec384fp6_type;
-  crucible_points_to line_ptr (crucible_term new_line);
+  llvm_execute_func [line_ptr, T_ptr, T_ptr, Q_ptr];
+  new_T <- llvm_fresh_var "new_line_add_T" (llvm_alias "struct.POINTonE2");
+  llvm_points_to T_ptr (llvm_term new_T);
+  new_line <- llvm_fresh_var "new_line_add_line" vec384fp6_type;
+  llvm_points_to line_ptr (llvm_term new_line);
 };
 
 let blst_core_verify_pk_in_g1_spec aug_len msg_len DST_len = do {
   (_, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE1_affine");
   (_, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE2_affine");
-  hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
+  hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);
   (_, sk_ptr) <- ptr_to_fresh_readonly "SK" pow256_type;
   (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));
   (_, dst_ptr) <- ptr_to_fresh_readonly "DST" (llvm_array DST_len (llvm_int 8));
   (_, aug_ptr) <- ptr_to_fresh_readonly "aug" (llvm_array aug_len (llvm_int 8));
-  crucible_execute_func [pk_ptr, signature_ptr, crucible_term hash_or_encode, msg_ptr, crucible_term {{ `msg_len : [64] }}, dst_ptr, crucible_term {{ `DST_len : [64] }}, aug_ptr, crucible_term {{ `aug_len : [64] }}];
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_return (crucible_term ret);
+  llvm_execute_func [pk_ptr, signature_ptr, llvm_term hash_or_encode, msg_ptr, llvm_term {{ `msg_len : [64] }}, dst_ptr, llvm_term {{ `DST_len : [64] }}, aug_ptr, llvm_term {{ `aug_len : [64] }}];
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_return (llvm_term ret);
 };
 
 let blst_core_verify_pk_in_g2_spec aug_len msg_len DST_len = do {
   (_, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE2_affine");
   (_, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE1_affine");
-  hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
+  hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);
   (_, sk_ptr) <- ptr_to_fresh_readonly "SK" pow256_type;
   (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));
   (_, dst_ptr) <- ptr_to_fresh_readonly "DST" (llvm_array DST_len (llvm_int 8));
   (_, aug_ptr) <- ptr_to_fresh_readonly "aug" (llvm_array aug_len (llvm_int 8));
-  crucible_execute_func [pk_ptr, signature_ptr, crucible_term hash_or_encode, msg_ptr, crucible_term {{ `msg_len : [64] }}, dst_ptr, crucible_term {{ `DST_len : [64] }}, aug_ptr, crucible_term {{ `aug_len : [64] }}];
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_return (crucible_term ret);
+  llvm_execute_func [pk_ptr, signature_ptr, llvm_term hash_or_encode, msg_ptr, llvm_term {{ `msg_len : [64] }}, dst_ptr, llvm_term {{ `DST_len : [64] }}, aug_ptr, llvm_term {{ `aug_len : [64] }}];
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_return (llvm_term ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/core_verify.saw
+++ b/proof/core_verify.saw
@@ -8,43 +8,43 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 let map_to_g2_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
   (_, u_ptr) <- ptr_to_fresh_readonly "u" vec384x_type;
   (_, v_ptr) <- ptr_to_fresh_readonly "v" vec384x_type;
   crucible_execute_func [out_ptr, u_ptr, v_ptr];
-  new_map_to_g2_out <- crucible_fresh_var "new_map_to_g2_out" (llvm_struct "struct.POINTonE2");
+  new_map_to_g2_out <- crucible_fresh_var "new_map_to_g2_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_map_to_g2_out);
 };
 
 let map_to_g2_v_null_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
   (_, u_ptr) <- ptr_to_fresh_readonly "u" vec384x_type;
   crucible_execute_func [out_ptr, u_ptr, crucible_null];
-  new_map_to_g2_out <- crucible_fresh_var "new_map_to_g2_out" (llvm_struct "struct.POINTonE2");
+  new_map_to_g2_out <- crucible_fresh_var "new_map_to_g2_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_map_to_g2_out);
 };
 
 let map_to_g1_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
   (_, u_ptr) <- ptr_to_fresh_readonly "u" vec384_type;
   (_, v_ptr) <- ptr_to_fresh_readonly "v" vec384_type;
   crucible_execute_func [out_ptr, u_ptr, v_ptr];
-  new_map_to_g1_out <- crucible_fresh_var "new_map_to_g1_out" (llvm_struct "struct.POINTonE1");
+  new_map_to_g1_out <- crucible_fresh_var "new_map_to_g1_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_map_to_g1_out);
 };
 
 let map_to_g1_v_null_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
   (_, u_ptr) <- ptr_to_fresh_readonly "u" vec384_type;
   crucible_execute_func [out_ptr, u_ptr, crucible_null];
-  new_map_to_g1_out <- crucible_fresh_var "new_map_to_g1_out" (llvm_struct "struct.POINTonE1");
+  new_map_to_g1_out <- crucible_fresh_var "new_map_to_g1_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_map_to_g1_out);
 };
 
 let miller_loop_n_spec n = do {
   ret_ptr <- crucible_alloc vec384fp12_type;
-  (_, Q_ptr) <- ptr_to_fresh_readonly "Q" (llvm_array n (llvm_struct "struct.POINTonE2_affine"));
-  (_, P_ptr) <- ptr_to_fresh_readonly "P" (llvm_array n (llvm_struct "struct.POINTonE1_affine"));
+  (_, Q_ptr) <- ptr_to_fresh_readonly "Q" (llvm_array n (llvm_alias "struct.POINTonE2_affine"));
+  (_, P_ptr) <- ptr_to_fresh_readonly "P" (llvm_array n (llvm_alias "struct.POINTonE1_affine"));
   crucible_execute_func [ret_ptr, Q_ptr, P_ptr, crucible_term {{ `n:[64] }}];
   new_miller_loop_n_ret <- crucible_fresh_var "new_miller_loop_n_ret" vec384fp12_type;
   crucible_points_to ret_ptr (crucible_term new_miller_loop_n_ret);
@@ -52,8 +52,8 @@ let miller_loop_n_spec n = do {
 
 let miller_loop_n_alias_spec n = do {
   ret_ptr <- crucible_alloc vec384fp12_type;
-  (_, Q_ptr) <- ptr_to_fresh_readonly "Q" (llvm_array n (llvm_struct "struct.POINTonE2_affine"));
-  (_, P_ptr) <- ptr_to_fresh_readonly "P" (llvm_array n (llvm_struct "struct.POINTonE1_affine"));
+  (_, Q_ptr) <- ptr_to_fresh_readonly "Q" (llvm_array n (llvm_alias "struct.POINTonE2_affine"));
+  (_, P_ptr) <- ptr_to_fresh_readonly "P" (llvm_array n (llvm_alias "struct.POINTonE1_affine"));
   crucible_execute_func [ret_ptr, Q_ptr, P_ptr, crucible_term {{ `n:[64] }}];
   new_miller_loop_n_ret <- crucible_fresh_var "new_miller_loop_n_ret" vec384fp12_type;
   crucible_points_to ret_ptr (crucible_term new_miller_loop_n_ret);
@@ -63,26 +63,26 @@ let miller_loop_n_alias_spec n = do {
 let start_dbl_n_spec n = do {
   ret_ptr <- crucible_alloc vec384fp12_type;
   //(_, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
-  //T_ptr <- crucible_alloc (llvm_array n (llvm_struct "struct.POINTonE2"));
-  (_, T_ptr) <- ptr_to_fresh "T" (llvm_array n (llvm_struct "struct.POINTonE2"));
-  (_, Px2_ptr) <- ptr_to_fresh_readonly "Px2" (llvm_array n (llvm_struct "struct.POINTonE1_affine"));
+  //T_ptr <- crucible_alloc (llvm_array n (llvm_alias "struct.POINTonE2"));
+  (_, T_ptr) <- ptr_to_fresh "T" (llvm_array n (llvm_alias "struct.POINTonE2"));
+  (_, Px2_ptr) <- ptr_to_fresh_readonly "Px2" (llvm_array n (llvm_alias "struct.POINTonE1_affine"));
   crucible_execute_func [ret_ptr, T_ptr, Px2_ptr, crucible_term {{ `n:[64] }}];
   new_start_dbl_n_ret <- crucible_fresh_var "new_start_dbl_n_ret" vec384fp12_type;
   crucible_points_to ret_ptr (crucible_term new_start_dbl_n_ret);
-  new_start_dbl_n_T <- crucible_fresh_var "new_start_dbl_n_T" (llvm_array n (llvm_struct "struct.POINTonE2"));
+  new_start_dbl_n_T <- crucible_fresh_var "new_start_dbl_n_T" (llvm_array n (llvm_alias "struct.POINTonE2"));
   crucible_points_to T_ptr (crucible_term new_start_dbl_n_T);
 };
 
 let add_n_dbl_n_spec n k = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
-  //T_ptr <- crucible_alloc (llvm_array n (llvm_struct "struct.POINTonE2"));
-  (_, T_ptr) <- ptr_to_fresh "T" (llvm_array n (llvm_struct "struct.POINTonE2"));
-  (_, Q_ptr) <- ptr_to_fresh_readonly "Q" (llvm_array n (llvm_struct "struct.POINTonE2_affine"));
-  (_, Px2_ptr) <- ptr_to_fresh_readonly "Px2" (llvm_array n (llvm_struct "struct.POINTonE1_affine"));
+  //T_ptr <- crucible_alloc (llvm_array n (llvm_alias "struct.POINTonE2"));
+  (_, T_ptr) <- ptr_to_fresh "T" (llvm_array n (llvm_alias "struct.POINTonE2"));
+  (_, Q_ptr) <- ptr_to_fresh_readonly "Q" (llvm_array n (llvm_alias "struct.POINTonE2_affine"));
+  (_, Px2_ptr) <- ptr_to_fresh_readonly "Px2" (llvm_array n (llvm_alias "struct.POINTonE1_affine"));
   crucible_execute_func [ret_ptr, T_ptr, Q_ptr, Px2_ptr, crucible_term {{ `n:[64] }}, crucible_term {{ `k:[64] }}];
   new_add_n_dbl_n_ret <- crucible_fresh_var "new_add_n_dbl_n_ret" vec384fp12_type;
   crucible_points_to ret_ptr (crucible_term new_add_n_dbl_n_ret);
-  new_add_n_dbl_n_T <- crucible_fresh_var "new_add_n_dbl_n_T" (llvm_array n (llvm_struct "struct.POINTonE2"));
+  new_add_n_dbl_n_T <- crucible_fresh_var "new_add_n_dbl_n_T" (llvm_array n (llvm_alias "struct.POINTonE2"));
   crucible_points_to T_ptr (crucible_term new_add_n_dbl_n_T);
 };
 
@@ -111,10 +111,10 @@ let mul_n_sqr_spec n = do {
 
 let line_dbl_spec = do {
   line_ptr <- crucible_alloc vec384fp6_type;
-  (_, T_ptr) <- ptr_to_fresh "line_dbl_T" (llvm_struct "struct.POINTonE2");
-  (_, Q_ptr) <- ptr_to_fresh_readonly "line_dbl_Q" (llvm_struct "struct.POINTonE2");
+  (_, T_ptr) <- ptr_to_fresh "line_dbl_T" (llvm_alias "struct.POINTonE2");
+  (_, Q_ptr) <- ptr_to_fresh_readonly "line_dbl_Q" (llvm_alias "struct.POINTonE2");
   crucible_execute_func [line_ptr, T_ptr, Q_ptr];
-  new_T <- crucible_fresh_var "new_line_dbl_T" (llvm_struct "struct.POINTonE2");
+  new_T <- crucible_fresh_var "new_line_dbl_T" (llvm_alias "struct.POINTonE2");
   crucible_points_to T_ptr (crucible_term new_T);
   new_line <- crucible_fresh_var "new_line_dbl_line" vec384fp6_type;
   crucible_points_to line_ptr (crucible_term new_line);
@@ -122,9 +122,9 @@ let line_dbl_spec = do {
 
 let line_dbl_alias_spec = do {
   line_ptr <- crucible_alloc vec384fp6_type;
-  (_, T_ptr) <- ptr_to_fresh "line_dbl_T" (llvm_struct "struct.POINTonE2");
+  (_, T_ptr) <- ptr_to_fresh "line_dbl_T" (llvm_alias "struct.POINTonE2");
   crucible_execute_func [line_ptr, T_ptr, T_ptr];
-  new_T <- crucible_fresh_var "new_line_dbl_T" (llvm_struct "struct.POINTonE2");
+  new_T <- crucible_fresh_var "new_line_dbl_T" (llvm_alias "struct.POINTonE2");
   crucible_points_to T_ptr (crucible_term new_T);
   new_line <- crucible_fresh_var "new_line_dbl_line" vec384fp6_type;
   crucible_points_to line_ptr (crucible_term new_line);
@@ -132,11 +132,11 @@ let line_dbl_alias_spec = do {
 
 let line_add_spec = do {
   line_ptr <- crucible_alloc vec384fp6_type;
-  (_, T_ptr) <- ptr_to_fresh "line_add_T" (llvm_struct "struct.POINTonE2");
-  (_, R_ptr) <- ptr_to_fresh_readonly "line_add_R" (llvm_struct "struct.POINTonE2");
-  (_, Q_ptr) <- ptr_to_fresh_readonly "line_add_Q" (llvm_struct "struct.POINTonE2_affine");
+  (_, T_ptr) <- ptr_to_fresh "line_add_T" (llvm_alias "struct.POINTonE2");
+  (_, R_ptr) <- ptr_to_fresh_readonly "line_add_R" (llvm_alias "struct.POINTonE2");
+  (_, Q_ptr) <- ptr_to_fresh_readonly "line_add_Q" (llvm_alias "struct.POINTonE2_affine");
   crucible_execute_func [line_ptr, T_ptr, R_ptr, Q_ptr];
-  new_T <- crucible_fresh_var "new_line_add_T" (llvm_struct "struct.POINTonE2");
+  new_T <- crucible_fresh_var "new_line_add_T" (llvm_alias "struct.POINTonE2");
   crucible_points_to T_ptr (crucible_term new_T);
   new_line <- crucible_fresh_var "new_line_add_line" vec384fp6_type;
   crucible_points_to line_ptr (crucible_term new_line);
@@ -144,18 +144,18 @@ let line_add_spec = do {
 
 let line_add_alias_spec = do {
   line_ptr <- crucible_alloc vec384fp6_type;
-  (_, T_ptr) <- ptr_to_fresh "line_add_T" (llvm_struct "struct.POINTonE2");
-  (_, Q_ptr) <- ptr_to_fresh_readonly "line_add_Q" (llvm_struct "struct.POINTonE2_affine");
+  (_, T_ptr) <- ptr_to_fresh "line_add_T" (llvm_alias "struct.POINTonE2");
+  (_, Q_ptr) <- ptr_to_fresh_readonly "line_add_Q" (llvm_alias "struct.POINTonE2_affine");
   crucible_execute_func [line_ptr, T_ptr, T_ptr, Q_ptr];
-  new_T <- crucible_fresh_var "new_line_add_T" (llvm_struct "struct.POINTonE2");
+  new_T <- crucible_fresh_var "new_line_add_T" (llvm_alias "struct.POINTonE2");
   crucible_points_to T_ptr (crucible_term new_T);
   new_line <- crucible_fresh_var "new_line_add_line" vec384fp6_type;
   crucible_points_to line_ptr (crucible_term new_line);
 };
 
 let blst_core_verify_pk_in_g1_spec aug_len msg_len DST_len = do {
-  (_, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_struct "struct.POINTonE1_affine");
-  (_, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_struct "struct.POINTonE2_affine");
+  (_, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE1_affine");
+  (_, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE2_affine");
   hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
   (_, sk_ptr) <- ptr_to_fresh_readonly "SK" pow256_type;
   (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));
@@ -167,8 +167,8 @@ let blst_core_verify_pk_in_g1_spec aug_len msg_len DST_len = do {
 };
 
 let blst_core_verify_pk_in_g2_spec aug_len msg_len DST_len = do {
-  (_, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_struct "struct.POINTonE2_affine");
-  (_, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_struct "struct.POINTonE1_affine");
+  (_, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE2_affine");
+  (_, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE1_affine");
   hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
   (_, sk_ptr) <- ptr_to_fresh_readonly "SK" pow256_type;
   (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));

--- a/proof/core_verify_pk_in_g1.saw
+++ b/proof/core_verify_pk_in_g1.saw
@@ -27,8 +27,8 @@ let {{
 
 // case in which no argument is null and the error condition is false
 let blst_core_verify_pk_in_g1_non_null_spec msg_len dst_len aug_len = do {
-  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_struct "struct.POINTonE1_affine");
-  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_struct "struct.POINTonE2_affine");
+  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE1_affine");
+  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE2_affine");
   llvm_precond {{ POINTonE1_affine_invariant pk /\ POINTonE2_affine_invariant sig /\ is_point_affine E' (POINTonE2_affine_abs sig) /\ ~blst_core_verify_pk_in_g1_error_precond pk sig}};
   hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);
   llvm_precond {{ hash_or_encode != zero }};
@@ -41,8 +41,8 @@ let blst_core_verify_pk_in_g1_non_null_spec msg_len dst_len aug_len = do {
 
 // same but with NULL aug
 let blst_core_verify_pk_in_g1_null_aug_spec msg_len dst_len = do {
-  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_struct "struct.POINTonE1_affine");
-  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_struct "struct.POINTonE2_affine");
+  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE1_affine");
+  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE2_affine");
   llvm_precond {{ POINTonE1_affine_invariant pk /\ POINTonE2_affine_invariant sig /\ is_point_affine E' (POINTonE2_affine_abs sig) /\ ~blst_core_verify_pk_in_g1_error_precond pk sig}};
   hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);
   llvm_precond {{ hash_or_encode != zero }};
@@ -55,8 +55,8 @@ let blst_core_verify_pk_in_g1_null_aug_spec msg_len dst_len = do {
 
 // error case
 let blst_core_verify_pk_in_g1_error_spec msg_len dst_len aug_len = do {
-  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_struct "struct.POINTonE1_affine");
-  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_struct "struct.POINTonE2_affine");
+  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE1_affine");
+  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE2_affine");
   llvm_precond {{ POINTonE1_affine_invariant pk /\ POINTonE2_affine_invariant sig /\ is_point_affine E' (POINTonE2_affine_abs sig) /\ blst_core_verify_pk_in_g1_error_precond pk sig }};
   hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);
   llvm_precond {{ hash_or_encode != zero }};
@@ -71,7 +71,7 @@ let blst_core_verify_pk_in_g1_error_spec msg_len dst_len aug_len = do {
 
 // sig is null
 let blst_core_verify_pk_in_g1_null_sig_spec msg_len dst_len aug_len = do {
-  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_struct "struct.POINTonE1_affine");
+  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE1_affine");
   let signature_ptr = llvm_null;
   llvm_precond {{ POINTonE1_affine_invariant pk }};
   hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);

--- a/proof/core_verify_pk_in_g2.saw
+++ b/proof/core_verify_pk_in_g2.saw
@@ -17,13 +17,13 @@ let blst_core_verify_pk_in_g2_non_null_spec msg_len dst_len aug_len = do {
   (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE2_affine");
   (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE1_affine");
   llvm_precond {{ POINTonE2_affine_invariant pk /\ POINTonE1_affine_invariant sig /\ is_point_affine E (POINTonE1_affine_abs sig) /\ ~blst_core_verify_pk_in_g2_error_precond pk sig }};
-  hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
+  hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);
   llvm_precond {{ hash_or_encode != zero }};
   (msg, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));
   (dst, dst_ptr) <- ptr_to_fresh_readonly "dst" (llvm_array dst_len (llvm_int 8));
   (aug, aug_ptr) <- ptr_to_fresh_readonly "aug" (llvm_array aug_len (llvm_int 8));
-  crucible_execute_func [pk_ptr, signature_ptr, crucible_term hash_or_encode, msg_ptr, crucible_term {{ `msg_len : [64] }}, dst_ptr, crucible_term {{ `dst_len : [64] }}, aug_ptr, crucible_term {{ `aug_len : [64] }}];
-  crucible_return (crucible_term {{ if core_verify_pk_in_g2_impl (POINTonE2_affine_abs pk) (POINTonE1_affine_abs sig) msg dst aug then (`BLST_SUCCESS:[32]) else `BLST_VERIFY_FAIL }});
+  llvm_execute_func [pk_ptr, signature_ptr, llvm_term hash_or_encode, msg_ptr, llvm_term {{ `msg_len : [64] }}, dst_ptr, llvm_term {{ `dst_len : [64] }}, aug_ptr, llvm_term {{ `aug_len : [64] }}];
+  llvm_return (llvm_term {{ if core_verify_pk_in_g2_impl (POINTonE2_affine_abs pk) (POINTonE1_affine_abs sig) msg dst aug then (`BLST_SUCCESS:[32]) else `BLST_VERIFY_FAIL }});
 };
 
 // same but with NULL aug
@@ -31,13 +31,13 @@ let blst_core_verify_pk_in_g2_null_aug_spec msg_len dst_len = do {
   (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE2_affine");
   (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE1_affine");
   llvm_precond {{ POINTonE2_affine_invariant pk /\ POINTonE1_affine_invariant sig /\ is_point_affine E (POINTonE1_affine_abs sig) /\ ~blst_core_verify_pk_in_g2_error_precond pk sig }};
-  hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
+  hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);
   llvm_precond {{ hash_or_encode != zero }};
   (msg, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));
   (dst, dst_ptr) <- ptr_to_fresh_readonly "dst" (llvm_array dst_len (llvm_int 8));
   let aug_ptr = llvm_null;
-  crucible_execute_func [pk_ptr, signature_ptr, crucible_term hash_or_encode, msg_ptr, crucible_term {{ `msg_len : [64] }}, dst_ptr, crucible_term {{ `dst_len : [64] }}, aug_ptr, crucible_term {{ zero : [64] }}];
-  crucible_return (crucible_term {{ if core_verify_pk_in_g2_impl (POINTonE2_affine_abs pk) (POINTonE1_affine_abs sig) msg dst [] then (`BLST_SUCCESS:[32]) else `BLST_VERIFY_FAIL }});
+  llvm_execute_func [pk_ptr, signature_ptr, llvm_term hash_or_encode, msg_ptr, llvm_term {{ `msg_len : [64] }}, dst_ptr, llvm_term {{ `dst_len : [64] }}, aug_ptr, llvm_term {{ zero : [64] }}];
+  llvm_return (llvm_term {{ if core_verify_pk_in_g2_impl (POINTonE2_affine_abs pk) (POINTonE1_affine_abs sig) msg dst [] then (`BLST_SUCCESS:[32]) else `BLST_VERIFY_FAIL }});
 };
 
 // error case
@@ -45,12 +45,12 @@ let blst_core_verify_pk_in_g2_error_spec msg_len dst_len aug_len = do {
   (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE2_affine");
   (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE1_affine");
   llvm_precond {{ POINTonE2_affine_invariant pk /\ POINTonE1_affine_invariant sig /\ is_point_affine E (POINTonE1_affine_abs sig) /\ blst_core_verify_pk_in_g2_error_precond pk sig }};
-  hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
+  hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);
   llvm_precond {{ hash_or_encode != zero }};
   (msg, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));
   (dst, dst_ptr) <- ptr_to_fresh_readonly "dst" (llvm_array dst_len (llvm_int 8));
   (aug, aug_ptr) <- ptr_to_fresh_readonly "aug" (llvm_array aug_len (llvm_int 8));
-  crucible_execute_func [pk_ptr, signature_ptr, crucible_term hash_or_encode, msg_ptr, crucible_term {{ `msg_len : [64] }}, dst_ptr, crucible_term {{ `dst_len : [64] }}, aug_ptr, crucible_term {{ `aug_len : [64] }}];
+  llvm_execute_func [pk_ptr, signature_ptr, llvm_term hash_or_encode, msg_ptr, llvm_term {{ `msg_len : [64] }}, dst_ptr, llvm_term {{ `dst_len : [64] }}, aug_ptr, llvm_term {{ `aug_len : [64] }}];
   ret <- llvm_fresh_var "blst_core_verify_pk_in_g2_ret" (llvm_int 32);
   llvm_return (llvm_term ret);
   llvm_postcond {{ ret != `BLST_SUCCESS }};
@@ -61,13 +61,13 @@ let blst_core_verify_pk_in_g2_null_sig_spec msg_len dst_len aug_len = do {
   (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE2_affine");
   let signature_ptr = llvm_null;
   llvm_precond {{ POINTonE2_affine_invariant pk }};
-  hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
+  hash_or_encode <- llvm_fresh_var "hash_or_encode" (llvm_int 32);
   llvm_precond {{ hash_or_encode != zero }};
   (msg, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));
   (dst, dst_ptr) <- ptr_to_fresh_readonly "dst" (llvm_array dst_len (llvm_int 8));
   (aug, aug_ptr) <- ptr_to_fresh_readonly "aug" (llvm_array aug_len (llvm_int 8));
-  crucible_execute_func [pk_ptr, signature_ptr, crucible_term hash_or_encode, msg_ptr, crucible_term {{ `msg_len : [64] }}, dst_ptr, crucible_term {{ `dst_len : [64] }}, aug_ptr, crucible_term {{ `aug_len : [64] }}];
-  crucible_return (crucible_term {{ if is_point_O E' (POINTonE2_affine_abs pk) then `BLST_PK_IS_INFINITY else if core_verify_pk_in_g2_impl (POINTonE2_affine_abs pk) (POINTonE1_affine_abs zero) msg dst aug then (`BLST_SUCCESS:[32]) else `BLST_VERIFY_FAIL }});
+  llvm_execute_func [pk_ptr, signature_ptr, llvm_term hash_or_encode, msg_ptr, llvm_term {{ `msg_len : [64] }}, dst_ptr, llvm_term {{ `dst_len : [64] }}, aug_ptr, llvm_term {{ `aug_len : [64] }}];
+  llvm_return (llvm_term {{ if is_point_O E' (POINTonE2_affine_abs pk) then `BLST_PK_IS_INFINITY else if core_verify_pk_in_g2_impl (POINTonE2_affine_abs pk) (POINTonE1_affine_abs zero) msg dst aug then (`BLST_SUCCESS:[32]) else `BLST_VERIFY_FAIL }});
 };
 
 // overrides:

--- a/proof/core_verify_pk_in_g2.saw
+++ b/proof/core_verify_pk_in_g2.saw
@@ -14,8 +14,8 @@ let {{
 
 // case in which no argument is null and the error condition is false
 let blst_core_verify_pk_in_g2_non_null_spec msg_len dst_len aug_len = do {
-  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_struct "struct.POINTonE2_affine");
-  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_struct "struct.POINTonE1_affine");
+  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE2_affine");
+  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE1_affine");
   llvm_precond {{ POINTonE2_affine_invariant pk /\ POINTonE1_affine_invariant sig /\ is_point_affine E (POINTonE1_affine_abs sig) /\ ~blst_core_verify_pk_in_g2_error_precond pk sig }};
   hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
   llvm_precond {{ hash_or_encode != zero }};
@@ -28,8 +28,8 @@ let blst_core_verify_pk_in_g2_non_null_spec msg_len dst_len aug_len = do {
 
 // same but with NULL aug
 let blst_core_verify_pk_in_g2_null_aug_spec msg_len dst_len = do {
-  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_struct "struct.POINTonE2_affine");
-  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_struct "struct.POINTonE1_affine");
+  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE2_affine");
+  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE1_affine");
   llvm_precond {{ POINTonE2_affine_invariant pk /\ POINTonE1_affine_invariant sig /\ is_point_affine E (POINTonE1_affine_abs sig) /\ ~blst_core_verify_pk_in_g2_error_precond pk sig }};
   hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
   llvm_precond {{ hash_or_encode != zero }};
@@ -42,8 +42,8 @@ let blst_core_verify_pk_in_g2_null_aug_spec msg_len dst_len = do {
 
 // error case
 let blst_core_verify_pk_in_g2_error_spec msg_len dst_len aug_len = do {
-  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_struct "struct.POINTonE2_affine");
-  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_struct "struct.POINTonE1_affine");
+  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE2_affine");
+  (sig, signature_ptr) <- ptr_to_fresh_readonly "signature" (llvm_alias "struct.POINTonE1_affine");
   llvm_precond {{ POINTonE2_affine_invariant pk /\ POINTonE1_affine_invariant sig /\ is_point_affine E (POINTonE1_affine_abs sig) /\ blst_core_verify_pk_in_g2_error_precond pk sig }};
   hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);
   llvm_precond {{ hash_or_encode != zero }};
@@ -58,7 +58,7 @@ let blst_core_verify_pk_in_g2_error_spec msg_len dst_len aug_len = do {
 
 // sig is null
 let blst_core_verify_pk_in_g2_null_sig_spec msg_len dst_len aug_len = do {
-  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_struct "struct.POINTonE2_affine");
+  (pk, pk_ptr) <- ptr_to_fresh_readonly "pk" (llvm_alias "struct.POINTonE2_affine");
   let signature_ptr = llvm_null;
   llvm_precond {{ POINTonE2_affine_invariant pk }};
   hash_or_encode <- crucible_fresh_var "hash_or_encode" (llvm_int 32);

--- a/proof/curve_operations.saw
+++ b/proof/curve_operations.saw
@@ -75,20 +75,20 @@ normalize_affine_point_abs_thm <- prove_cryptol
            else apply normalize_affine_point Fp (POINTonE1_affine_abs p) }} [];
 
 let POINTonE1_add_spec = do {
-  out_ptr <- crucible_alloc POINTonE1_type;
+  out_ptr <- llvm_alloc POINTonE1_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
+  llvm_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr];
   if use_abs_method
   then do {
-    out <- crucible_fresh_var "new_POINTonE1_add_out" POINTonE1_type;
-    crucible_points_to out_ptr (crucible_term out);
-    crucible_postcond {{ POINTonE1_invariant out }};
-    crucible_postcond {{ POINTonE1_abs out == point_add Fp (POINTonE1_abs p1) (POINTonE1_abs p2)}};
+    out <- llvm_fresh_var "new_POINTonE1_add_out" POINTonE1_type;
+    llvm_points_to out_ptr (llvm_term out);
+    llvm_postcond {{ POINTonE1_invariant out }};
+    llvm_postcond {{ POINTonE1_abs out == point_add Fp (POINTonE1_abs p1) (POINTonE1_abs p2)}};
     }
   else
-    crucible_points_to out_ptr (crucible_term  {{ POINTonE1_rep (point_add Fp (POINTonE1_abs p1) (POINTonE1_abs p2)) }} );
+    llvm_points_to out_ptr (llvm_term  {{ POINTonE1_rep (point_add Fp (POINTonE1_abs p1) (POINTonE1_abs p2)) }} );
 };
 
 POINTonE1_add_ov <- custom_verify "POINTonE1_add"
@@ -108,17 +108,17 @@ POINTonE1_add_ov <- custom_verify "POINTonE1_add"
 let POINTonE1_add_alias_1_2_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh "p1" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
-  crucible_execute_func [p1_ptr, p1_ptr, p2_ptr];
+  llvm_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
+  llvm_execute_func [p1_ptr, p1_ptr, p2_ptr];
   if use_abs_method
   then do {
-    out <- crucible_fresh_var "new_POINTonE1_add_out" POINTonE1_type;
-    crucible_points_to p1_ptr (crucible_term out);
-    crucible_postcond {{ POINTonE1_invariant out }};
-    crucible_postcond {{ POINTonE1_abs out == point_add Fp (POINTonE1_abs p1) (POINTonE1_abs p2)}};
+    out <- llvm_fresh_var "new_POINTonE1_add_out" POINTonE1_type;
+    llvm_points_to p1_ptr (llvm_term out);
+    llvm_postcond {{ POINTonE1_invariant out }};
+    llvm_postcond {{ POINTonE1_abs out == point_add Fp (POINTonE1_abs p1) (POINTonE1_abs p2)}};
     }
   else
-    crucible_points_to p1_ptr (crucible_term  {{ POINTonE1_rep (point_add Fp (POINTonE1_abs p1) (POINTonE1_abs p2)) }} );
+    llvm_points_to p1_ptr (llvm_term  {{ POINTonE1_rep (point_add Fp (POINTonE1_abs p1) (POINTonE1_abs p2)) }} );
 };
 
 
@@ -152,20 +152,20 @@ POINTonE1_add_affine_equiv_thm <-
 
 
 let POINTonE1_add_affine_spec = do {
-  out_ptr <- crucible_alloc POINTonE1_type;
+  out_ptr <- llvm_alloc POINTonE1_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE1_affine_type;
-  crucible_precond {{ POINTonE1_invariant p1 /\ POINTonE1_affine_invariant p2 }};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
+  llvm_precond {{ POINTonE1_invariant p1 /\ POINTonE1_affine_invariant p2 }};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr];
   if use_abs_method
   then do {
-    out <- crucible_fresh_var "new_POINTonE1_add_out" POINTonE1_type;
-    crucible_points_to out_ptr (crucible_term out);
-    crucible_postcond {{ POINTonE1_invariant out }};
-    crucible_postcond {{ POINTonE1_abs out == point_add_affine Fp (POINTonE1_abs p1) (POINTonE1_affine_abs p2) }};
+    out <- llvm_fresh_var "new_POINTonE1_add_out" POINTonE1_type;
+    llvm_points_to out_ptr (llvm_term out);
+    llvm_postcond {{ POINTonE1_invariant out }};
+    llvm_postcond {{ POINTonE1_abs out == point_add_affine Fp (POINTonE1_abs p1) (POINTonE1_affine_abs p2) }};
     }
   else
-    crucible_points_to out_ptr (crucible_term {{ POINTonE1_rep ( point_add_affine Fp (POINTonE1_abs p1) (POINTonE1_affine_abs p2)) }});
+    llvm_points_to out_ptr (llvm_term {{ POINTonE1_rep ( point_add_affine Fp (POINTonE1_abs p1) (POINTonE1_affine_abs p2)) }});
 };
 
 fp_zero_abs_thm <- prove_cryptol (rewrite (cryptol_ss ()) {{ fp_abs zero == Fp.field_zero }}) [];
@@ -221,19 +221,19 @@ POINTonE1_double_eqv_thm <-
   z3;
 
 let POINTonE1_double_spec = do {
-  out_ptr <- crucible_alloc POINTonE1_type;
+  out_ptr <- llvm_alloc POINTonE1_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant p1 }};
-  crucible_execute_func [out_ptr, p1_ptr];
+  llvm_precond {{ POINTonE1_invariant p1 }};
+  llvm_execute_func [out_ptr, p1_ptr];
   if use_abs_method
   then do {
-    out <- crucible_fresh_var "new_POINTonE1_double_out" POINTonE1_type;
-    crucible_points_to out_ptr (crucible_term out);
-    crucible_postcond {{ POINTonE1_invariant out }};
-    crucible_postcond {{ POINTonE1_abs out == point_double Fp (POINTonE1_abs p1)}};
+    out <- llvm_fresh_var "new_POINTonE1_double_out" POINTonE1_type;
+    llvm_points_to out_ptr (llvm_term out);
+    llvm_postcond {{ POINTonE1_invariant out }};
+    llvm_postcond {{ POINTonE1_abs out == point_double Fp (POINTonE1_abs p1)}};
     }
   else 
-    crucible_points_to out_ptr (crucible_term {{ POINTonE1_rep (point_double Fp (POINTonE1_abs p1)) }});
+    llvm_points_to out_ptr (llvm_term {{ POINTonE1_rep (point_double Fp (POINTonE1_abs p1)) }});
 };
 
 POINTonE1_double_ov <- custom_verify "POINTonE1_double"
@@ -246,17 +246,17 @@ POINTonE1_double_ov <- custom_verify "POINTonE1_double"
 
 let POINTonE1_double_alias_1_2_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh "p1" POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant p1 }};
-  crucible_execute_func [p1_ptr, p1_ptr];
+  llvm_precond {{ POINTonE1_invariant p1 }};
+  llvm_execute_func [p1_ptr, p1_ptr];
   if use_abs_method
   then do {
-    out <- crucible_fresh_var "new_POINTonE1_double_out" POINTonE1_type;
-    crucible_points_to p1_ptr (crucible_term out);
-    crucible_postcond {{ POINTonE1_invariant out }};
-    crucible_postcond {{ POINTonE1_abs out == point_double Fp (POINTonE1_abs p1)}};
+    out <- llvm_fresh_var "new_POINTonE1_double_out" POINTonE1_type;
+    llvm_points_to p1_ptr (llvm_term out);
+    llvm_postcond {{ POINTonE1_invariant out }};
+    llvm_postcond {{ POINTonE1_abs out == point_double Fp (POINTonE1_abs p1)}};
     }
   else 
-    crucible_points_to p1_ptr (crucible_term {{ POINTonE1_rep (point_double Fp (POINTonE1_abs p1)) }});
+    llvm_points_to p1_ptr (llvm_term {{ POINTonE1_rep (point_double Fp (POINTonE1_abs p1)) }});
 };
 
 POINTonE1_double_alias_1_2_ov <- custom_verify "POINTonE1_double"
@@ -276,20 +276,20 @@ POINTonE1_double_alias_1_2_ov <- custom_verify "POINTonE1_double"
 
 
 let POINTonE1_dadd_null_spec = do {
-  out_ptr <- crucible_alloc POINTonE1_type;
+  out_ptr <- llvm_alloc POINTonE1_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr, crucible_null];
+  llvm_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr, llvm_null];
   if use_abs_method
   then do {
-    out <- crucible_fresh_var "new_POINTonE1_dadd_out" POINTonE1_type;
-    crucible_points_to out_ptr (crucible_term out);
-    crucible_postcond {{ POINTonE1_invariant out }};
-    crucible_postcond {{ POINTonE1_abs out == point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True }};
+    out <- llvm_fresh_var "new_POINTonE1_dadd_out" POINTonE1_type;
+    llvm_points_to out_ptr (llvm_term out);
+    llvm_postcond {{ POINTonE1_invariant out }};
+    llvm_postcond {{ POINTonE1_abs out == point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True }};
     }
   else
-     crucible_points_to out_ptr (crucible_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True) }});
+     llvm_points_to out_ptr (llvm_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True) }});
 };
 
 let prove_POINTonE1_dadd spec = custom_verify "POINTonE1_dadd"
@@ -311,17 +311,17 @@ POINTonE1_dadd_null_ov <- prove_POINTonE1_dadd POINTonE1_dadd_null_spec;
 let POINTonE1_dadd_null_alias_1_2_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh "p1" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
-  crucible_execute_func [p1_ptr, p1_ptr, p2_ptr, crucible_null];
+  llvm_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
+  llvm_execute_func [p1_ptr, p1_ptr, p2_ptr, llvm_null];
   if use_abs_method
   then do {
-    out <- crucible_fresh_var "new_POINTonE1_dadd_out" POINTonE1_type;
-    crucible_points_to p1_ptr (crucible_term out);
-    crucible_postcond {{ POINTonE1_invariant out }};
-    crucible_postcond {{ POINTonE1_abs out == point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True }};
+    out <- llvm_fresh_var "new_POINTonE1_dadd_out" POINTonE1_type;
+    llvm_points_to p1_ptr (llvm_term out);
+    llvm_postcond {{ POINTonE1_invariant out }};
+    llvm_postcond {{ POINTonE1_abs out == point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True }};
     }
   else
-     crucible_points_to p1_ptr (crucible_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True) }});
+     llvm_points_to p1_ptr (llvm_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True) }});
 };
 
 POINTonE1_dadd_null_alias_1_2_ov <- prove_POINTonE1_dadd POINTonE1_dadd_null_alias_1_2_spec;
@@ -329,37 +329,37 @@ POINTonE1_dadd_null_alias_1_2_ov <- prove_POINTonE1_dadd POINTonE1_dadd_null_ali
 let POINTonE1_dadd_null_alias_1_3_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh "p2" POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
-  crucible_execute_func [p2_ptr, p1_ptr, p2_ptr, crucible_null];
+  llvm_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
+  llvm_execute_func [p2_ptr, p1_ptr, p2_ptr, llvm_null];
   if use_abs_method
   then do {
-    out <- crucible_fresh_var "new_POINTonE1_dadd_out" POINTonE1_type;
-    crucible_points_to p2_ptr (crucible_term out);
-    crucible_postcond {{ POINTonE1_invariant out }};
-    crucible_postcond {{ POINTonE1_abs out == point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True }};
+    out <- llvm_fresh_var "new_POINTonE1_dadd_out" POINTonE1_type;
+    llvm_points_to p2_ptr (llvm_term out);
+    llvm_postcond {{ POINTonE1_invariant out }};
+    llvm_postcond {{ POINTonE1_abs out == point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True }};
     }
   else
-     crucible_points_to p2_ptr (crucible_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True) }});
+     llvm_points_to p2_ptr (llvm_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) Fp.field_zero True) }});
 };
 
 POINTonE1_dadd_null_alias_1_3_ov <- prove_POINTonE1_dadd POINTonE1_dadd_null_alias_1_3_spec;
 
 let POINTonE1_dadd_nonnull_spec = do {
-  out_ptr <- crucible_alloc POINTonE1_type;
+  out_ptr <- llvm_alloc POINTonE1_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE1_type;
   (a4, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384_type;
-  crucible_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 /\ fp_invariant a4 }};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
+  llvm_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 /\ fp_invariant a4 }};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
   if use_abs_method
   then do {
-    out <- crucible_fresh_var "new_POINTonE1_dadd_out" POINTonE1_type;
-    crucible_points_to out_ptr (crucible_term out);
-    crucible_postcond {{ POINTonE1_invariant out }};
-    crucible_postcond {{ POINTonE1_abs out == point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) (fp_abs a4) False}};
+    out <- llvm_fresh_var "new_POINTonE1_dadd_out" POINTonE1_type;
+    llvm_points_to out_ptr (llvm_term out);
+    llvm_postcond {{ POINTonE1_invariant out }};
+    llvm_postcond {{ POINTonE1_abs out == point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) (fp_abs a4) False}};
     }
   else
-    crucible_points_to out_ptr (crucible_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) (fp_abs a4) False) }});
+    llvm_points_to out_ptr (llvm_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs p1) (POINTonE1_abs p2) (fp_abs a4) False) }});
 };
 
 POINTonE1_dadd_nonnull_ov <- prove_POINTonE1_dadd POINTonE1_dadd_nonnull_spec;
@@ -368,9 +368,9 @@ let POINTonE1_dadd_nonnull_alias_1_2_spec = do {
   (out, out_ptr) <- ptr_to_fresh "out" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE1_type;
   (a4, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384_type;
-  crucible_precond {{ POINTonE1_invariant out /\ POINTonE1_invariant p2 /\ fp_invariant a4 }};
-  crucible_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
-  crucible_points_to out_ptr (crucible_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs out) (POINTonE1_abs p2) (fp_abs a4) False) }});
+  llvm_precond {{ POINTonE1_invariant out /\ POINTonE1_invariant p2 /\ fp_invariant a4 }};
+  llvm_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
+  llvm_points_to out_ptr (llvm_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs out) (POINTonE1_abs p2) (fp_abs a4) False) }});
 };
 
 POINTonE1_dadd_nonnull_alias_1_2_ov <- prove_POINTonE1_dadd POINTonE1_dadd_nonnull_alias_1_2_spec;
@@ -378,29 +378,29 @@ POINTonE1_dadd_nonnull_alias_1_2_ov <- prove_POINTonE1_dadd POINTonE1_dadd_nonnu
 // ... POINTonE1_dadd_affine
 
 let POINTonE1_dadd_affine_spec = do {
-  out_ptr <- crucible_alloc POINTonE1_type;
+  out_ptr <- llvm_alloc POINTonE1_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE1_affine_type;
-  crucible_precond {{ POINTonE1_invariant p1 /\ POINTonE1_affine_invariant p2 }};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
+  llvm_precond {{ POINTonE1_invariant p1 /\ POINTonE1_affine_invariant p2 }};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr];
   if use_abs_method
   then do {
-    out <- crucible_fresh_var "new_POINTonE1_dadd_out" POINTonE1_type;
-    crucible_points_to out_ptr (crucible_term out);
-    crucible_postcond {{ POINTonE1_invariant out }};
-    crucible_postcond {{ POINTonE1_abs out == point_dadd_affine Fp (POINTonE1_abs p1) (POINTonE1_affine_abs p2) }};
+    out <- llvm_fresh_var "new_POINTonE1_dadd_out" POINTonE1_type;
+    llvm_points_to out_ptr (llvm_term out);
+    llvm_postcond {{ POINTonE1_invariant out }};
+    llvm_postcond {{ POINTonE1_abs out == point_dadd_affine Fp (POINTonE1_abs p1) (POINTonE1_affine_abs p2) }};
     }
   else
-     // crucible_points_to out_ptr (crucible_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs p1) (projectify E (POINTonE1_affine_abs p2)) Fp.field_zero True) }});
-     crucible_points_to out_ptr (crucible_term {{ POINTonE1_rep (point_dadd_affine Fp (POINTonE1_abs p1) (POINTonE1_affine_abs p2)) }});
+     // llvm_points_to out_ptr (llvm_term {{ POINTonE1_rep (point_dadd Fp (POINTonE1_abs p1) (projectify E (POINTonE1_affine_abs p2)) Fp.field_zero True) }});
+     llvm_points_to out_ptr (llvm_term {{ POINTonE1_rep (point_dadd_affine Fp (POINTonE1_abs p1) (POINTonE1_affine_abs p2)) }});
 };
 
 let POINTonE1_dadd_affine_alias_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh "p1" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE1_affine_type;
-  crucible_precond {{ POINTonE1_invariant p1 /\ POINTonE1_affine_invariant p2 }};
-  crucible_execute_func [p1_ptr, p1_ptr, p2_ptr];
-  crucible_points_to p1_ptr (crucible_term {{ POINTonE1_rep (point_dadd_affine Fp (POINTonE1_abs p1) (POINTonE1_affine_abs p2)) }});
+  llvm_precond {{ POINTonE1_invariant p1 /\ POINTonE1_affine_invariant p2 }};
+  llvm_execute_func [p1_ptr, p1_ptr, p2_ptr];
+  llvm_points_to p1_ptr (llvm_term {{ POINTonE1_rep (point_dadd_affine Fp (POINTonE1_abs p1) (POINTonE1_affine_abs p2)) }});
 };
 
 POINTonE1_dadd_affine_ov <- custom_verify "POINTonE1_dadd_affine"
@@ -451,9 +451,9 @@ POINTonE1_dadd_affine_alias_ov <- custom_verify "POINTonE1_dadd_affine"
 let POINTonE1_is_equal_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE1_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
-  crucible_execute_func [p1_ptr, p2_ptr];
-  crucible_return (crucible_term
+  llvm_precond {{ POINTonE1_invariant p1 /\ POINTonE1_invariant p2 }};
+  llvm_execute_func [p1_ptr, p2_ptr];
+  llvm_return (llvm_term
    {{ bool_to_limb ((same_point E (POINTonE1_abs p1) (POINTonE1_abs p2))
                     /\ ((Fp.field_zero ==  fp_abs p1.2) ^ (Fp.field_zero == fp_abs p2.2) ^ True))
     }} );
@@ -485,9 +485,9 @@ POINTonE1_affine_on_curve_eqv_thm <- custom_prove_cryptol
 
 let POINTonE1_affine_on_curve_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE1_affine_type;
-  crucible_precond {{ POINTonE1_affine_invariant p1 }};
-  crucible_execute_func [p1_ptr];
-  crucible_return (crucible_term {{ if is_point_affine E (POINTonE1_affine_abs p1) then (1:Limb) else 0 }});
+  llvm_precond {{ POINTonE1_affine_invariant p1 }};
+  llvm_execute_func [p1_ptr];
+  llvm_return (llvm_term {{ if is_point_affine E (POINTonE1_affine_abs p1) then (1:Limb) else 0 }});
 };
 
 let B_E1 = {{
@@ -540,9 +540,9 @@ let {{
 
 let POINTonE1_on_curve_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant p1 }};
-  crucible_execute_func [p1_ptr];
-  crucible_return (crucible_term {{ if POINTonE1_on_curve (POINTonE1_abs p1) then (1:Limb) else 0 }});
+  llvm_precond {{ POINTonE1_invariant p1 }};
+  llvm_execute_func [p1_ptr];
+  llvm_return (llvm_term {{ if POINTonE1_on_curve (POINTonE1_abs p1) then (1:Limb) else 0 }});
 };
 
 // TODO:
@@ -575,10 +575,10 @@ POINTonE1_on_curve_ov <- custom_verify "POINTonE1_on_curve"
 
 let POINTonE1_cneg_spec = do {
   (p, p_ptr) <- ptr_to_fresh "p" POINTonE1_type;
-  cbit <- crucible_fresh_var "cbit" limb_type;
-  crucible_precond {{ POINTonE1_invariant p }};
-  crucible_execute_func [p_ptr, crucible_term cbit];
-  crucible_points_to p_ptr (crucible_term {{ if cbit != 0 then POINTonE1_rep (point_neg Fp (POINTonE1_abs p))
+  cbit <- llvm_fresh_var "cbit" limb_type;
+  llvm_precond {{ POINTonE1_invariant p }};
+  llvm_execute_func [p_ptr, llvm_term cbit];
+  llvm_points_to p_ptr (llvm_term {{ if cbit != 0 then POINTonE1_rep (point_neg Fp (POINTonE1_abs p))
                                                           else p }});
 };
 

--- a/proof/curve_operations_e2.saw
+++ b/proof/curve_operations_e2.saw
@@ -55,12 +55,12 @@ let simpset =
   addsimps (concat core_rewrites [hoist_if_proj_int_0, hoist_if_proj_int_1, hoist_if_proj_int_2, hoist_if_proj_0, hoist_if_proj_1, hoist_if_proj_2, normalize_point_fp2_abs_thm, normalize_affine_point_fp2_abs_thm, normalize_point_3fp_abs_thm, normalize_affine_point_fp_abs_thm]) extended_fp2_simpset;
 
 let POINTonE2_add_spec = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  crucible_points_to out_ptr (crucible_term  {{ POINTonE2_rep (point_add Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2)) }} );
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr];
+  llvm_points_to out_ptr (llvm_term  {{ POINTonE2_rep (point_add Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2)) }} );
 };
 
 POINTonE2_add_ov <- custom_verify "POINTonE2_add"
@@ -75,9 +75,9 @@ POINTonE2_add_ov <- custom_verify "POINTonE2_add"
 let POINTonE2_add_alias_1_2_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
-  crucible_execute_func [p1_ptr, p1_ptr, p2_ptr];
-  crucible_points_to p1_ptr (crucible_term  {{ POINTonE2_rep (point_add Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2)) }} );
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
+  llvm_execute_func [p1_ptr, p1_ptr, p2_ptr];
+  llvm_points_to p1_ptr (llvm_term  {{ POINTonE2_rep (point_add Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2)) }} );
 };
 
 POINTonE2_add_alias_1_2_ov <- custom_verify "POINTonE2_add"
@@ -90,12 +90,12 @@ POINTonE2_add_alias_1_2_ov <- custom_verify "POINTonE2_add"
                       });
 
 let POINTonE2_add_affine_spec = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_affine_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_affine_invariant p2 }};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  crucible_points_to out_ptr (crucible_term  {{ POINTonE2_rep (point_add_affine Fp_2 (POINTonE2_abs p1) (POINTonE2_affine_abs p2)) }} );
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_affine_invariant p2 }};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr];
+  llvm_points_to out_ptr (llvm_term  {{ POINTonE2_rep (point_add_affine Fp_2 (POINTonE2_abs p1) (POINTonE2_affine_abs p2)) }} );
 };
 
 POINTonE2_add_affine_ov <- custom_verify "POINTonE2_add_affine"
@@ -110,9 +110,9 @@ POINTonE2_add_affine_ov <- custom_verify "POINTonE2_add_affine"
 let POINTonE2_add_affine_alias_1_2_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_affine_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_affine_invariant p2 }};
-  crucible_execute_func [p1_ptr, p1_ptr, p2_ptr];
-  crucible_points_to p1_ptr (crucible_term  {{ POINTonE2_rep (point_add_affine Fp_2 (POINTonE2_abs p1) (POINTonE2_affine_abs p2)) }} );
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_affine_invariant p2 }};
+  llvm_execute_func [p1_ptr, p1_ptr, p2_ptr];
+  llvm_points_to p1_ptr (llvm_term  {{ POINTonE2_rep (point_add_affine Fp_2 (POINTonE2_abs p1) (POINTonE2_affine_abs p2)) }} );
 };
 
 
@@ -126,11 +126,11 @@ POINTonE2_add_affine_alias_1_2_ov <- custom_verify "POINTonE2_add_affine"
                       });
 
 let POINTonE2_double_spec = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant p1 }};
-  crucible_execute_func [out_ptr, p1_ptr];
-  crucible_points_to out_ptr (crucible_term {{ POINTonE2_rep (point_double Fp_2 (POINTonE2_abs p1)) }});
+  llvm_precond {{ POINTonE2_invariant p1 }};
+  llvm_execute_func [out_ptr, p1_ptr];
+  llvm_points_to out_ptr (llvm_term {{ POINTonE2_rep (point_double Fp_2 (POINTonE2_abs p1)) }});
 };
 
 POINTonE2_double_ov <- custom_verify "POINTonE2_double"
@@ -144,9 +144,9 @@ POINTonE2_double_ov <- custom_verify "POINTonE2_double"
 
 let POINTonE2_double_alias_1_2_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh "p1" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant p1 }};
-  crucible_execute_func [p1_ptr, p1_ptr];
-  crucible_points_to p1_ptr (crucible_term {{ POINTonE2_rep (point_double Fp_2 (POINTonE2_abs p1)) }});
+  llvm_precond {{ POINTonE2_invariant p1 }};
+  llvm_execute_func [p1_ptr, p1_ptr];
+  llvm_points_to p1_ptr (llvm_term {{ POINTonE2_rep (point_double Fp_2 (POINTonE2_abs p1)) }});
 };
 
 POINTonE2_double_alias_1_2_ov <- custom_verify "POINTonE2_double"
@@ -159,12 +159,12 @@ POINTonE2_double_alias_1_2_ov <- custom_verify "POINTonE2_double"
                       });
 
 let POINTonE2_dadd_null_spec = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr, crucible_null];
-   crucible_points_to out_ptr (crucible_term {{ POINTonE2_rep (point_dadd Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2) Fp_2.field_zero True) }});
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr, llvm_null];
+   llvm_points_to out_ptr (llvm_term {{ POINTonE2_rep (point_dadd Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2) Fp_2.field_zero True) }});
 };
 
 
@@ -181,9 +181,9 @@ POINTonE2_dadd_null_ov <- custom_verify "POINTonE2_dadd"
 let POINTonE2_dadd_null_alias_1_2_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
-  crucible_execute_func [p1_ptr, p1_ptr, p2_ptr, crucible_null];
-  crucible_points_to p1_ptr (crucible_term {{ POINTonE2_rep (point_dadd Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2) Fp_2.field_zero True) }});
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
+  llvm_execute_func [p1_ptr, p1_ptr, p2_ptr, llvm_null];
+  llvm_points_to p1_ptr (llvm_term {{ POINTonE2_rep (point_dadd Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2) Fp_2.field_zero True) }});
 };
 
 
@@ -198,13 +198,13 @@ POINTonE2_dadd_null_alias_1_2_ov <- custom_verify "POINTonE2_dadd"
 );
 
 let POINTonE2_dadd_nonnull_spec = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_type;
   (a4, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384x_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 /\ fp2_invariant a4}};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
-  crucible_points_to out_ptr (crucible_term {{ POINTonE2_rep (point_dadd Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2) (fp2_abs a4) False) }});
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 /\ fp2_invariant a4}};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
+  llvm_points_to out_ptr (llvm_term {{ POINTonE2_rep (point_dadd Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2) (fp2_abs a4) False) }});
 };
 
 POINTonE2_dadd_nonnull_ov <- custom_verify "POINTonE2_dadd"
@@ -220,9 +220,9 @@ let POINTonE2_dadd_nonnull_alias_1_2_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_type;
   (a4, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384x_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 /\ fp2_invariant a4}};
-  crucible_execute_func [p1_ptr, p1_ptr, p2_ptr, a4_ptr];
-  crucible_points_to p1_ptr (crucible_term {{ POINTonE2_rep (point_dadd Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2) (fp2_abs a4) False) }});
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 /\ fp2_invariant a4}};
+  llvm_execute_func [p1_ptr, p1_ptr, p2_ptr, a4_ptr];
+  llvm_points_to p1_ptr (llvm_term {{ POINTonE2_rep (point_dadd Fp_2 (POINTonE2_abs p1) (POINTonE2_abs p2) (fp2_abs a4) False) }});
 };
 
 POINTonE2_dadd_nonnull_alias_1_2_ov <- custom_verify "POINTonE2_dadd"
@@ -235,12 +235,12 @@ POINTonE2_dadd_nonnull_alias_1_2_ov <- custom_verify "POINTonE2_dadd"
                           });
 
 let POINTonE2_dadd_affine_spec = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_affine_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_affine_invariant p2 }};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  crucible_points_to out_ptr (crucible_term {{ POINTonE2_rep (point_dadd_affine Fp_2 (POINTonE2_abs p1) (POINTonE2_affine_abs p2)) }});
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_affine_invariant p2 }};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr];
+  llvm_points_to out_ptr (llvm_term {{ POINTonE2_rep (point_dadd_affine Fp_2 (POINTonE2_abs p1) (POINTonE2_affine_abs p2)) }});
 };
 
 POINTonE2_dadd_affine_ov <- custom_verify "POINTonE2_dadd_affine"
@@ -255,9 +255,9 @@ POINTonE2_dadd_affine_ov <- custom_verify "POINTonE2_dadd_affine"
 let POINTonE2_dadd_affine_alias_1_2_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_affine_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_affine_invariant p2 }};
-  crucible_execute_func [p1_ptr, p1_ptr, p2_ptr];
-  crucible_points_to p1_ptr (crucible_term {{ POINTonE2_rep (point_dadd_affine Fp_2 (POINTonE2_abs p1) (POINTonE2_affine_abs p2)) }});
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_affine_invariant p2 }};
+  llvm_execute_func [p1_ptr, p1_ptr, p2_ptr];
+  llvm_points_to p1_ptr (llvm_term {{ POINTonE2_rep (point_dadd_affine Fp_2 (POINTonE2_abs p1) (POINTonE2_affine_abs p2)) }});
 };
 
 POINTonE2_dadd_affine_alias_1_2_ov <- custom_verify "POINTonE2_dadd_affine"
@@ -272,9 +272,9 @@ POINTonE2_dadd_affine_alias_1_2_ov <- custom_verify "POINTonE2_dadd_affine"
 let POINTonE2_is_equal_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
-  crucible_execute_func [p1_ptr, p2_ptr];
-  crucible_return (crucible_term
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
+  llvm_execute_func [p1_ptr, p2_ptr];
+  llvm_return (llvm_term
    {{ bool_to_limb ((same_point E' (POINTonE2_abs p1) (POINTonE2_abs p2))
                     /\ (Fp_2.is_equal(fp2_abs p1.2, Fp_2.field_zero) ^ Fp_2.is_equal(fp2_abs p2.2, Fp_2.field_zero) ^ True))
     }} );
@@ -297,9 +297,9 @@ POINTonE2_affine_on_curve_eqv_thm <- custom_prove_cryptol
 
 let POINTonE2_affine_on_curve_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_affine_type;
-  crucible_precond {{ POINTonE2_affine_invariant p1 }};
-  crucible_execute_func [p1_ptr];
-  crucible_return (crucible_term {{ if is_point_affine E' (POINTonE2_affine_abs p1) then (1:Limb) else 0 }});
+  llvm_precond {{ POINTonE2_affine_invariant p1 }};
+  llvm_execute_func [p1_ptr];
+  llvm_return (llvm_term {{ if is_point_affine E' (POINTonE2_affine_abs p1) then (1:Limb) else 0 }});
 };
 
 B_E2_invariant_thm <- prove_cryptol (rewrite (cryptol_ss ()) {{ fp2_invariant [B_E1, B_E1] == True }}) [];
@@ -330,9 +330,9 @@ mul_by_b_onE2_alias_1_2_ov <-
 
 let POINTonE2_on_curve_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant p1 }};
-  crucible_execute_func [p1_ptr];
-  crucible_return (crucible_term {{ if POINTonE2_on_curve (POINTonE2_abs p1) then (1:Limb) else 0 }});
+  llvm_precond {{ POINTonE2_invariant p1 }};
+  llvm_execute_func [p1_ptr];
+  llvm_return (llvm_term {{ if POINTonE2_on_curve (POINTonE2_abs p1) then (1:Limb) else 0 }});
 };
 
 // NOTE: the precondition in the equality below
@@ -342,9 +342,9 @@ POINTonE2_on_curve_eqv_thm <- custom_prove_cryptol
 
 let POINTonE2_on_curve_spec = do {
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant p1 }};
-  crucible_execute_func [p1_ptr];
-  crucible_return (crucible_term {{ if POINTonE2_on_curve (POINTonE2_abs p1) then (1:Limb) else 0 }});
+  llvm_precond {{ POINTonE2_invariant p1 }};
+  llvm_execute_func [p1_ptr];
+  llvm_return (llvm_term {{ if POINTonE2_on_curve (POINTonE2_abs p1) then (1:Limb) else 0 }});
 };
 
 POINTonE2_on_curve_ov <- custom_verify "POINTonE2_on_curve"
@@ -358,10 +358,10 @@ POINTonE2_on_curve_ov <- custom_verify "POINTonE2_on_curve"
 
 let POINTonE2_cneg_spec = do {
   (p, p_ptr) <- ptr_to_fresh "p" POINTonE2_type;
-  cbit <- crucible_fresh_var "cbit" limb_type;
-  crucible_precond {{ POINTonE2_invariant p }};
-  crucible_execute_func [p_ptr, crucible_term cbit];
-  crucible_points_to p_ptr (crucible_term {{ if cbit != 0 then POINTonE2_rep (point_neg Fp_2 (POINTonE2_abs p))
+  cbit <- llvm_fresh_var "cbit" limb_type;
+  llvm_precond {{ POINTonE2_invariant p }};
+  llvm_execute_func [p_ptr, llvm_term cbit];
+  llvm_points_to p_ptr (llvm_term {{ if cbit != 0 then POINTonE2_rep (point_neg Fp_2 (POINTonE2_abs p))
                                                           else p }});
 };
 

--- a/proof/deserialize-p1.saw
+++ b/proof/deserialize-p1.saw
@@ -12,14 +12,14 @@ include "blst_error.saw";
 // The main specification here is for blst_p1_uncompress
 
 let blst_p1_uncompress_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
-  crucible_precond {{ uncompress_E1_imp inp != nothing }};
-  crucible_execute_func [out_ptr, in_ptr];
+  llvm_precond {{ uncompress_E1_imp inp != nothing }};
+  llvm_execute_func [out_ptr, in_ptr];
 
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_return (crucible_term ret);
-  crucible_points_to out_ptr (crucible_term {{
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_return (llvm_term ret);
+  llvm_points_to out_ptr (llvm_term {{
     POINTonE1_affine_rep (if (inp@0)@1 // infinity bit // was uncompress_E1_imp inp == just (point_O E)
                           then point_O E
                           else uncompress_E1_OK inp) }});
@@ -34,176 +34,176 @@ let blst_p1_uncompress_OK_spec = do {
 
 // ... the success case
 let POINTonE1_Uncompress_BE_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
-  // crucible_precond {{ fp_invariant (uncompress_E1_x inp) }};
-  crucible_precond {{ uncompress_E1_x inp < `p }};
-  crucible_precond {{ is_square_fp (uncompress_E1_y2 inp) }};
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_points_to out_ptr (crucible_term {{
+  // llvm_precond {{ fp_invariant (uncompress_E1_x inp) }};
+  llvm_precond {{ uncompress_E1_x inp < `p }};
+  llvm_precond {{ is_square_fp (uncompress_E1_y2 inp) }};
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_points_to out_ptr (llvm_term {{
      (fp_rep (uncompress_E1_x_fp inp), fp_rep (sqrt_fp (uncompress_E1_y2 inp))) }}) ;
-  crucible_return (crucible_term {{ ((zext [sign_F_p a, HE1::sgn0 a]):Limb) where a = sqrt_fp (uncompress_E1_y2 inp) }});
+  llvm_return (llvm_term {{ ((zext [sign_F_p a, HE1::sgn0 a]):Limb) where a = sqrt_fp (uncompress_E1_y2 inp) }});
 };
 
 // ... first error case, when the given X coordinate is too large
 let POINTonE1_Uncompress_BE_BAD0_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
-  crucible_precond {{ uncompress_E1_x inp >= `p }};
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_return (crucible_term {{ (0:Limb) - `BLST_BAD_ENCODING }} );
+  llvm_precond {{ uncompress_E1_x inp >= `p }};
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_return (llvm_term {{ (0:Limb) - `BLST_BAD_ENCODING }} );
 };
 
 // ... second error case, when the X coordinate does not belong to a point on the curve
 let POINTonE1_Uncompress_BE_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
-  crucible_precond {{ uncompress_E1_x inp < `p }};
-  crucible_precond {{ ~ (is_square_fp (uncompress_E1_y2 inp)) }};
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_return (crucible_term {{ (0:Limb) - `BLST_POINT_NOT_ON_CURVE }} );
+  llvm_precond {{ uncompress_E1_x inp < `p }};
+  llvm_precond {{ ~ (is_square_fp (uncompress_E1_y2 inp)) }};
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_return (llvm_term {{ (0:Limb) - `BLST_POINT_NOT_ON_CURVE }} );
 };
 
 // Uncompress
 
 let POINTonE1_Uncompress_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
 
-  crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
-  crucible_precond {{ ~ (inp@0)@1 }}; // not point-at-infinity
-  crucible_precond {{ uncompress_E1_x inp < `p }}; // given X is not too big
-  crucible_precond {{ is_square_fp (uncompress_E1_y2 inp) }}; // and is on the curve
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_points_to out_ptr (crucible_term {{ POINTonE1_affine_rep (uncompress_E1_OK inp) }});
-  crucible_return (crucible_term {{ if uncompress_E1_x_fp inp == Fp.field_zero
+  llvm_precond {{ (inp@0)@0 }}; // only dealing with compressed points
+  llvm_precond {{ ~ (inp@0)@1 }}; // not point-at-infinity
+  llvm_precond {{ uncompress_E1_x inp < `p }}; // given X is not too big
+  llvm_precond {{ is_square_fp (uncompress_E1_y2 inp) }}; // and is on the curve
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_points_to out_ptr (llvm_term {{ POINTonE1_affine_rep (uncompress_E1_OK inp) }});
+  llvm_return (llvm_term {{ if uncompress_E1_x_fp inp == Fp.field_zero
                                     then `BLST_POINT_NOT_IN_GROUP
                                     else `BLST_SUCCESS: [32] }});
   };
 
 let POINTonE1_Uncompress_inf_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
 
-  crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
-  crucible_precond {{ (inp@0)@1 }}; // point-at-infinity
-  crucible_precond {{ ~(inp@0)@2 }}; // sign bit clear
-  crucible_precond {{ uncompress_E1_x inp == zero }};
+  llvm_precond {{ (inp@0)@0 }}; // only dealing with compressed points
+  llvm_precond {{ (inp@0)@1 }}; // point-at-infinity
+  llvm_precond {{ ~(inp@0)@2 }}; // sign bit clear
+  llvm_precond {{ uncompress_E1_x inp == zero }};
 
-  crucible_execute_func [out_ptr, in_ptr];
+  llvm_execute_func [out_ptr, in_ptr];
 
-  crucible_points_to out_ptr (crucible_term {{ POINTonE1_affine_rep (point_O E) }});
-  crucible_return (crucible_term {{ `BLST_SUCCESS: [32] }});
+  llvm_points_to out_ptr (llvm_term {{ POINTonE1_affine_rep (point_O E) }});
+  llvm_return (llvm_term {{ `BLST_SUCCESS: [32] }});
 };
 
 let POINTonE1_Uncompress_inf_BAD_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
 
-  crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
-  crucible_precond {{ (inp@0)@1 }}; // point-at-infinity
-  crucible_precond {{ (inp@0)@2 \/ uncompress_E1_x inp != zero }};
+  llvm_precond {{ (inp@0)@0 }}; // only dealing with compressed points
+  llvm_precond {{ (inp@0)@1 }}; // point-at-infinity
+  llvm_precond {{ (inp@0)@2 \/ uncompress_E1_x inp != zero }};
 
-  crucible_execute_func [out_ptr, in_ptr];
+  llvm_execute_func [out_ptr, in_ptr];
 
-  crucible_return (crucible_term {{ `BLST_BAD_ENCODING: [32] }});
+  llvm_return (llvm_term {{ `BLST_BAD_ENCODING: [32] }});
 };
 
 // We do not care about specific error codes, so...
 let POINTonE1_Uncompress_BAD_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
-  crucible_precond {{ ~ (inp@0)@1 }}; // not point-at-infinity
-  crucible_precond {{    ~ (inp@0)@0
+  llvm_precond {{ ~ (inp@0)@1 }}; // not point-at-infinity
+  llvm_precond {{    ~ (inp@0)@0
                       \/ uncompress_E1_x inp >= `p
                       \/ ~ is_square_fp (uncompress_E1_y2 inp) }}; // and is on the curve
-  crucible_execute_func [out_ptr, in_ptr];
-  ret <- crucible_fresh_var "ret_POINTonE1_Uncompress" (llvm_int 32);
-  crucible_return (crucible_term {{ ret }});
-  crucible_postcond {{ ret != `BLST_SUCCESS }};
+  llvm_execute_func [out_ptr, in_ptr];
+  ret <- llvm_fresh_var "ret_POINTonE1_Uncompress" (llvm_int 32);
+  llvm_return (llvm_term {{ ret }});
+  llvm_postcond {{ ret != `BLST_SUCCESS }};
   };
 
 let POINTonE1_Uncompress_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
-  crucible_precond {{ ~ (inp@0)@0 }}; // not compressed
-  crucible_execute_func [out_ptr, in_ptr];
-  ret <- crucible_fresh_var "ret_POINTonE1_Uncompress" (llvm_int 32);
-  crucible_return (crucible_term {{ ret }});
-  crucible_postcond {{ ret == `BLST_BAD_ENCODING }};
+  llvm_precond {{ ~ (inp@0)@0 }}; // not compressed
+  llvm_execute_func [out_ptr, in_ptr];
+  ret <- llvm_fresh_var "ret_POINTonE1_Uncompress" (llvm_int 32);
+  llvm_return (llvm_term {{ ret }});
+  llvm_postcond {{ ret == `BLST_BAD_ENCODING }};
   };
 
 // ... Deserialize (out of scope; the BLS ciphersuites use compression)
 // but some analysis is included here in case we want to include these functions later.
 
 let POINTonE1_Deserialize_BE_BAD0_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Deserialize_in" (llvm_array 96 (llvm_int 8));
-  // crucible_precond {{ deserialize_E1_x inp >= `p \/ deserialize_E1_y inp < `p }}; // given X or Y is too big
-  crucible_precond {{ deserialize_E1_x inp >= `p }}; // given X is too big
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_return (crucible_term {{ `BLST_BAD_ENCODING: [32] }});
+  // llvm_precond {{ deserialize_E1_x inp >= `p \/ deserialize_E1_y inp < `p }}; // given X or Y is too big
+  llvm_precond {{ deserialize_E1_x inp >= `p }}; // given X is too big
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_return (llvm_term {{ `BLST_BAD_ENCODING: [32] }});
   };
 
 let POINTonE1_Deserialize_BE_BAD0a_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Deserialize_in" (llvm_array 96 (llvm_int 8));
-  // crucible_precond {{ deserialize_E1_x inp >= `p \/ deserialize_E1_y inp < `p }}; // given X or Y is too big
-  crucible_precond {{ deserialize_E1_y inp >= `p }}; // given Y is too big
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_return (crucible_term {{ `BLST_BAD_ENCODING: [32] }});
+  // llvm_precond {{ deserialize_E1_x inp >= `p \/ deserialize_E1_y inp < `p }}; // given X or Y is too big
+  llvm_precond {{ deserialize_E1_y inp >= `p }}; // given Y is too big
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_return (llvm_term {{ `BLST_BAD_ENCODING: [32] }});
   };
 
 let POINTonE1_Deserialize_BE_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Deserialize_in" (llvm_array 96 (llvm_int 8));
-  crucible_precond {{ deserialize_E1_x inp < `p }}; // given X is not too big
-  crucible_precond {{ deserialize_E1_y inp < `p }}; // given Y is not too big
-  crucible_precond {{ ~ (is_point_affine E (deserialize_E1_x_fp inp, deserialize_E1_y_fp inp)) }}; // not on curve
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_return (crucible_term {{ `BLST_POINT_NOT_ON_CURVE: [32] }});
+  llvm_precond {{ deserialize_E1_x inp < `p }}; // given X is not too big
+  llvm_precond {{ deserialize_E1_y inp < `p }}; // given Y is not too big
+  llvm_precond {{ ~ (is_point_affine E (deserialize_E1_x_fp inp, deserialize_E1_y_fp inp)) }}; // not on curve
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_return (llvm_term {{ `BLST_POINT_NOT_ON_CURVE: [32] }});
   };
 
 let POINTonE1_Deserialize_BE_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Deserialize_in" (llvm_array 96 (llvm_int 8));
-  crucible_precond {{ deserialize_E1_x inp < `p }}; // given X is not too big
-  crucible_precond {{ deserialize_E1_y inp < `p }}; // given Y is not too big
-  crucible_precond {{ is_point_affine E (deserialize_E1_x_fp inp, deserialize_E1_y_fp inp) }}; // on the curve
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_points_to out_ptr (crucible_term {{
+  llvm_precond {{ deserialize_E1_x inp < `p }}; // given X is not too big
+  llvm_precond {{ deserialize_E1_y inp < `p }}; // given Y is not too big
+  llvm_precond {{ is_point_affine E (deserialize_E1_x_fp inp, deserialize_E1_y_fp inp) }}; // on the curve
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_points_to out_ptr (llvm_term {{
      (fp_rep (deserialize_E1_x_fp inp), fp_rep (deserialize_E1_y_fp inp)) }} );
   };
 
 let POINTonE1_Deserialize_BE_OK_spec' = do { // For proof debugging
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Deserialize_in" (llvm_array 96 (llvm_int 8));
-  crucible_precond {{ deserialize_E1_x inp < `p }}; // given X is not too big
-  crucible_precond {{ deserialize_E1_y inp < `p }}; // given Y is not too big
-  crucible_precond {{ is_point_affine E (deserialize_E1_x_fp inp, deserialize_E1_y_fp inp) }}; // on the curve
-  crucible_execute_func [out_ptr, in_ptr];
-  w <- crucible_fresh_var "w" (llvm_alias "struct.POINTonE1_affine");
-  crucible_points_to out_ptr (crucible_term w);
-  crucible_postcond {{ w.1 == fp_rep (deserialize_E1_y_fp inp) }};
+  llvm_precond {{ deserialize_E1_x inp < `p }}; // given X is not too big
+  llvm_precond {{ deserialize_E1_y inp < `p }}; // given Y is not too big
+  llvm_precond {{ is_point_affine E (deserialize_E1_x_fp inp, deserialize_E1_y_fp inp) }}; // on the curve
+  llvm_execute_func [out_ptr, in_ptr];
+  w <- llvm_fresh_var "w" (llvm_alias "struct.POINTonE1_affine");
+  llvm_points_to out_ptr (llvm_term w);
+  llvm_postcond {{ w.1 == fp_rep (deserialize_E1_y_fp inp) }};
   // {{ w.0 ==  fp_rep (deserialize_E1_x_fp inp) }} ?
   };
 
 // just to try:
 let blst_p1_deserialize_inf_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
-  inp <- crucible_fresh_var "p1_deserialize_in" (llvm_array 96 (llvm_int 8));
-  in_ptr <- crucible_alloc_readonly (llvm_array 96 (llvm_int 8));
-  crucible_points_to_untyped in_ptr (crucible_term inp);
-  crucible_precond {{ inp@0 && 0x80 == zero }}; // not compressed
-  crucible_precond {{ inp@0 && 0x40 != zero }}; // point at infinity
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
+  inp <- llvm_fresh_var "p1_deserialize_in" (llvm_array 96 (llvm_int 8));
+  in_ptr <- llvm_alloc_readonly (llvm_array 96 (llvm_int 8));
+  llvm_points_to_untyped in_ptr (llvm_term inp);
+  llvm_precond {{ inp@0 && 0x80 == zero }}; // not compressed
+  llvm_precond {{ inp@0 && 0x40 != zero }}; // point at infinity
 
-  crucible_execute_func [out_ptr, in_ptr];
+  llvm_execute_func [out_ptr, in_ptr];
 
-  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE1_affine");
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_conditional_points_to {{ ret == `BLST_SUCCESS }} out_ptr (crucible_term new_out);
-  crucible_postcond {{ inp@0 && 0x40 != zero /\ ([inp@0 && 0x3F]#(tail inp)) == zero ==> ret == `BLST_SUCCESS /\ new_out.0 == vec384_rep (from_Fp (point_O E).0) /\ new_out.1 == vec384_rep (from_Fp (point_O E).1) }}; // TODO spec says 0x1F and not 0x3F
-  crucible_return (crucible_term ret);
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE1_affine");
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_conditional_points_to {{ ret == `BLST_SUCCESS }} out_ptr (llvm_term new_out);
+  llvm_postcond {{ inp@0 && 0x40 != zero /\ ([inp@0 && 0x3F]#(tail inp)) == zero ==> ret == `BLST_SUCCESS /\ new_out.0 == vec384_rep (from_Fp (point_O E).0) /\ new_out.1 == vec384_rep (from_Fp (point_O E).1) }}; // TODO spec says 0x1F and not 0x3F
+  llvm_return (llvm_term ret);
 };
 
 // ... other overrides used in the proofs:
@@ -211,21 +211,21 @@ let blst_p1_deserialize_inf_spec = do {
 // Not necessary, but useful when developing a proof, to keep the SAW
 // formulas more readable.  This override also appears in keygen.saw: TODO refactor
 let limbs_from_be_bytes_spec48 = do {
-  ret_p <-crucible_alloc (llvm_array 6 limb_type);
+  ret_p <- llvm_alloc (llvm_array 6 limb_type);
   (inx, in_ptr) <- ptr_to_fresh_readonly "limbs_from_be_bytes_in"
                    (llvm_array 48 (llvm_int 8)); // "in" is a keyword
-  crucible_execute_func [ret_p, in_ptr, crucible_term {{ 48:[64] }}];
-  crucible_points_to ret_p (crucible_term {{ vec384_rep (join inx) }});
+  llvm_execute_func [ret_p, in_ptr, llvm_term {{ 48:[64] }}];
+  llvm_points_to ret_p (llvm_term {{ vec384_rep (join inx) }});
   };
 
 let blst_p2_deserialize_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array 192 (llvm_int 8));
-  crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE2_affine");
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_conditional_points_to {{ ret == zero }} out_ptr (crucible_term new_out);
-  crucible_return (crucible_term ret);
+  llvm_execute_func [out_ptr, in_ptr];
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE2_affine");
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_conditional_points_to {{ ret == zero }} out_ptr (llvm_term new_out);
+  llvm_return (llvm_term ret);
 };
 
 let {{
@@ -233,13 +233,13 @@ let {{
   }};
 
 let add_fp_noabs_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_precond {{ b == zero }}; // make sure this override is applied only where we want it.
+  llvm_precond {{ b == zero }}; // make sure this override is applied only where we want it.
 
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ add_rep a }});
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ add_rep a }});
   //  {{ if vec384_abs a < `p then a else vec384_rep ((vec384_abs a) - `p) }}) ;
 };
 

--- a/proof/deserialize-p1.saw
+++ b/proof/deserialize-p1.saw
@@ -12,7 +12,7 @@ include "blst_error.saw";
 // The main specification here is for blst_p1_uncompress
 
 let blst_p1_uncompress_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
   crucible_precond {{ uncompress_E1_imp inp != nothing }};
   crucible_execute_func [out_ptr, in_ptr];
@@ -34,7 +34,7 @@ let blst_p1_uncompress_OK_spec = do {
 
 // ... the success case
 let POINTonE1_Uncompress_BE_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
   // crucible_precond {{ fp_invariant (uncompress_E1_x inp) }};
   crucible_precond {{ uncompress_E1_x inp < `p }};
@@ -47,7 +47,7 @@ let POINTonE1_Uncompress_BE_OK_spec = do {
 
 // ... first error case, when the given X coordinate is too large
 let POINTonE1_Uncompress_BE_BAD0_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
   crucible_precond {{ uncompress_E1_x inp >= `p }};
   crucible_execute_func [out_ptr, in_ptr];
@@ -56,7 +56,7 @@ let POINTonE1_Uncompress_BE_BAD0_spec = do {
 
 // ... second error case, when the X coordinate does not belong to a point on the curve
 let POINTonE1_Uncompress_BE_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
   crucible_precond {{ uncompress_E1_x inp < `p }};
   crucible_precond {{ ~ (is_square_fp (uncompress_E1_y2 inp)) }};
@@ -67,7 +67,7 @@ let POINTonE1_Uncompress_BE_BAD1_spec = do {
 // Uncompress
 
 let POINTonE1_Uncompress_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
 
   crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
@@ -82,7 +82,7 @@ let POINTonE1_Uncompress_OK_spec = do {
   };
 
 let POINTonE1_Uncompress_inf_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
 
   crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
@@ -97,7 +97,7 @@ let POINTonE1_Uncompress_inf_OK_spec = do {
 };
 
 let POINTonE1_Uncompress_inf_BAD_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
 
   crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
@@ -111,7 +111,7 @@ let POINTonE1_Uncompress_inf_BAD_spec = do {
 
 // We do not care about specific error codes, so...
 let POINTonE1_Uncompress_BAD_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
   crucible_precond {{ ~ (inp@0)@1 }}; // not point-at-infinity
   crucible_precond {{    ~ (inp@0)@0
@@ -124,7 +124,7 @@ let POINTonE1_Uncompress_BAD_spec = do {
   };
 
 let POINTonE1_Uncompress_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Uncompress_in" (llvm_array 48 (llvm_int 8));
   crucible_precond {{ ~ (inp@0)@0 }}; // not compressed
   crucible_execute_func [out_ptr, in_ptr];
@@ -137,7 +137,7 @@ let POINTonE1_Uncompress_BAD1_spec = do {
 // but some analysis is included here in case we want to include these functions later.
 
 let POINTonE1_Deserialize_BE_BAD0_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Deserialize_in" (llvm_array 96 (llvm_int 8));
   // crucible_precond {{ deserialize_E1_x inp >= `p \/ deserialize_E1_y inp < `p }}; // given X or Y is too big
   crucible_precond {{ deserialize_E1_x inp >= `p }}; // given X is too big
@@ -146,7 +146,7 @@ let POINTonE1_Deserialize_BE_BAD0_spec = do {
   };
 
 let POINTonE1_Deserialize_BE_BAD0a_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Deserialize_in" (llvm_array 96 (llvm_int 8));
   // crucible_precond {{ deserialize_E1_x inp >= `p \/ deserialize_E1_y inp < `p }}; // given X or Y is too big
   crucible_precond {{ deserialize_E1_y inp >= `p }}; // given Y is too big
@@ -155,7 +155,7 @@ let POINTonE1_Deserialize_BE_BAD0a_spec = do {
   };
 
 let POINTonE1_Deserialize_BE_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Deserialize_in" (llvm_array 96 (llvm_int 8));
   crucible_precond {{ deserialize_E1_x inp < `p }}; // given X is not too big
   crucible_precond {{ deserialize_E1_y inp < `p }}; // given Y is not too big
@@ -165,7 +165,7 @@ let POINTonE1_Deserialize_BE_BAD1_spec = do {
   };
 
 let POINTonE1_Deserialize_BE_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Deserialize_in" (llvm_array 96 (llvm_int 8));
   crucible_precond {{ deserialize_E1_x inp < `p }}; // given X is not too big
   crucible_precond {{ deserialize_E1_y inp < `p }}; // given Y is not too big
@@ -176,13 +176,13 @@ let POINTonE1_Deserialize_BE_OK_spec = do {
   };
 
 let POINTonE1_Deserialize_BE_OK_spec' = do { // For proof debugging
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE1_Deserialize_in" (llvm_array 96 (llvm_int 8));
   crucible_precond {{ deserialize_E1_x inp < `p }}; // given X is not too big
   crucible_precond {{ deserialize_E1_y inp < `p }}; // given Y is not too big
   crucible_precond {{ is_point_affine E (deserialize_E1_x_fp inp, deserialize_E1_y_fp inp) }}; // on the curve
   crucible_execute_func [out_ptr, in_ptr];
-  w <- crucible_fresh_var "w" (llvm_struct "struct.POINTonE1_affine");
+  w <- crucible_fresh_var "w" (llvm_alias "struct.POINTonE1_affine");
   crucible_points_to out_ptr (crucible_term w);
   crucible_postcond {{ w.1 == fp_rep (deserialize_E1_y_fp inp) }};
   // {{ w.0 ==  fp_rep (deserialize_E1_x_fp inp) }} ?
@@ -190,7 +190,7 @@ let POINTonE1_Deserialize_BE_OK_spec' = do { // For proof debugging
 
 // just to try:
 let blst_p1_deserialize_inf_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   inp <- crucible_fresh_var "p1_deserialize_in" (llvm_array 96 (llvm_int 8));
   in_ptr <- crucible_alloc_readonly (llvm_array 96 (llvm_int 8));
   crucible_points_to_untyped in_ptr (crucible_term inp);
@@ -199,7 +199,7 @@ let blst_p1_deserialize_inf_spec = do {
 
   crucible_execute_func [out_ptr, in_ptr];
 
-  new_out <- crucible_fresh_var "new_out" (llvm_struct "struct.POINTonE1_affine");
+  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE1_affine");
   ret <- crucible_fresh_var "ret" (llvm_int 32);
   crucible_conditional_points_to {{ ret == `BLST_SUCCESS }} out_ptr (crucible_term new_out);
   crucible_postcond {{ inp@0 && 0x40 != zero /\ ([inp@0 && 0x3F]#(tail inp)) == zero ==> ret == `BLST_SUCCESS /\ new_out.0 == vec384_rep (from_Fp (point_O E).0) /\ new_out.1 == vec384_rep (from_Fp (point_O E).1) }}; // TODO spec says 0x1F and not 0x3F
@@ -219,10 +219,10 @@ let limbs_from_be_bytes_spec48 = do {
   };
 
 let blst_p2_deserialize_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array 192 (llvm_int 8));
   crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_out" (llvm_struct "struct.POINTonE2_affine");
+  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE2_affine");
   ret <- crucible_fresh_var "ret" (llvm_int 32);
   crucible_conditional_points_to {{ ret == zero }} out_ptr (crucible_term new_out);
   crucible_return (crucible_term ret);

--- a/proof/deserialize-p2.saw
+++ b/proof/deserialize-p2.saw
@@ -14,7 +14,7 @@ let compressed_E2_rep_type = (llvm_array 96 (llvm_int 8));
 // The main specification here is for blst_p2_uncompress
 
 let blst_p2_uncompress_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
   crucible_precond {{ uncompress_E2_imp inp != nothing }};
   crucible_execute_func [out_ptr, in_ptr];
@@ -33,7 +33,7 @@ let blst_p2_uncompress_OK_spec = do {
 
 // ... the success case
 let POINTonE2_Uncompress_BE_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
   crucible_precond {{ not_too_big_E2 (uncompress_E2_x inp) }};
   crucible_precond {{ is_square_fp2 (uncompress_E2_y2 inp) }};
@@ -46,7 +46,7 @@ let POINTonE2_Uncompress_BE_OK_spec = do {
 
 // ... first error case, when the given X coordinate is too large
 let POINTonE2_Uncompress_BE_BAD0_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
   crucible_precond {{ ~ (not_too_big_E2 (uncompress_E2_x inp))  }};
   crucible_execute_func [out_ptr, in_ptr];
@@ -55,7 +55,7 @@ let POINTonE2_Uncompress_BE_BAD0_spec = do {
 
 // ... second error case, when the X coordinate does not belong to a point on the curve
 let POINTonE2_Uncompress_BE_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
   crucible_precond {{ not_too_big_E2 (uncompress_E2_x inp)  }};
   crucible_precond {{ ~ (is_square_fp2 (uncompress_E2_y2 inp)) }};
@@ -66,7 +66,7 @@ let POINTonE2_Uncompress_BE_BAD1_spec = do {
 // Uncompress
 
 let POINTonE2_Uncompress_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
 
   crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
@@ -79,7 +79,7 @@ let POINTonE2_Uncompress_OK_spec = do {
   };
 
 let POINTonE2_Uncompress_inf_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
 
   crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
@@ -94,7 +94,7 @@ let POINTonE2_Uncompress_inf_OK_spec = do {
 };
 
 let POINTonE2_Uncompress_inf_BAD_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
 
   crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
@@ -108,7 +108,7 @@ let POINTonE2_Uncompress_inf_BAD_spec = do {
 
 // We do not care about specific error codes, so...
 let POINTonE2_Uncompress_BAD_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
   crucible_precond {{ ~ (inp@0)@1 }}; // not point-at-infinity
   crucible_precond {{    ~ (inp@0)@0
@@ -121,7 +121,7 @@ let POINTonE2_Uncompress_BAD_spec = do {
   };
 
 let POINTonE2_Uncompress_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
   crucible_precond {{ ~ (inp@0)@0 }}; // not compressed
   crucible_execute_func [out_ptr, in_ptr];
@@ -134,7 +134,7 @@ let POINTonE2_Uncompress_BAD1_spec = do {
 // but some analysis is included here in case we want to include these functions later.
 /*
 let POINTonE2_Deserialize_BE_BAD0_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Deserialize_in" (llvm_array 96 (llvm_int 8));
   // crucible_precond {{ deserialize_E2_x inp >= `p \/ deserialize_E2_y inp < `p }}; // given X or Y is too big
   crucible_precond {{ deserialize_E2_x inp >= `p }}; // given X is too big
@@ -143,7 +143,7 @@ let POINTonE2_Deserialize_BE_BAD0_spec = do {
   };
 
 let POINTonE2_Deserialize_BE_BAD0a_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Deserialize_in" (llvm_array 96 (llvm_int 8));
   // crucible_precond {{ deserialize_E2_x inp >= `p \/ deserialize_E2_y inp < `p }}; // given X or Y is too big
   crucible_precond {{ deserialize_E2_y inp >= `p }}; // given Y is too big
@@ -152,7 +152,7 @@ let POINTonE2_Deserialize_BE_BAD0a_spec = do {
   };
 
 let POINTonE2_Deserialize_BE_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Deserialize_in" (llvm_array 96 (llvm_int 8));
   crucible_precond {{ deserialize_E2_x inp < `p }}; // given X is not too big
   crucible_precond {{ deserialize_E2_y inp < `p }}; // given Y is not too big
@@ -162,7 +162,7 @@ let POINTonE2_Deserialize_BE_BAD1_spec = do {
   };
 
 let POINTonE2_Deserialize_BE_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Deserialize_in" (llvm_array 96 (llvm_int 8));
   crucible_precond {{ deserialize_E2_x inp < `p }}; // given X is not too big
   crucible_precond {{ deserialize_E2_y inp < `p }}; // given Y is not too big
@@ -173,13 +173,13 @@ let POINTonE2_Deserialize_BE_OK_spec = do {
   };
 
 let POINTonE2_Deserialize_BE_OK_spec' = do { // For proof debugging
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Deserialize_in" (llvm_array 96 (llvm_int 8));
   crucible_precond {{ deserialize_E2_x inp < `p }}; // given X is not too big
   crucible_precond {{ deserialize_E2_y inp < `p }}; // given Y is not too big
   crucible_precond {{ is_point_affine E (deserialize_E2_x_fp inp, deserialize_E2_y_fp inp) }}; // on the curve
   crucible_execute_func [out_ptr, in_ptr];
-  w <- crucible_fresh_var "w" (llvm_struct "struct.POINTonE2_affine");
+  w <- crucible_fresh_var "w" (llvm_alias "struct.POINTonE2_affine");
   crucible_points_to out_ptr (crucible_term w);
   crucible_postcond {{ w.1 == fp_rep (deserialize_E2_y_fp inp) }};
   // {{ w.0 ==  fp_rep (deserialize_E2_x_fp inp) }} ?
@@ -187,7 +187,7 @@ let POINTonE2_Deserialize_BE_OK_spec' = do { // For proof debugging
 
 // just to try:
 let blst_p2_deserialize_inf_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   inp <- crucible_fresh_var "p2_deserialize_in" (llvm_array 96 (llvm_int 8));
   in_ptr <- crucible_alloc_readonly (llvm_array 96 (llvm_int 8));
   crucible_points_to_untyped in_ptr (crucible_term inp);
@@ -196,7 +196,7 @@ let blst_p2_deserialize_inf_spec = do {
 
   crucible_execute_func [out_ptr, in_ptr];
 
-  new_out <- crucible_fresh_var "new_out" (llvm_struct "struct.POINTonE2_affine");
+  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE2_affine");
   ret <- crucible_fresh_var "ret" (llvm_int 32);
   crucible_conditional_points_to {{ ret == `BLST_SUCCESS }} out_ptr (crucible_term new_out);
   crucible_postcond {{ inp@0 && 0x40 != zero /\ ([inp@0 && 0x3F]#(tail inp)) == zero ==> ret == `BLST_SUCCESS /\ new_out.0 == vec384_rep (from_Fp (point_O E).0) /\ new_out.1 == vec384_rep (from_Fp (point_O E).1) }}; // TODO spec says 0x1F and not 0x3F

--- a/proof/deserialize-p2.saw
+++ b/proof/deserialize-p2.saw
@@ -14,15 +14,15 @@ let compressed_E2_rep_type = (llvm_array 96 (llvm_int 8));
 // The main specification here is for blst_p2_uncompress
 
 let blst_p2_uncompress_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
-  crucible_precond {{ uncompress_E2_imp inp != nothing }};
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_points_to out_ptr (crucible_term {{
+  llvm_precond {{ uncompress_E2_imp inp != nothing }};
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_points_to out_ptr (llvm_term {{
     POINTonE2_affine_rep (if (inp@0)@1 // infinity bit 
                           then point_O E'
                           else uncompress_E2_OK inp) }});
-  crucible_return (crucible_term {{`BLST_SUCCESS:[32] }});
+  llvm_return (llvm_term {{`BLST_SUCCESS:[32] }});
 };
 
 // The proof is a compostional verification, in 3 stages: first proofs about POINTonE2_Uncompress_BE,
@@ -33,174 +33,174 @@ let blst_p2_uncompress_OK_spec = do {
 
 // ... the success case
 let POINTonE2_Uncompress_BE_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
-  crucible_precond {{ not_too_big_E2 (uncompress_E2_x inp) }};
-  crucible_precond {{ is_square_fp2 (uncompress_E2_y2 inp) }};
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_points_to out_ptr (crucible_term {{
+  llvm_precond {{ not_too_big_E2 (uncompress_E2_x inp) }};
+  llvm_precond {{ is_square_fp2 (uncompress_E2_y2 inp) }};
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_points_to out_ptr (llvm_term {{
      (fp2_rep (uncompress_E2_x_fp inp), fp2_rep (sqrt_fp2 (uncompress_E2_y2 inp))) }}) ;
   // This return value is copied from sgn0_pty_mont_384x_spec
-  crucible_return (crucible_term {{ if sign_F_p_2 (sqrt_fp2 (uncompress_E2_y2 inp)) then zext 0b10 else (zero:[64]) }});
+  llvm_return (llvm_term {{ if sign_F_p_2 (sqrt_fp2 (uncompress_E2_y2 inp)) then zext 0b10 else (zero:[64]) }});
 };
 
 // ... first error case, when the given X coordinate is too large
 let POINTonE2_Uncompress_BE_BAD0_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
-  crucible_precond {{ ~ (not_too_big_E2 (uncompress_E2_x inp))  }};
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_return (crucible_term {{ (0:Limb) - `BLST_BAD_ENCODING }} );
+  llvm_precond {{ ~ (not_too_big_E2 (uncompress_E2_x inp))  }};
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_return (llvm_term {{ (0:Limb) - `BLST_BAD_ENCODING }} );
 };
 
 // ... second error case, when the X coordinate does not belong to a point on the curve
 let POINTonE2_Uncompress_BE_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
-  crucible_precond {{ not_too_big_E2 (uncompress_E2_x inp)  }};
-  crucible_precond {{ ~ (is_square_fp2 (uncompress_E2_y2 inp)) }};
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_return (crucible_term {{ (0:Limb) - `BLST_POINT_NOT_ON_CURVE }} );
+  llvm_precond {{ not_too_big_E2 (uncompress_E2_x inp)  }};
+  llvm_precond {{ ~ (is_square_fp2 (uncompress_E2_y2 inp)) }};
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_return (llvm_term {{ (0:Limb) - `BLST_POINT_NOT_ON_CURVE }} );
 };
 
 // Uncompress
 
 let POINTonE2_Uncompress_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
 
-  crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
-  crucible_precond {{ ~ (inp@0)@1 }}; // not point-at-infinity
-  crucible_precond {{ not_too_big_E2 (uncompress_E2_x inp)  }}; // not too large
-  crucible_precond {{ is_square_fp2 (uncompress_E2_y2 inp) }}; // and is on the curve
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_points_to out_ptr (crucible_term {{ POINTonE2_affine_rep (uncompress_E2_OK inp) }});
-  crucible_return (crucible_term {{ `BLST_SUCCESS: [32] }});
+  llvm_precond {{ (inp@0)@0 }}; // only dealing with compressed points
+  llvm_precond {{ ~ (inp@0)@1 }}; // not point-at-infinity
+  llvm_precond {{ not_too_big_E2 (uncompress_E2_x inp)  }}; // not too large
+  llvm_precond {{ is_square_fp2 (uncompress_E2_y2 inp) }}; // and is on the curve
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_points_to out_ptr (llvm_term {{ POINTonE2_affine_rep (uncompress_E2_OK inp) }});
+  llvm_return (llvm_term {{ `BLST_SUCCESS: [32] }});
   };
 
 let POINTonE2_Uncompress_inf_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
 
-  crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
-  crucible_precond {{ (inp@0)@1 }}; // point-at-infinity
-  crucible_precond {{ ~(inp@0)@2 }}; // sign bit clear
-  crucible_precond {{ uncompress_E2_x inp == zero }};
+  llvm_precond {{ (inp@0)@0 }}; // only dealing with compressed points
+  llvm_precond {{ (inp@0)@1 }}; // point-at-infinity
+  llvm_precond {{ ~(inp@0)@2 }}; // sign bit clear
+  llvm_precond {{ uncompress_E2_x inp == zero }};
 
-  crucible_execute_func [out_ptr, in_ptr];
+  llvm_execute_func [out_ptr, in_ptr];
 
-  crucible_points_to out_ptr (crucible_term {{ POINTonE2_affine_rep (point_O E') }});
-  crucible_return (crucible_term {{ `BLST_SUCCESS: [32] }});
+  llvm_points_to out_ptr (llvm_term {{ POINTonE2_affine_rep (point_O E') }});
+  llvm_return (llvm_term {{ `BLST_SUCCESS: [32] }});
 };
 
 let POINTonE2_Uncompress_inf_BAD_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
 
-  crucible_precond {{ (inp@0)@0 }}; // only dealing with compressed points
-  crucible_precond {{ (inp@0)@1 }}; // point-at-infinity
-  crucible_precond {{ (inp@0)@2 \/ uncompress_E2_x inp != zero }};
+  llvm_precond {{ (inp@0)@0 }}; // only dealing with compressed points
+  llvm_precond {{ (inp@0)@1 }}; // point-at-infinity
+  llvm_precond {{ (inp@0)@2 \/ uncompress_E2_x inp != zero }};
 
-  crucible_execute_func [out_ptr, in_ptr];
+  llvm_execute_func [out_ptr, in_ptr];
 
-  crucible_return (crucible_term {{ `BLST_BAD_ENCODING: [32] }});
+  llvm_return (llvm_term {{ `BLST_BAD_ENCODING: [32] }});
 };
 
 // We do not care about specific error codes, so...
 let POINTonE2_Uncompress_BAD_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
-  crucible_precond {{ ~ (inp@0)@1 }}; // not point-at-infinity
-  crucible_precond {{    ~ (inp@0)@0
+  llvm_precond {{ ~ (inp@0)@1 }}; // not point-at-infinity
+  llvm_precond {{    ~ (inp@0)@0
                       \/ ~ (not_too_big_E2 (uncompress_E2_x inp))
                       \/ ~ is_square_fp2 (uncompress_E2_y2 inp) }}; // and is on the curve
-  crucible_execute_func [out_ptr, in_ptr];
-  ret <- crucible_fresh_var "ret_POINTonE2_Uncompress" (llvm_int 32);
-  crucible_return (crucible_term {{ ret }});
-  crucible_postcond {{ ret != `BLST_SUCCESS }};
+  llvm_execute_func [out_ptr, in_ptr];
+  ret <- llvm_fresh_var "ret_POINTonE2_Uncompress" (llvm_int 32);
+  llvm_return (llvm_term {{ ret }});
+  llvm_postcond {{ ret != `BLST_SUCCESS }};
   };
 
 let POINTonE2_Uncompress_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Uncompress_in" compressed_E2_rep_type;
-  crucible_precond {{ ~ (inp@0)@0 }}; // not compressed
-  crucible_execute_func [out_ptr, in_ptr];
-  ret <- crucible_fresh_var "ret_POINTonE2_Uncompress" (llvm_int 32);
-  crucible_return (crucible_term {{ ret }});
-  crucible_postcond {{ ret == `BLST_BAD_ENCODING }};
+  llvm_precond {{ ~ (inp@0)@0 }}; // not compressed
+  llvm_execute_func [out_ptr, in_ptr];
+  ret <- llvm_fresh_var "ret_POINTonE2_Uncompress" (llvm_int 32);
+  llvm_return (llvm_term {{ ret }});
+  llvm_postcond {{ ret == `BLST_BAD_ENCODING }};
   };
 
 // ... Deserialize (out of scope; the BLS ciphersuites use compression)
 // but some analysis is included here in case we want to include these functions later.
 /*
 let POINTonE2_Deserialize_BE_BAD0_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Deserialize_in" (llvm_array 96 (llvm_int 8));
-  // crucible_precond {{ deserialize_E2_x inp >= `p \/ deserialize_E2_y inp < `p }}; // given X or Y is too big
-  crucible_precond {{ deserialize_E2_x inp >= `p }}; // given X is too big
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_return (crucible_term {{ `BLST_BAD_ENCODING: [32] }});
+  // llvm_precond {{ deserialize_E2_x inp >= `p \/ deserialize_E2_y inp < `p }}; // given X or Y is too big
+  llvm_precond {{ deserialize_E2_x inp >= `p }}; // given X is too big
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_return (llvm_term {{ `BLST_BAD_ENCODING: [32] }});
   };
 
 let POINTonE2_Deserialize_BE_BAD0a_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Deserialize_in" (llvm_array 96 (llvm_int 8));
-  // crucible_precond {{ deserialize_E2_x inp >= `p \/ deserialize_E2_y inp < `p }}; // given X or Y is too big
-  crucible_precond {{ deserialize_E2_y inp >= `p }}; // given Y is too big
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_return (crucible_term {{ `BLST_BAD_ENCODING: [32] }});
+  // llvm_precond {{ deserialize_E2_x inp >= `p \/ deserialize_E2_y inp < `p }}; // given X or Y is too big
+  llvm_precond {{ deserialize_E2_y inp >= `p }}; // given Y is too big
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_return (llvm_term {{ `BLST_BAD_ENCODING: [32] }});
   };
 
 let POINTonE2_Deserialize_BE_BAD1_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Deserialize_in" (llvm_array 96 (llvm_int 8));
-  crucible_precond {{ deserialize_E2_x inp < `p }}; // given X is not too big
-  crucible_precond {{ deserialize_E2_y inp < `p }}; // given Y is not too big
-  crucible_precond {{ ~ (is_point_affine E (deserialize_E2_x_fp inp, deserialize_E2_y_fp inp)) }}; // not on curve
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_return (crucible_term {{ `BLST_POINT_NOT_ON_CURVE: [32] }});
+  llvm_precond {{ deserialize_E2_x inp < `p }}; // given X is not too big
+  llvm_precond {{ deserialize_E2_y inp < `p }}; // given Y is not too big
+  llvm_precond {{ ~ (is_point_affine E (deserialize_E2_x_fp inp, deserialize_E2_y_fp inp)) }}; // not on curve
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_return (llvm_term {{ `BLST_POINT_NOT_ON_CURVE: [32] }});
   };
 
 let POINTonE2_Deserialize_BE_OK_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Deserialize_in" (llvm_array 96 (llvm_int 8));
-  crucible_precond {{ deserialize_E2_x inp < `p }}; // given X is not too big
-  crucible_precond {{ deserialize_E2_y inp < `p }}; // given Y is not too big
-  crucible_precond {{ is_point_affine E (deserialize_E2_x_fp inp, deserialize_E2_y_fp inp) }}; // on the curve
-  crucible_execute_func [out_ptr, in_ptr];
-  crucible_points_to out_ptr (crucible_term {{
+  llvm_precond {{ deserialize_E2_x inp < `p }}; // given X is not too big
+  llvm_precond {{ deserialize_E2_y inp < `p }}; // given Y is not too big
+  llvm_precond {{ is_point_affine E (deserialize_E2_x_fp inp, deserialize_E2_y_fp inp) }}; // on the curve
+  llvm_execute_func [out_ptr, in_ptr];
+  llvm_points_to out_ptr (llvm_term {{
      (fp_rep (deserialize_E2_x_fp inp), fp_rep (deserialize_E2_y_fp inp)) }} );
   };
 
 let POINTonE2_Deserialize_BE_OK_spec' = do { // For proof debugging
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (inp, in_ptr) <- ptr_to_fresh_readonly "POINTonE2_Deserialize_in" (llvm_array 96 (llvm_int 8));
-  crucible_precond {{ deserialize_E2_x inp < `p }}; // given X is not too big
-  crucible_precond {{ deserialize_E2_y inp < `p }}; // given Y is not too big
-  crucible_precond {{ is_point_affine E (deserialize_E2_x_fp inp, deserialize_E2_y_fp inp) }}; // on the curve
-  crucible_execute_func [out_ptr, in_ptr];
-  w <- crucible_fresh_var "w" (llvm_alias "struct.POINTonE2_affine");
-  crucible_points_to out_ptr (crucible_term w);
-  crucible_postcond {{ w.1 == fp_rep (deserialize_E2_y_fp inp) }};
+  llvm_precond {{ deserialize_E2_x inp < `p }}; // given X is not too big
+  llvm_precond {{ deserialize_E2_y inp < `p }}; // given Y is not too big
+  llvm_precond {{ is_point_affine E (deserialize_E2_x_fp inp, deserialize_E2_y_fp inp) }}; // on the curve
+  llvm_execute_func [out_ptr, in_ptr];
+  w <- llvm_fresh_var "w" (llvm_alias "struct.POINTonE2_affine");
+  llvm_points_to out_ptr (llvm_term w);
+  llvm_postcond {{ w.1 == fp_rep (deserialize_E2_y_fp inp) }};
   // {{ w.0 ==  fp_rep (deserialize_E2_x_fp inp) }} ?
   };
 
 // just to try:
 let blst_p2_deserialize_inf_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
-  inp <- crucible_fresh_var "p2_deserialize_in" (llvm_array 96 (llvm_int 8));
-  in_ptr <- crucible_alloc_readonly (llvm_array 96 (llvm_int 8));
-  crucible_points_to_untyped in_ptr (crucible_term inp);
-  crucible_precond {{ inp@0 && 0x80 == zero }}; // not compressed
-  crucible_precond {{ inp@0 && 0x40 != zero }}; // point at infinity
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
+  inp <- llvm_fresh_var "p2_deserialize_in" (llvm_array 96 (llvm_int 8));
+  in_ptr <- llvm_alloc_readonly (llvm_array 96 (llvm_int 8));
+  llvm_points_to_untyped in_ptr (llvm_term inp);
+  llvm_precond {{ inp@0 && 0x80 == zero }}; // not compressed
+  llvm_precond {{ inp@0 && 0x40 != zero }}; // point at infinity
 
-  crucible_execute_func [out_ptr, in_ptr];
+  llvm_execute_func [out_ptr, in_ptr];
 
-  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE2_affine");
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_conditional_points_to {{ ret == `BLST_SUCCESS }} out_ptr (crucible_term new_out);
-  crucible_postcond {{ inp@0 && 0x40 != zero /\ ([inp@0 && 0x3F]#(tail inp)) == zero ==> ret == `BLST_SUCCESS /\ new_out.0 == vec384_rep (from_Fp (point_O E).0) /\ new_out.1 == vec384_rep (from_Fp (point_O E).1) }}; // TODO spec says 0x1F and not 0x3F
-  crucible_return (crucible_term ret);
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE2_affine");
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_conditional_points_to {{ ret == `BLST_SUCCESS }} out_ptr (llvm_term new_out);
+  llvm_postcond {{ inp@0 && 0x40 != zero /\ ([inp@0 && 0x3F]#(tail inp)) == zero ==> ret == `BLST_SUCCESS /\ new_out.0 == vec384_rep (from_Fp (point_O E).0) /\ new_out.1 == vec384_rep (from_Fp (point_O E).1) }}; // TODO spec says 0x1F and not 0x3F
+  llvm_return (llvm_term ret);
 };
 */
 
@@ -210,20 +210,20 @@ let blst_p2_deserialize_inf_spec = do {
 // formulas more readable.  This override also appears in keygen.saw: TODO refactor
 // TODO: duplicate in deserialize-p1.saw
 let limbs_from_be_bytes_spec48 = do {
-  ret_p <-crucible_alloc (llvm_array 6 limb_type);
+  ret_p <- llvm_alloc (llvm_array 6 limb_type);
   (inx, in_ptr) <- ptr_to_fresh_readonly "limbs_from_be_bytes_in" (llvm_array 48 (llvm_int 8)); // "in" is a keyword
-  crucible_execute_func [ret_p, in_ptr, crucible_term {{ 48:[64] }}];
-  crucible_points_to ret_p (crucible_term {{ vec384_rep (join inx) }});
+  llvm_execute_func [ret_p, in_ptr, llvm_term {{ 48:[64] }}];
+  llvm_points_to ret_p (llvm_term {{ vec384_rep (join inx) }});
   };
 
 
 let sgn0_pty_mont_384x_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_precond {{ b == vec384_rep `p }};
-  crucible_execute_func [a_ptr, b_ptr, crucible_term {{0x89f3fffcfffcfffd}}];
+  llvm_precond {{ b == vec384_rep `p }};
+  llvm_execute_func [a_ptr, b_ptr, llvm_term {{0x89f3fffcfffcfffd}}];
   // TODO: Not sure what the return value should be. From what follows in the C code, it seems that the sign bit is the second bit of the return value.
-  crucible_return (crucible_term {{ (if (sign_F_p_2 (fp2_abs a)) then (zext 0b10) else zero):[64] }});
+  llvm_return (llvm_term {{ (if (sign_F_p_2 (fp2_abs a)) then (zext 0b10) else zero):[64] }});
 };
 
 

--- a/proof/deserialize.saw
+++ b/proof/deserialize.saw
@@ -9,19 +9,19 @@
 
 
 let blst_p1_deserialize_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
   (_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array 96 (llvm_int 8));
   crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_out" (llvm_struct "struct.POINTonE1_affine");
+  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE1_affine");
   ret <- crucible_fresh_var "ret" (llvm_int 32);
   crucible_conditional_points_to {{ ret == zero }} out_ptr (crucible_term new_out);
   crucible_return (crucible_term ret);
 };
 let blst_p2_deserialize_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
   (_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array 192 (llvm_int 8));
   crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_out" (llvm_struct "struct.POINTonE2_affine");
+  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE2_affine");
   ret <- crucible_fresh_var "ret" (llvm_int 32);
   crucible_conditional_points_to {{ ret == zero }} out_ptr (crucible_term new_out);
   crucible_return (crucible_term ret);

--- a/proof/deserialize.saw
+++ b/proof/deserialize.saw
@@ -9,22 +9,22 @@
 
 
 let blst_p1_deserialize_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1_affine");
   (_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array 96 (llvm_int 8));
-  crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE1_affine");
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_conditional_points_to {{ ret == zero }} out_ptr (crucible_term new_out);
-  crucible_return (crucible_term ret);
+  llvm_execute_func [out_ptr, in_ptr];
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE1_affine");
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_conditional_points_to {{ ret == zero }} out_ptr (llvm_term new_out);
+  llvm_return (llvm_term ret);
 };
 let blst_p2_deserialize_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2_affine");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2_affine");
   (_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array 192 (llvm_int 8));
-  crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE2_affine");
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_conditional_points_to {{ ret == zero }} out_ptr (crucible_term new_out);
-  crucible_return (crucible_term ret);
+  llvm_execute_func [out_ptr, in_ptr];
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE2_affine");
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_conditional_points_to {{ ret == zero }} out_ptr (llvm_term new_out);
+  llvm_return (llvm_term ret);
 };
 
 blst_p1_deserialize_ov <- verify "blst_p1_deserialize" assembly_overrides blst_p1_deserialize_spec;

--- a/proof/e2_dadd_extract.saw
+++ b/proof/e2_dadd_extract.saw
@@ -8,18 +8,18 @@ import "../spec/implementation/Types.cry";
 import "../spec/implementation/CurveOperation.cry";
 
 let POINTonE2_dadd_null_spec = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (p1, p1_ptr) <- ptr_to_fresh_readonly "p1" POINTonE2_type;
   (p2, p2_ptr) <- ptr_to_fresh_readonly "p2" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr, crucible_null];
-  new_out <- crucible_fresh_var "new_POINTonE2_add_affine_out" POINTonE2_type;
-  crucible_points_to out_ptr (crucible_term  new_out);
+  llvm_precond {{ POINTonE2_invariant p1 /\ POINTonE2_invariant p2 }};
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr, llvm_null];
+  new_out <- llvm_fresh_var "new_POINTonE2_add_affine_out" POINTonE2_type;
+  llvm_points_to out_ptr (llvm_term  new_out);
 };
 
 enable_experimental;
 
-POINTonE2_dadd_null_ov <- crucible_llvm_compositional_extract m
+POINTonE2_dadd_null_ov <- llvm_compositional_extract m
   "POINTonE2_dadd"
   "POINTonE2_dadd_term"
   (foldr concat [vec_fp2_overrides, fp2_overrides] [])

--- a/proof/ec_mult.saw
+++ b/proof/ec_mult.saw
@@ -313,11 +313,11 @@ precomputed_table_invariant_thm <- custom_prove_cryptol
 
 
 let POINTonE1_precompute_w5_spec = do {
-    row_ptr <- crucible_alloc (llvm_array 16 POINTonE1_type);
+    row_ptr <- llvm_alloc (llvm_array 16 POINTonE1_type);
     (point, point_ptr) <- ptr_to_fresh_readonly "point" POINTonE1_type;
-    crucible_precond {{ POINTonE1_invariant point }};
-    crucible_execute_func [row_ptr, point_ptr];
-    crucible_points_to row_ptr (crucible_term {{ precomputed_table (POINTonE1_abs point) }} );
+    llvm_precond {{ POINTonE1_invariant point }};
+    llvm_execute_func [row_ptr, point_ptr];
+    llvm_points_to row_ptr (llvm_term {{ precomputed_table (POINTonE1_abs point) }} );
     };
 
 POINTonE1_precompute_w5_ov <-
@@ -453,14 +453,14 @@ booth'_precomputed_table_thm <- custom_prove_cryptol
 
 
 let POINTonE1_gather_booth_w5_spec = do {
-    p_ptr <- crucible_alloc POINTonE1_type;
+    p_ptr <- llvm_alloc POINTonE1_type;
     (table, table_ptr) <- ptr_to_fresh_readonly "table" (llvm_array 16 POINTonE1_type);
-    booth_idx <- crucible_fresh_var "booth_idx" limb_type;
-    crucible_precond {{ booth_idx <= 16 \/ (-32 <= booth_idx /\ booth_idx <= -16) }}; // NB unsigned comparisons
+    booth_idx <- llvm_fresh_var "booth_idx" limb_type;
+    llvm_precond {{ booth_idx <= 16 \/ (-32 <= booth_idx /\ booth_idx <= -16) }}; // NB unsigned comparisons
     // need to assume each element of the table satisfies the invariant:
-    crucible_precond {{ all POINTonE1_invariant table }};
-    crucible_execute_func [p_ptr, table_ptr, crucible_term {{booth_idx}}];
-    crucible_points_to p_ptr (crucible_term {{ booth' table booth_idx }});
+    llvm_precond {{ all POINTonE1_invariant table }};
+    llvm_execute_func [p_ptr, table_ptr, llvm_term {{booth_idx}}];
+    llvm_points_to p_ptr (llvm_term {{ booth' table booth_idx }});
     };
 
 
@@ -562,19 +562,19 @@ let {{
   }};
 
 let POINTonE1_mult_w5_spec n_bytes bits = do {
-    ret_ptr <- crucible_alloc  POINTonE1_type;
+    ret_ptr <- llvm_alloc  POINTonE1_type;
     (point, point_ptr) <- ptr_to_fresh_readonly "point" POINTonE1_type;
     // needs alignment
-    scalar_ptr <- crucible_alloc_readonly_aligned 8 (llvm_array n_bytes (llvm_int 8));
-    scalar <- crucible_fresh_var "scalar" (llvm_array n_bytes (llvm_int 8));
-    crucible_points_to scalar_ptr (crucible_term scalar);
-    crucible_precond {{ POINTonE1_invariant point }};
-    crucible_precond {{ e1_order (affinify E (POINTonE1_abs point)) >
+    scalar_ptr <- llvm_alloc_readonly_aligned 8 (llvm_array n_bytes (llvm_int 8));
+    scalar <- llvm_fresh_var "scalar" (llvm_array n_bytes (llvm_int 8));
+    llvm_points_to scalar_ptr (llvm_term scalar);
+    llvm_precond {{ POINTonE1_invariant point }};
+    llvm_precond {{ e1_order (affinify E (POINTonE1_abs point)) >
                         scalar_value`{bits,n_bytes} scalar + shift }};
-    crucible_execute_func [ret_ptr, point_ptr, scalar_ptr, crucible_term {{`bits:Limb}}];
-    ret <- crucible_fresh_var "ret" POINTonE1_type;
-    crucible_points_to ret_ptr (crucible_term ret);
-    crucible_postcond {{ affinify E (POINTonE1_abs ret) ==
+    llvm_execute_func [ret_ptr, point_ptr, scalar_ptr, llvm_term {{`bits:Limb}}];
+    ret <- llvm_fresh_var "ret" POINTonE1_type;
+    llvm_points_to ret_ptr (llvm_term ret);
+    llvm_postcond {{ affinify E (POINTonE1_abs ret) ==
                           e1_scalar_mult (scalar_value`{bits,n_bytes} scalar)
                                          (affinify E (POINTonE1_abs point)) }};
     };

--- a/proof/ec_mult2.saw
+++ b/proof/ec_mult2.saw
@@ -199,11 +199,11 @@ precomputed_table_invariant_thm <- custom_prove_cryptol
 
 
 let POINTonE2_precompute_w5_spec = do {
-    row_ptr <- crucible_alloc (llvm_array 16 POINTonE2_type);
+    row_ptr <- llvm_alloc (llvm_array 16 POINTonE2_type);
     (point, point_ptr) <- ptr_to_fresh_readonly "point" POINTonE2_type;
-    crucible_precond {{ POINTonE2_invariant point }};
-    crucible_execute_func [row_ptr, point_ptr];
-    crucible_points_to row_ptr (crucible_term {{ precomputed_table (POINTonE2_abs point) }} );
+    llvm_precond {{ POINTonE2_invariant point }};
+    llvm_execute_func [row_ptr, point_ptr];
+    llvm_points_to row_ptr (llvm_term {{ precomputed_table (POINTonE2_abs point) }} );
     };
 
 POINTonE2_precompute_w5_ov <-
@@ -334,14 +334,14 @@ booth'_precomputed_table_thm <- custom_prove_cryptol
 
 
 let POINTonE2_gather_booth_w5_spec = do {
-    p_ptr <- crucible_alloc POINTonE2_type;
+    p_ptr <- llvm_alloc POINTonE2_type;
     (table, table_ptr) <- ptr_to_fresh_readonly "table" (llvm_array 16 POINTonE2_type);
-    booth_idx <- crucible_fresh_var "booth_idx" limb_type;
-    crucible_precond {{ booth_idx <= 16 \/ (-32 <= booth_idx /\ booth_idx <= -16) }}; // NB unsigned comparisons
+    booth_idx <- llvm_fresh_var "booth_idx" limb_type;
+    llvm_precond {{ booth_idx <= 16 \/ (-32 <= booth_idx /\ booth_idx <= -16) }}; // NB unsigned comparisons
     // need to assume each element of the table satisfies the invariant:
-    crucible_precond {{ all POINTonE2_invariant table }};
-    crucible_execute_func [p_ptr, table_ptr, crucible_term {{booth_idx}}];
-    crucible_points_to p_ptr (crucible_term {{ booth' table booth_idx }});
+    llvm_precond {{ all POINTonE2_invariant table }};
+    llvm_execute_func [p_ptr, table_ptr, llvm_term {{booth_idx}}];
+    llvm_points_to p_ptr (llvm_term {{ booth' table booth_idx }});
     };
 
 
@@ -445,19 +445,19 @@ let {{
 */
 
 let POINTonE2_mult_w5_spec n_bytes bits = do {
-    ret_ptr <- crucible_alloc  POINTonE2_type;
+    ret_ptr <- llvm_alloc  POINTonE2_type;
     (point, point_ptr) <- ptr_to_fresh_readonly "point" POINTonE2_type;
     // needs alignment
-    scalar_ptr <- crucible_alloc_readonly_aligned 8 (llvm_array n_bytes (llvm_int 8));
-    scalar <- crucible_fresh_var "scalar" (llvm_array n_bytes (llvm_int 8));
-    crucible_points_to scalar_ptr (crucible_term scalar);
-    crucible_precond {{ POINTonE2_invariant point }};
-    crucible_precond {{ e2_order (affinify E' (POINTonE2_abs point)) >
+    scalar_ptr <- llvm_alloc_readonly_aligned 8 (llvm_array n_bytes (llvm_int 8));
+    scalar <- llvm_fresh_var "scalar" (llvm_array n_bytes (llvm_int 8));
+    llvm_points_to scalar_ptr (llvm_term scalar);
+    llvm_precond {{ POINTonE2_invariant point }};
+    llvm_precond {{ e2_order (affinify E' (POINTonE2_abs point)) >
                         scalar_value`{bits,n_bytes} scalar + shift }};
-    crucible_execute_func [ret_ptr, point_ptr, scalar_ptr, crucible_term {{`bits:Limb}}];
-    ret <- crucible_fresh_var "ret" POINTonE2_type;
-    crucible_points_to ret_ptr (crucible_term ret);
-    crucible_postcond {{ affinify E' (POINTonE2_abs ret) ==
+    llvm_execute_func [ret_ptr, point_ptr, scalar_ptr, llvm_term {{`bits:Limb}}];
+    ret <- llvm_fresh_var "ret" POINTonE2_type;
+    llvm_points_to ret_ptr (llvm_term ret);
+    llvm_postcond {{ affinify E' (POINTonE2_abs ret) ==
                           e2_scalar_mult (scalar_value`{bits,n_bytes} scalar)
                                          (affinify E' (POINTonE2_abs point)) }};
     };

--- a/proof/ec_opts.saw
+++ b/proof/ec_opts.saw
@@ -7,253 +7,253 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 let POINTonE1_384_dadd_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
   (_, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384_type;
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
-  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_out);
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
+  new_POINTonE1_384_dadd_out <- llvm_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_POINTonE1_384_dadd_out);
 };
 
 let POINTonE1_384_dadd_alias_spec = do {
   (_, out_ptr) <- ptr_to_fresh "p1" (llvm_alias "struct.POINTonE1");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
   (_, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384_type;
-  crucible_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
-  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_out);
+  llvm_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
+  new_POINTonE1_384_dadd_out <- llvm_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_POINTonE1_384_dadd_out);
 };
 
 let POINTonE1_384_dadd_null_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
-  let a4_ptr = crucible_null;
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
-  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_out);
+  let a4_ptr = llvm_null;
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
+  new_POINTonE1_384_dadd_out <- llvm_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_POINTonE1_384_dadd_out);
 };
 
 let POINTonE1_384_dadd_alias_null_spec = do {
   (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE1");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
-  let a4_ptr = crucible_null;
-  crucible_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
-  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_out);
+  let a4_ptr = llvm_null;
+  llvm_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
+  new_POINTonE1_384_dadd_out <- llvm_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_POINTonE1_384_dadd_out);
 };
 
 let POINTonE1_384_dadd_alias_1_3_null_spec = do {
   (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE1");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
-  let a4_ptr = crucible_null;
-  crucible_execute_func [out_ptr, p1_ptr, out_ptr, a4_ptr];
-  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_out);
+  let a4_ptr = llvm_null;
+  llvm_execute_func [out_ptr, p1_ptr, out_ptr, a4_ptr];
+  new_POINTonE1_384_dadd_out <- llvm_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_POINTonE1_384_dadd_out);
 };
 
 let POINTonE2_384x_dadd_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
   (_, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384x_type;
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
-  new_POINTonE2_384x_dadd_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_POINTonE2_384x_dadd_out);
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
+  new_POINTonE2_384x_dadd_out <- llvm_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_POINTonE2_384x_dadd_out);
 };
 
 let POINTonE2_384x_dadd_alias_spec = do {
   (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
   (_, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384x_type;
-  crucible_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
-  new_POINTonE2_384x_dadd_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_POINTonE2_384x_dadd_out);
+  llvm_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
+  new_POINTonE2_384x_dadd_out <- llvm_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_POINTonE2_384x_dadd_out);
 };
 
 let POINTonE2_384x_dadd_alias_null_spec = do {
   (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
-  let a4_ptr = crucible_null;
-  crucible_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
-  new_POINTonE2_384x_dadd_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_POINTonE2_384x_dadd_out);
+  let a4_ptr = llvm_null;
+  llvm_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
+  new_POINTonE2_384x_dadd_out <- llvm_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_POINTonE2_384x_dadd_out);
 };
 
 let POINTonE1_384_dadd_affine_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1_affine");
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  new_POINTonE1_384_dadd_affine_out <- crucible_fresh_var "new_POINTonE1_384_dadd_affine_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_affine_out);
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr];
+  new_POINTonE1_384_dadd_affine_out <- llvm_fresh_var "new_POINTonE1_384_dadd_affine_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_POINTonE1_384_dadd_affine_out);
 };
 
 let POINTonE1_384_dadd_affine_alias_spec = do {
   (_, out_ptr) <- ptr_to_fresh "p1" (llvm_alias "struct.POINTonE1");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1_affine");
-  crucible_execute_func [out_ptr, out_ptr, p2_ptr];
-  new_POINTonE1_384_dadd_affine_out <- crucible_fresh_var "new_POINTonE1_384_dadd_affine_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_affine_out);
+  llvm_execute_func [out_ptr, out_ptr, p2_ptr];
+  new_POINTonE1_384_dadd_affine_out <- llvm_fresh_var "new_POINTonE1_384_dadd_affine_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_POINTonE1_384_dadd_affine_out);
 };
 
 let POINTonE2_384x_dadd_affine_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2_affine");
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  new_POINTonE2_384x_dadd_affine_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_affine_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_POINTonE2_384x_dadd_affine_out);
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr];
+  new_POINTonE2_384x_dadd_affine_out <- llvm_fresh_var "new_POINTonE2_384x_dadd_affine_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_POINTonE2_384x_dadd_affine_out);
 };
 
 let POINTonE2_384x_dadd_affine_alias_spec = do {
   (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2_affine");
-  crucible_execute_func [out_ptr, out_ptr, p2_ptr];
-  new_POINTonE2_384x_dadd_affine_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_affine_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_POINTonE2_384x_dadd_affine_out);
+  llvm_execute_func [out_ptr, out_ptr, p2_ptr];
+  new_POINTonE2_384x_dadd_affine_out <- llvm_fresh_var "new_POINTonE2_384x_dadd_affine_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_POINTonE2_384x_dadd_affine_out);
 };
 
 let POINTonE1_add_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  new_POINTonE1_add_out <- crucible_fresh_var "new_POINTonE1_add_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_POINTonE1_add_out);
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr];
+  new_POINTonE1_add_out <- llvm_fresh_var "new_POINTonE1_add_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_POINTonE1_add_out);
 };
 
 let POINTonE1_add_alias_spec = do {
   (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE1");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
-  crucible_execute_func [out_ptr, out_ptr, p2_ptr];
-  new_POINTonE1_add_alias_out <- crucible_fresh_var "new_POINTonE1_add_alias_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_POINTonE1_add_alias_out);
+  llvm_execute_func [out_ptr, out_ptr, p2_ptr];
+  new_POINTonE1_add_alias_out <- llvm_fresh_var "new_POINTonE1_add_alias_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_POINTonE1_add_alias_out);
 };
 
 let POINTonE1_add_alias_1_3_spec = do {
   (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE1");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
-  crucible_execute_func [out_ptr, p1_ptr, out_ptr];
-  new_POINTonE1_add_alias_1_3_out <- crucible_fresh_var "new_POINTonE1_add_alias_1_3_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_POINTonE1_add_alias_1_3_out);
+  llvm_execute_func [out_ptr, p1_ptr, out_ptr];
+  new_POINTonE1_add_alias_1_3_out <- llvm_fresh_var "new_POINTonE1_add_alias_1_3_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_POINTonE1_add_alias_1_3_out);
 };
 
 let POINTonE2_add_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
-  crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  new_POINTonE2_add_out <- crucible_fresh_var "new_POINTonE2_add_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_POINTonE2_add_out);
+  llvm_execute_func [out_ptr, p1_ptr, p2_ptr];
+  new_POINTonE2_add_out <- llvm_fresh_var "new_POINTonE2_add_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_POINTonE2_add_out);
 };
 
 let POINTonE2_add_alias_spec = do {
   (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
-  crucible_execute_func [out_ptr, out_ptr, p2_ptr];
-  new_POINTonE2_add_alias_out <- crucible_fresh_var "new_POINTonE2_add_alias_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_POINTonE2_add_alias_out);
+  llvm_execute_func [out_ptr, out_ptr, p2_ptr];
+  new_POINTonE2_add_alias_out <- llvm_fresh_var "new_POINTonE2_add_alias_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_POINTonE2_add_alias_out);
 };
 
 
 let POINTonE1_add_affine_spec = do {
-  p3_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  p3_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1_affine");
-  crucible_execute_func [p3_ptr, p1_ptr, p2_ptr];
-  new_POINTonE1_add_affine_p3 <- crucible_fresh_var "new_POINTonE1_add_affine_p3" (llvm_alias "struct.POINTonE1");
-  crucible_points_to p3_ptr (crucible_term new_POINTonE1_add_affine_p3);
+  llvm_execute_func [p3_ptr, p1_ptr, p2_ptr];
+  new_POINTonE1_add_affine_p3 <- llvm_fresh_var "new_POINTonE1_add_affine_p3" (llvm_alias "struct.POINTonE1");
+  llvm_points_to p3_ptr (llvm_term new_POINTonE1_add_affine_p3);
 };
 
 let POINTonE1_add_affine_alias_spec = do {
   (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_alias "struct.POINTonE1");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1_affine");
-  crucible_execute_func [p3_ptr, p3_ptr, p2_ptr];
-  new_POINTonE1_add_affine_alias_p3 <- crucible_fresh_var "new_POINTonE1_add_affine_alias_p3" (llvm_alias "struct.POINTonE1");
-  crucible_points_to p3_ptr (crucible_term new_POINTonE1_add_affine_alias_p3);
+  llvm_execute_func [p3_ptr, p3_ptr, p2_ptr];
+  new_POINTonE1_add_affine_alias_p3 <- llvm_fresh_var "new_POINTonE1_add_affine_alias_p3" (llvm_alias "struct.POINTonE1");
+  llvm_points_to p3_ptr (llvm_term new_POINTonE1_add_affine_alias_p3);
 };
 
 let POINTonE2_add_affine_spec = do {
-  p3_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  p3_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2_affine");
-  crucible_execute_func [p3_ptr, p1_ptr, p2_ptr];
-  new_POINTonE2_add_affine_p3 <- crucible_fresh_var "new_POINTonE2_add_affine_p3" (llvm_alias "struct.POINTonE2");
-  crucible_points_to p3_ptr (crucible_term new_POINTonE2_add_affine_p3);
+  llvm_execute_func [p3_ptr, p1_ptr, p2_ptr];
+  new_POINTonE2_add_affine_p3 <- llvm_fresh_var "new_POINTonE2_add_affine_p3" (llvm_alias "struct.POINTonE2");
+  llvm_points_to p3_ptr (llvm_term new_POINTonE2_add_affine_p3);
 };
 
 let POINTonE2_add_affine_alias_spec = do {
   (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2_affine");
-  crucible_execute_func [p3_ptr, p3_ptr, p2_ptr];
-  new_POINTonE2_add_affine_alias_p3 <- crucible_fresh_var "new_POINTonE2_add_affine_alias_p3" (llvm_alias "struct.POINTonE2");
-  crucible_points_to p3_ptr (crucible_term new_POINTonE2_add_affine_alias_p3);
+  llvm_execute_func [p3_ptr, p3_ptr, p2_ptr];
+  new_POINTonE2_add_affine_alias_p3 <- llvm_fresh_var "new_POINTonE2_add_affine_alias_p3" (llvm_alias "struct.POINTonE2");
+  llvm_points_to p3_ptr (llvm_term new_POINTonE2_add_affine_alias_p3);
 };
 
 let POINTonE1_double_spec = do {
-  p3_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  p3_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
-  crucible_execute_func [p3_ptr, p1_ptr];
-  new_POINTonE1_double_p3 <- crucible_fresh_var "new_POINTonE1_double_p3" (llvm_alias "struct.POINTonE1");
-  crucible_points_to p3_ptr (crucible_term new_POINTonE1_double_p3);
+  llvm_execute_func [p3_ptr, p1_ptr];
+  new_POINTonE1_double_p3 <- llvm_fresh_var "new_POINTonE1_double_p3" (llvm_alias "struct.POINTonE1");
+  llvm_points_to p3_ptr (llvm_term new_POINTonE1_double_p3);
 };
 
 let POINTonE1_double_alias_spec = do {
   (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_alias "struct.POINTonE1");
-  crucible_execute_func [p3_ptr, p3_ptr];
-  new_POINTonE1_double_alias_p3 <- crucible_fresh_var "new_POINTonE1_double_alias_p3" (llvm_alias "struct.POINTonE1");
-  crucible_points_to p3_ptr (crucible_term new_POINTonE1_double_alias_p3);
+  llvm_execute_func [p3_ptr, p3_ptr];
+  new_POINTonE1_double_alias_p3 <- llvm_fresh_var "new_POINTonE1_double_alias_p3" (llvm_alias "struct.POINTonE1");
+  llvm_points_to p3_ptr (llvm_term new_POINTonE1_double_alias_p3);
 };
 
 let POINTonE2_double_spec = do {
-  p3_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  p3_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
-  crucible_execute_func [p3_ptr, p1_ptr];
-  new_POINTonE2_double_p3 <- crucible_fresh_var "new_POINTonE2_double_p3" (llvm_alias "struct.POINTonE2");
-  crucible_points_to p3_ptr (crucible_term new_POINTonE2_double_p3);
+  llvm_execute_func [p3_ptr, p1_ptr];
+  new_POINTonE2_double_p3 <- llvm_fresh_var "new_POINTonE2_double_p3" (llvm_alias "struct.POINTonE2");
+  llvm_points_to p3_ptr (llvm_term new_POINTonE2_double_p3);
 };
 
 let POINTonE2_double_alias_spec = do {
   (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_alias "struct.POINTonE2");
-  crucible_execute_func [p3_ptr, p3_ptr];
-  new_POINTonE2_double_alias_p3 <- crucible_fresh_var "new_POINTonE2_double_alias_p3" (llvm_alias "struct.POINTonE2");
-  crucible_points_to p3_ptr (crucible_term new_POINTonE2_double_alias_p3);
+  llvm_execute_func [p3_ptr, p3_ptr];
+  new_POINTonE2_double_alias_p3 <- llvm_fresh_var "new_POINTonE2_double_alias_p3" (llvm_alias "struct.POINTonE2");
+  llvm_points_to p3_ptr (llvm_term new_POINTonE2_double_alias_p3);
 };
 
 let POINTonE1_is_equal_spec = do {
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
-  crucible_execute_func [p1_ptr, p2_ptr];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_return (crucible_term ret);
+  llvm_execute_func [p1_ptr, p2_ptr];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 
 let POINTonE2_is_equal_spec = do {
   (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
   (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
-  crucible_execute_func [p1_ptr, p2_ptr];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_return (crucible_term ret);
+  llvm_execute_func [p1_ptr, p2_ptr];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 
 let POINTonE1_mult_w5_spec nbits = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, point_ptr) <- ptr_to_fresh_readonly "point" (llvm_alias "struct.POINTonE1");
   (_, scalar_ptr) <- ptr_to_fresh_readonly "scalar" (llvm_array (eval_size {| nbits /^ 8 |}) (llvm_int 8));
-  crucible_execute_func [out_ptr, point_ptr, scalar_ptr, crucible_term {{`nbits:[64]}}];
-  new_out <- crucible_fresh_var "new_POINTonE1_mult_w5_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, point_ptr, scalar_ptr, llvm_term {{`nbits:[64]}}];
+  new_out <- llvm_fresh_var "new_POINTonE1_mult_w5_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 
 let POINTonE2_mult_w5_spec nbits = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   (_, point_ptr) <- ptr_to_fresh_readonly "point" (llvm_alias "struct.POINTonE2");
   (_, scalar_ptr) <- ptr_to_fresh_readonly "scalar" (llvm_array (eval_size {| nbits /^ 8 |}) (llvm_int 8));
-  crucible_execute_func [out_ptr, point_ptr, scalar_ptr, crucible_term {{`nbits:[64]}}];
-  new_out <- crucible_fresh_var "new_POINTonE2_mult_w5_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, point_ptr, scalar_ptr, llvm_term {{`nbits:[64]}}];
+  new_out <- llvm_fresh_var "new_POINTonE2_mult_w5_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 ///////////////////////////////////////////////////////////////////////////////
 // Proofs

--- a/proof/ec_opts.saw
+++ b/proof/ec_opts.saw
@@ -7,252 +7,252 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 let POINTonE1_384_dadd_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE1");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
   (_, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384_type;
   crucible_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
-  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_out);
 };
 
 let POINTonE1_384_dadd_alias_spec = do {
-  (_, out_ptr) <- ptr_to_fresh "p1" (llvm_struct "struct.POINTonE1");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1");
+  (_, out_ptr) <- ptr_to_fresh "p1" (llvm_alias "struct.POINTonE1");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
   (_, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384_type;
   crucible_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
-  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_out);
 };
 
 let POINTonE1_384_dadd_null_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE1");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
   let a4_ptr = crucible_null;
   crucible_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
-  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_out);
 };
 
 let POINTonE1_384_dadd_alias_null_spec = do {
-  (_, out_ptr) <- ptr_to_fresh "out" (llvm_struct "struct.POINTonE1");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1");
+  (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE1");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
   let a4_ptr = crucible_null;
   crucible_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
-  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_out);
 };
 
 let POINTonE1_384_dadd_alias_1_3_null_spec = do {
-  (_, out_ptr) <- ptr_to_fresh "out" (llvm_struct "struct.POINTonE1");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE1");
+  (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE1");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
   let a4_ptr = crucible_null;
   crucible_execute_func [out_ptr, p1_ptr, out_ptr, a4_ptr];
-  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_384_dadd_out <- crucible_fresh_var "new_POINTonE1_384_dadd_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_out);
 };
 
 let POINTonE2_384x_dadd_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
   (_, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384x_type;
   crucible_execute_func [out_ptr, p1_ptr, p2_ptr, a4_ptr];
-  new_POINTonE2_384x_dadd_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_384x_dadd_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_POINTonE2_384x_dadd_out);
 };
 
 let POINTonE2_384x_dadd_alias_spec = do {
-  (_, out_ptr) <- ptr_to_fresh "out" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2");
+  (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
   (_, a4_ptr) <- ptr_to_fresh_readonly "a4" vec384x_type;
   crucible_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
-  new_POINTonE2_384x_dadd_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_384x_dadd_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_POINTonE2_384x_dadd_out);
 };
 
 let POINTonE2_384x_dadd_alias_null_spec = do {
-  (_, out_ptr) <- ptr_to_fresh "out" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2");
+  (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
   let a4_ptr = crucible_null;
   crucible_execute_func [out_ptr, out_ptr, p2_ptr, a4_ptr];
-  new_POINTonE2_384x_dadd_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_384x_dadd_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_POINTonE2_384x_dadd_out);
 };
 
 let POINTonE1_384_dadd_affine_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE1");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1_affine");
   crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  new_POINTonE1_384_dadd_affine_out <- crucible_fresh_var "new_POINTonE1_384_dadd_affine_out" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_384_dadd_affine_out <- crucible_fresh_var "new_POINTonE1_384_dadd_affine_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_affine_out);
 };
 
 let POINTonE1_384_dadd_affine_alias_spec = do {
-  (_, out_ptr) <- ptr_to_fresh "p1" (llvm_struct "struct.POINTonE1");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1_affine");
+  (_, out_ptr) <- ptr_to_fresh "p1" (llvm_alias "struct.POINTonE1");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1_affine");
   crucible_execute_func [out_ptr, out_ptr, p2_ptr];
-  new_POINTonE1_384_dadd_affine_out <- crucible_fresh_var "new_POINTonE1_384_dadd_affine_out" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_384_dadd_affine_out <- crucible_fresh_var "new_POINTonE1_384_dadd_affine_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_POINTonE1_384_dadd_affine_out);
 };
 
 let POINTonE2_384x_dadd_affine_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2_affine");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2_affine");
   crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  new_POINTonE2_384x_dadd_affine_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_affine_out" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_384x_dadd_affine_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_affine_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_POINTonE2_384x_dadd_affine_out);
 };
 
 let POINTonE2_384x_dadd_affine_alias_spec = do {
-  (_, out_ptr) <- ptr_to_fresh "out" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2_affine");
+  (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2_affine");
   crucible_execute_func [out_ptr, out_ptr, p2_ptr];
-  new_POINTonE2_384x_dadd_affine_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_affine_out" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_384x_dadd_affine_out <- crucible_fresh_var "new_POINTonE2_384x_dadd_affine_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_POINTonE2_384x_dadd_affine_out);
 };
 
 let POINTonE1_add_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE1");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
   crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  new_POINTonE1_add_out <- crucible_fresh_var "new_POINTonE1_add_out" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_add_out <- crucible_fresh_var "new_POINTonE1_add_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_POINTonE1_add_out);
 };
 
 let POINTonE1_add_alias_spec = do {
-  (_, out_ptr) <- ptr_to_fresh "out" (llvm_struct "struct.POINTonE1");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1");
+  (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE1");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
   crucible_execute_func [out_ptr, out_ptr, p2_ptr];
-  new_POINTonE1_add_alias_out <- crucible_fresh_var "new_POINTonE1_add_alias_out" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_add_alias_out <- crucible_fresh_var "new_POINTonE1_add_alias_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_POINTonE1_add_alias_out);
 };
 
 let POINTonE1_add_alias_1_3_spec = do {
-  (_, out_ptr) <- ptr_to_fresh "out" (llvm_struct "struct.POINTonE1");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1");
+  (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE1");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1");
   crucible_execute_func [out_ptr, p1_ptr, out_ptr];
-  new_POINTonE1_add_alias_1_3_out <- crucible_fresh_var "new_POINTonE1_add_alias_1_3_out" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_add_alias_1_3_out <- crucible_fresh_var "new_POINTonE1_add_alias_1_3_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_POINTonE1_add_alias_1_3_out);
 };
 
 let POINTonE2_add_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
   crucible_execute_func [out_ptr, p1_ptr, p2_ptr];
-  new_POINTonE2_add_out <- crucible_fresh_var "new_POINTonE2_add_out" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_add_out <- crucible_fresh_var "new_POINTonE2_add_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_POINTonE2_add_out);
 };
 
 let POINTonE2_add_alias_spec = do {
-  (_, out_ptr) <- ptr_to_fresh "out" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2");
+  (_, out_ptr) <- ptr_to_fresh "out" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
   crucible_execute_func [out_ptr, out_ptr, p2_ptr];
-  new_POINTonE2_add_alias_out <- crucible_fresh_var "new_POINTonE2_add_alias_out" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_add_alias_out <- crucible_fresh_var "new_POINTonE2_add_alias_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_POINTonE2_add_alias_out);
 };
 
 
 let POINTonE1_add_affine_spec = do {
-  p3_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE1");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1_affine");
+  p3_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1_affine");
   crucible_execute_func [p3_ptr, p1_ptr, p2_ptr];
-  new_POINTonE1_add_affine_p3 <- crucible_fresh_var "new_POINTonE1_add_affine_p3" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_add_affine_p3 <- crucible_fresh_var "new_POINTonE1_add_affine_p3" (llvm_alias "struct.POINTonE1");
   crucible_points_to p3_ptr (crucible_term new_POINTonE1_add_affine_p3);
 };
 
 let POINTonE1_add_affine_alias_spec = do {
-  (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_struct "struct.POINTonE1");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE1_affine");
+  (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_alias "struct.POINTonE1");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE1_affine");
   crucible_execute_func [p3_ptr, p3_ptr, p2_ptr];
-  new_POINTonE1_add_affine_alias_p3 <- crucible_fresh_var "new_POINTonE1_add_affine_alias_p3" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_add_affine_alias_p3 <- crucible_fresh_var "new_POINTonE1_add_affine_alias_p3" (llvm_alias "struct.POINTonE1");
   crucible_points_to p3_ptr (crucible_term new_POINTonE1_add_affine_alias_p3);
 };
 
 let POINTonE2_add_affine_spec = do {
-  p3_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2_affine");
+  p3_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2_affine");
   crucible_execute_func [p3_ptr, p1_ptr, p2_ptr];
-  new_POINTonE2_add_affine_p3 <- crucible_fresh_var "new_POINTonE2_add_affine_p3" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_add_affine_p3 <- crucible_fresh_var "new_POINTonE2_add_affine_p3" (llvm_alias "struct.POINTonE2");
   crucible_points_to p3_ptr (crucible_term new_POINTonE2_add_affine_p3);
 };
 
 let POINTonE2_add_affine_alias_spec = do {
-  (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2_affine");
+  (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2_affine");
   crucible_execute_func [p3_ptr, p3_ptr, p2_ptr];
-  new_POINTonE2_add_affine_alias_p3 <- crucible_fresh_var "new_POINTonE2_add_affine_alias_p3" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_add_affine_alias_p3 <- crucible_fresh_var "new_POINTonE2_add_affine_alias_p3" (llvm_alias "struct.POINTonE2");
   crucible_points_to p3_ptr (crucible_term new_POINTonE2_add_affine_alias_p3);
 };
 
 let POINTonE1_double_spec = do {
-  p3_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE1");
+  p3_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE1");
   crucible_execute_func [p3_ptr, p1_ptr];
-  new_POINTonE1_double_p3 <- crucible_fresh_var "new_POINTonE1_double_p3" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_double_p3 <- crucible_fresh_var "new_POINTonE1_double_p3" (llvm_alias "struct.POINTonE1");
   crucible_points_to p3_ptr (crucible_term new_POINTonE1_double_p3);
 };
 
 let POINTonE1_double_alias_spec = do {
-  (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_struct "struct.POINTonE1");
+  (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_alias "struct.POINTonE1");
   crucible_execute_func [p3_ptr, p3_ptr];
-  new_POINTonE1_double_alias_p3 <- crucible_fresh_var "new_POINTonE1_double_alias_p3" (llvm_struct "struct.POINTonE1");
+  new_POINTonE1_double_alias_p3 <- crucible_fresh_var "new_POINTonE1_double_alias_p3" (llvm_alias "struct.POINTonE1");
   crucible_points_to p3_ptr (crucible_term new_POINTonE1_double_alias_p3);
 };
 
 let POINTonE2_double_spec = do {
-  p3_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2");
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE2");
+  p3_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
   crucible_execute_func [p3_ptr, p1_ptr];
-  new_POINTonE2_double_p3 <- crucible_fresh_var "new_POINTonE2_double_p3" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_double_p3 <- crucible_fresh_var "new_POINTonE2_double_p3" (llvm_alias "struct.POINTonE2");
   crucible_points_to p3_ptr (crucible_term new_POINTonE2_double_p3);
 };
 
 let POINTonE2_double_alias_spec = do {
-  (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_struct "struct.POINTonE2");
+  (_, p3_ptr) <- ptr_to_fresh "p3" (llvm_alias "struct.POINTonE2");
   crucible_execute_func [p3_ptr, p3_ptr];
-  new_POINTonE2_double_alias_p3 <- crucible_fresh_var "new_POINTonE2_double_alias_p3" (llvm_struct "struct.POINTonE2");
+  new_POINTonE2_double_alias_p3 <- crucible_fresh_var "new_POINTonE2_double_alias_p3" (llvm_alias "struct.POINTonE2");
   crucible_points_to p3_ptr (crucible_term new_POINTonE2_double_alias_p3);
 };
 
 let POINTonE1_is_equal_spec = do {
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
   crucible_execute_func [p1_ptr, p2_ptr];
   ret <- crucible_fresh_var "ret" limb_type;
   crucible_return (crucible_term ret);
 };
 
 let POINTonE2_is_equal_spec = do {
-  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_struct "struct.POINTonE2");
-  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_struct "struct.POINTonE2");
+  (_, p1_ptr) <- ptr_to_fresh_readonly "p1" (llvm_alias "struct.POINTonE2");
+  (_, p2_ptr) <- ptr_to_fresh_readonly "p2" (llvm_alias "struct.POINTonE2");
   crucible_execute_func [p1_ptr, p2_ptr];
   ret <- crucible_fresh_var "ret" limb_type;
   crucible_return (crucible_term ret);
 };
 
 let POINTonE1_mult_w5_spec nbits = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
-  (_, point_ptr) <- ptr_to_fresh_readonly "point" (llvm_struct "struct.POINTonE1");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  (_, point_ptr) <- ptr_to_fresh_readonly "point" (llvm_alias "struct.POINTonE1");
   (_, scalar_ptr) <- ptr_to_fresh_readonly "scalar" (llvm_array (eval_size {| nbits /^ 8 |}) (llvm_int 8));
   crucible_execute_func [out_ptr, point_ptr, scalar_ptr, crucible_term {{`nbits:[64]}}];
-  new_out <- crucible_fresh_var "new_POINTonE1_mult_w5_out" (llvm_struct "struct.POINTonE1");
+  new_out <- crucible_fresh_var "new_POINTonE1_mult_w5_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_out);
 };
 
 let POINTonE2_mult_w5_spec nbits = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2");
-  (_, point_ptr) <- ptr_to_fresh_readonly "point" (llvm_struct "struct.POINTonE2");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  (_, point_ptr) <- ptr_to_fresh_readonly "point" (llvm_alias "struct.POINTonE2");
   (_, scalar_ptr) <- ptr_to_fresh_readonly "scalar" (llvm_array (eval_size {| nbits /^ 8 |}) (llvm_int 8));
   crucible_execute_func [out_ptr, point_ptr, scalar_ptr, crucible_term {{`nbits:[64]}}];
-  new_out <- crucible_fresh_var "new_POINTonE2_mult_w5_out" (llvm_struct "struct.POINTonE2");
+  new_out <- crucible_fresh_var "new_POINTonE2_mult_w5_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_out);
 };
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/exp.saw
+++ b/proof/exp.saw
@@ -10,17 +10,17 @@ let mul_mont_384_alias_spec = do { // NOTE: first two args are aliases
   (ret, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   (p, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_precond {{ p ==  BLS12_381_p }} ;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term {{ p0 }} ];
-  crucible_points_to ret_ptr (crucible_term {{fp_rep (Fp.mul (fp_abs ret, fp_abs b))}});
+  llvm_precond {{ p ==  BLS12_381_p }} ;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term {{ p0 }} ];
+  llvm_points_to ret_ptr (llvm_term {{fp_rep (Fp.mul (fp_abs ret, fp_abs b))}});
 };
 
 let sqr_mont_384_alias_spec = do { // NOTE: first two args are aliases
   (ret, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (p, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_precond {{ p ==  BLS12_381_p }} ;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term {{ p0 }} ];
-  crucible_points_to ret_ptr (crucible_term {{fp_rep (Fp.sq (fp_abs ret))}});
+  llvm_precond {{ p ==  BLS12_381_p }} ;
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, llvm_term {{ p0 }} ];
+  llvm_points_to ret_ptr (llvm_term {{fp_rep (Fp.sq (fp_abs ret))}});
 };
 
 // "is_bit_set" indexes bytes naturally (v[0], then v[1], etc), and bits from the least significant.
@@ -32,20 +32,20 @@ let {{ BLS12_381_p = [ 0xb9feffffffffaaab, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f62
 
 
 let exp_mont_384_spec n_bytes <- do {
-    out_ptr <- crucible_alloc vec384;
+    out_ptr <- llvm_alloc vec384;
     (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384;
     (pow, pow_ptr) <- ptr_to_fresh_readonly "inp" (llvm_array n_bytes (llvm_int 8));
-    pow_bits <- crucible_fresh_var "pow_bits" size_t;
+    pow_bits <- llvm_fresh_var "pow_bits" size_t;
     (p, p_ptr) <- ptr_to_fresh_readonly "p" vec384;
-    crucible_precond {{ p == BLS12_381_p }};
-    crucible_precond {{ fp_invariant inp }};
-    crucible_precond {{ pow_bits < 8*n_bytes }}; // otherwise we get indexing errors
-    crucible_precond {{ (join pow)!pow_bits }}; // pow_bits marks the most significant 1 bit
-    // crucible_precond {{ ... all 0 bits above pow_bit? }};
-    crucible_execute_func [ out_ptr, inp_ptr, pow_ptr, crucible_term pow_bits
-                          , p_ptr, crucible_term {{ p0:Limb }}];
-    crucible_points_to out_ptr
-      (crucible_term {{ fp_rep (F_expt Fp (fp_abs inp) pow) }});
+    llvm_precond {{ p == BLS12_381_p }};
+    llvm_precond {{ fp_invariant inp }};
+    llvm_precond {{ pow_bits < 8*n_bytes }}; // otherwise we get indexing errors
+    llvm_precond {{ (join pow)!pow_bits }}; // pow_bits marks the most significant 1 bit
+    // llvm_precond {{ ... all 0 bits above pow_bit? }};
+    llvm_execute_func [ out_ptr, inp_ptr, pow_ptr, llvm_term pow_bits
+                          , p_ptr, llvm_term {{ p0:Limb }}];
+    llvm_points_to out_ptr
+      (llvm_term {{ fp_rep (F_expt Fp (fp_abs inp) pow) }});
     };
 
 */
@@ -87,22 +87,22 @@ let {{
   }};
 
 let sqr_n_mul_fp_spec = do {
-    out_ptr <- crucible_alloc vec384_type;
+    out_ptr <- llvm_alloc vec384_type;
     (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-    count <- crucible_fresh_var "count" size_type;
+    count <- llvm_fresh_var "count" size_type;
     (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-    crucible_precond {{ count > 0 }};
-    crucible_execute_func [out_ptr, a_ptr, crucible_term count, b_ptr];
-    crucible_points_to out_ptr (crucible_term {{ fp_rep (sqr_n_mul (fp_abs a) count (fp_abs b)) }});
+    llvm_precond {{ count > 0 }};
+    llvm_execute_func [out_ptr, a_ptr, llvm_term count, b_ptr];
+    llvm_points_to out_ptr (llvm_term {{ fp_rep (sqr_n_mul (fp_abs a) count (fp_abs b)) }});
     };
 
 let sqr_n_mul_fp_alias_1_2_spec = do {
     (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-    count <- crucible_fresh_var "count" size_type;
+    count <- llvm_fresh_var "count" size_type;
     (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-    crucible_precond {{ count > 0 }};
-    crucible_execute_func [a_ptr, a_ptr, crucible_term count, b_ptr];
-    crucible_points_to a_ptr (crucible_term {{ fp_rep (sqr_n_mul (fp_abs a) count (fp_abs b)) }});
+    llvm_precond {{ count > 0 }};
+    llvm_execute_func [a_ptr, a_ptr, llvm_term count, b_ptr];
+    llvm_points_to a_ptr (llvm_term {{ fp_rep (sqr_n_mul (fp_abs a) count (fp_abs b)) }});
     };
 
 sqr_n_mul_fp_ov <- admit "sqr_n_mul_fp" sqr_n_mul_fp_spec;
@@ -121,22 +121,22 @@ let ovs_for_reciprocal =
 recip_fp_algebra_thm <- admit_cryptol {{ \x -> inverse_fp x == fp_exp x (`p-2) }};
 
 let reciprocal_fp_spec = do {
-    out_ptr <- crucible_alloc vec384_type;
+    out_ptr <- llvm_alloc vec384_type;
     (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384_type;
-    crucible_precond {{ fp_invariant inp }};
-    crucible_execute_func [out_ptr, inp_ptr];
-    // crucible_points_to out_ptr (crucible_term {{ fp_rep (fp_exp (fp_abs inp) (`p-2)) }});
-    // crucible_points_to out_ptr (crucible_term {{ fp_rep (Fp.div (Fp.field_unit, fp_abs inp)) }});
-    crucible_points_to out_ptr (crucible_term {{ fp_rep (inverse_fp (fp_abs inp)) }});
+    llvm_precond {{ fp_invariant inp }};
+    llvm_execute_func [out_ptr, inp_ptr];
+    // llvm_points_to out_ptr (llvm_term {{ fp_rep (fp_exp (fp_abs inp) (`p-2)) }});
+    // llvm_points_to out_ptr (llvm_term {{ fp_rep (Fp.div (Fp.field_unit, fp_abs inp)) }});
+    llvm_points_to out_ptr (llvm_term {{ fp_rep (inverse_fp (fp_abs inp)) }});
     };
 
 let reciprocal_fp_alias_spec = do {
     (inp, inp_ptr) <- ptr_to_fresh "inp" vec384_type;
-    crucible_precond {{ fp_invariant inp }};
-    crucible_execute_func [inp_ptr, inp_ptr];
-    // crucible_points_to out_ptr (crucible_term {{ fp_rep (fp_exp (fp_abs inp) (`p-2)) }});
-    // crucible_points_to out_ptr (crucible_term {{ fp_rep (Fp.div (Fp.field_unit, fp_abs inp)) }});
-    crucible_points_to inp_ptr (crucible_term {{ fp_rep (inverse_fp (fp_abs inp)) }});
+    llvm_precond {{ fp_invariant inp }};
+    llvm_execute_func [inp_ptr, inp_ptr];
+    // llvm_points_to out_ptr (llvm_term {{ fp_rep (fp_exp (fp_abs inp) (`p-2)) }});
+    // llvm_points_to out_ptr (llvm_term {{ fp_rep (Fp.div (Fp.field_unit, fp_abs inp)) }});
+    llvm_points_to inp_ptr (llvm_term {{ fp_rep (inverse_fp (fp_abs inp)) }});
     };
 
 reciprocal_fp_ov <- custom_verify "reciprocal_fp"
@@ -172,22 +172,22 @@ is_square_fp_thm <- admit_cryptol
   {{ \x -> is_square_fp x == (x == Fp.sq (sqrt_fp x)) }} ;
 
 let recip_sqrt_fp_spec = do {
-    out_ptr <- crucible_alloc vec384_type;
+    out_ptr <- llvm_alloc vec384_type;
     (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384_type;
-    crucible_precond {{ fp_invariant inp }};
-    crucible_execute_func [out_ptr, inp_ptr];
-    // crucible_points_to out_ptr (crucible_term {{ fp_rep (fp_exp (fp_abs inp) ((`p-3)/4)) }});
-    crucible_points_to out_ptr (crucible_term {{fp_rep (Fp.div (Fp.field_unit, sqrt_fp (fp_abs inp))) }});
-    crucible_return (crucible_term {{ if is_square_fp (fp_abs inp) then 1:Limb else 0 }});
+    llvm_precond {{ fp_invariant inp }};
+    llvm_execute_func [out_ptr, inp_ptr];
+    // llvm_points_to out_ptr (llvm_term {{ fp_rep (fp_exp (fp_abs inp) ((`p-3)/4)) }});
+    llvm_points_to out_ptr (llvm_term {{fp_rep (Fp.div (Fp.field_unit, sqrt_fp (fp_abs inp))) }});
+    llvm_return (llvm_term {{ if is_square_fp (fp_abs inp) then 1:Limb else 0 }});
     };
 
 let recip_sqrt_fp_alias_spec = do {
     (out, out_ptr) <- ptr_to_fresh "out" vec384_type;
-    crucible_precond {{ fp_invariant out }};
-    crucible_execute_func [out_ptr, out_ptr];
-    // crucible_points_to out_ptr (crucible_term {{ fp_rep (fp_exp (fp_abs inp) ((`p-3)/4)) }});
-    crucible_points_to out_ptr (crucible_term {{fp_rep (Fp.div (Fp.field_unit, sqrt_fp (fp_abs out))) }});
-    crucible_return (crucible_term {{ if is_square_fp (fp_abs out) then 1:Limb else 0 }});
+    llvm_precond {{ fp_invariant out }};
+    llvm_execute_func [out_ptr, out_ptr];
+    // llvm_points_to out_ptr (llvm_term {{ fp_rep (fp_exp (fp_abs inp) ((`p-3)/4)) }});
+    llvm_points_to out_ptr (llvm_term {{fp_rep (Fp.div (Fp.field_unit, sqrt_fp (fp_abs out))) }});
+    llvm_return (llvm_term {{ if is_square_fp (fp_abs out) then 1:Limb else 0 }});
     };
 
 recip_sqrt_fp_ov <- custom_verify "recip_sqrt_fp"
@@ -216,21 +216,21 @@ recip_sqrt_fp_alias_ov <- custom_verify "recip_sqrt_fp"
 // ... sqrt_fp
 
 let sqrt_fp_spec = do {
-    out_ptr <- crucible_alloc vec384_type;
+    out_ptr <- llvm_alloc vec384_type;
     (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384_type;
-    crucible_precond {{ fp_invariant inp }};
-    crucible_execute_func [out_ptr, inp_ptr];
-    // crucible_points_to out_ptr (crucible_term {{ fp_rep (fp_exp (fp_abs inp) ((`p+1)/4)) }});
-    crucible_points_to out_ptr (crucible_term {{ fp_rep (sqrt_fp (fp_abs inp)) }});
-    crucible_return (crucible_term {{ if is_square_fp (fp_abs inp) then 1:Limb else 0 }});
+    llvm_precond {{ fp_invariant inp }};
+    llvm_execute_func [out_ptr, inp_ptr];
+    // llvm_points_to out_ptr (llvm_term {{ fp_rep (fp_exp (fp_abs inp) ((`p+1)/4)) }});
+    llvm_points_to out_ptr (llvm_term {{ fp_rep (sqrt_fp (fp_abs inp)) }});
+    llvm_return (llvm_term {{ if is_square_fp (fp_abs inp) then 1:Limb else 0 }});
 };
 
 let sqrt_fp_alias_spec = do {
     (out, out_ptr) <- ptr_to_fresh "out" vec384_type;
-    crucible_precond {{ fp_invariant out }};
-    crucible_execute_func [out_ptr, out_ptr];
-    crucible_points_to out_ptr (crucible_term {{ fp_rep (sqrt_fp (fp_abs out)) }});
-    crucible_return (crucible_term {{ if is_square_fp (fp_abs out) then 1:Limb else 0 }});
+    llvm_precond {{ fp_invariant out }};
+    llvm_execute_func [out_ptr, out_ptr];
+    llvm_points_to out_ptr (llvm_term {{ fp_rep (sqrt_fp (fp_abs out)) }});
+    llvm_return (llvm_term {{ if is_square_fp (fp_abs out) then 1:Limb else 0 }});
 };
 
 let verify_sqrt_fp spec = custom_verify "sqrt_fp"

--- a/proof/exp2.saw
+++ b/proof/exp2.saw
@@ -152,22 +152,22 @@ let {{
   }};
 
 let sqr_n_mul_fp2_spec = do {
-  out_ptr <- crucible_alloc vec384x_type;
+  out_ptr <- llvm_alloc vec384x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
-  count <- crucible_fresh_var "count" size_type;
+  count <- llvm_fresh_var "count" size_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
-  crucible_precond {{ count > 0 }};
-  crucible_execute_func [out_ptr, a_ptr, crucible_term count, b_ptr];
-  crucible_points_to out_ptr (crucible_term {{ fp2_rep (sqr_n_mul_fp2 (fp2_abs a) count (fp2_abs b)) }});
+  llvm_precond {{ count > 0 }};
+  llvm_execute_func [out_ptr, a_ptr, llvm_term count, b_ptr];
+  llvm_points_to out_ptr (llvm_term {{ fp2_rep (sqr_n_mul_fp2 (fp2_abs a) count (fp2_abs b)) }});
   };
 
 let sqr_n_mul_fp2_alias_1_2_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
-  count <- crucible_fresh_var "count" size_type;
+  count <- llvm_fresh_var "count" size_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
-  crucible_precond {{ count > 0 }};
-  crucible_execute_func [a_ptr, a_ptr, crucible_term count, b_ptr];
-  crucible_points_to a_ptr (crucible_term {{ fp2_rep (sqr_n_mul_fp2 (fp2_abs a) count (fp2_abs b)) }});
+  llvm_precond {{ count > 0 }};
+  llvm_execute_func [a_ptr, a_ptr, llvm_term count, b_ptr];
+  llvm_points_to a_ptr (llvm_term {{ fp2_rep (sqr_n_mul_fp2 (fp2_abs a) count (fp2_abs b)) }});
   };
 
 let recip_sqrt_fp2_9mod16_spec = fp2_unop_spec "recip_sqrt_fp2_9mod16" {{ \ x ->  fp2_exp x ((`p^^2-9)/16) }};
@@ -296,17 +296,17 @@ let sqrt_align_test_lemmas =
 enable_experimental;
 
 let sqrt_align_fp2_spec = do {
-  out_ptr <- crucible_alloc vec384x_type;
+  out_ptr <- llvm_alloc vec384x_type;
   (ret, ret_ptr) <- ptr_to_fresh_readonly "ret" vec384x_type;
   (sqrt, sqrt_ptr) <- ptr_to_fresh_readonly "sqrt" vec384x_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384x_type;
-  crucible_precond {{ fp2_invariant inp }};
-  crucible_precond {{ fp2_invariant sqrt }};
-  crucible_precond {{ fp2_invariant ret }};
-  crucible_execute_func [out_ptr, ret_ptr, sqrt_ptr, inp_ptr];
-  crucible_points_to out_ptr (crucible_term
+  llvm_precond {{ fp2_invariant inp }};
+  llvm_precond {{ fp2_invariant sqrt }};
+  llvm_precond {{ fp2_invariant ret }};
+  llvm_execute_func [out_ptr, ret_ptr, sqrt_ptr, inp_ptr];
+  llvm_points_to out_ptr (llvm_term
       {{ fp2_rep (Fp_2.mul(fp2_abs ret, sqrt_align_fp2_coeff (fp2_abs sqrt) (fp2_abs inp))) }});
-  crucible_return (crucible_term
+  llvm_return (llvm_term
 //      {{ bool_to_limb (Fp_2.sq (Fp_2.mul(fp2_abs sqrt, sqrt_align_fp2_coeff (fp2_abs sqrt) (fp2_abs inp)))
 //                        == fp2_abs inp) }});
       {{ bool_to_limb (Fp_2.sq (Fp_2.mul(sqrt_align_fp2_coeff (fp2_abs sqrt) (fp2_abs inp), fp2_abs sqrt))
@@ -314,16 +314,16 @@ let sqrt_align_fp2_spec = do {
   };
 
 let sqrt_align_fp2_alias_2_3_spec = do { // for the call in sqrt_fp2
-  out_ptr <- crucible_alloc vec384x_type;
+  out_ptr <- llvm_alloc vec384x_type;
   (ret, ret_ptr) <- ptr_to_fresh_readonly "ret" vec384x_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384x_type;
-  crucible_precond {{ fp2_invariant inp }};
-  crucible_precond {{ fp2_invariant ret }};
-  crucible_execute_func [out_ptr, ret_ptr, ret_ptr, inp_ptr];
-  crucible_points_to out_ptr (crucible_term
+  llvm_precond {{ fp2_invariant inp }};
+  llvm_precond {{ fp2_invariant ret }};
+  llvm_execute_func [out_ptr, ret_ptr, ret_ptr, inp_ptr];
+  llvm_points_to out_ptr (llvm_term
       {{ fp2_rep (Fp_2.mul( sqrt_align_fp2_coeff (fp2_abs ret) (fp2_abs inp)
                           , fp2_abs ret)) }});
-  crucible_return (crucible_term
+  llvm_return (llvm_term
       {{ bool_to_limb (Fp_2.sq (Fp_2.mul( sqrt_align_fp2_coeff (fp2_abs ret) (fp2_abs inp)
                                         , fp2_abs ret))
                         == fp2_abs inp) }});
@@ -332,13 +332,13 @@ let sqrt_align_fp2_alias_2_3_spec = do { // for the call in sqrt_fp2
 let sqrt_align_fp2_alias_1_4_and_2_3_spec = do { // for the call in sqrt_fp2 with aliasing
   (ret, ret_ptr) <- ptr_to_fresh_readonly "ret" vec384x_type;
   (inp, inp_ptr) <- ptr_to_fresh "inp" vec384x_type;
-  crucible_precond {{ fp2_invariant inp }};
-  crucible_precond {{ fp2_invariant ret }};
-  crucible_execute_func [inp_ptr, ret_ptr, ret_ptr, inp_ptr];
-  crucible_points_to inp_ptr (crucible_term
+  llvm_precond {{ fp2_invariant inp }};
+  llvm_precond {{ fp2_invariant ret }};
+  llvm_execute_func [inp_ptr, ret_ptr, ret_ptr, inp_ptr];
+  llvm_points_to inp_ptr (llvm_term
       {{ fp2_rep (Fp_2.mul( sqrt_align_fp2_coeff (fp2_abs ret) (fp2_abs inp)
                           , fp2_abs ret)) }});
-  crucible_return (crucible_term
+  llvm_return (llvm_term
       {{ bool_to_limb (Fp_2.sq (Fp_2.mul( sqrt_align_fp2_coeff (fp2_abs ret) (fp2_abs inp)
                                         , fp2_abs ret))
                         == fp2_abs inp) }});
@@ -349,13 +349,13 @@ let sqrt_align_fp2_alias_1_2_spec = do {
   (out, out_ptr) <- ptr_to_fresh "out" vec384x_type;
   (sqrt, sqrt_ptr) <- ptr_to_fresh_readonly "sqrt" vec384x_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384x_type;
-  crucible_precond {{ fp2_invariant inp }};
-  crucible_precond {{ fp2_invariant sqrt }};
-  crucible_precond {{ fp2_invariant out }};
-  crucible_execute_func [out_ptr, out_ptr, sqrt_ptr, inp_ptr];
-  crucible_points_to out_ptr (crucible_term
+  llvm_precond {{ fp2_invariant inp }};
+  llvm_precond {{ fp2_invariant sqrt }};
+  llvm_precond {{ fp2_invariant out }};
+  llvm_execute_func [out_ptr, out_ptr, sqrt_ptr, inp_ptr];
+  llvm_points_to out_ptr (llvm_term
       {{ fp2_rep (Fp_2.mul(fp2_abs out, sqrt_align_fp2_coeff (fp2_abs sqrt) (fp2_abs inp))) }});
-  crucible_return (crucible_term
+  llvm_return (llvm_term
       {{ bool_to_limb (Fp_2.sq (Fp_2.mul(fp2_abs sqrt, sqrt_align_fp2_coeff (fp2_abs sqrt) (fp2_abs inp)))
                         == fp2_abs inp) }});
   };
@@ -466,44 +466,44 @@ sqrt_align_fp2_alias_1_2_ov <- verify_sqrt_align_fp2  sqrt_align_fp2_alias_1_2_s
 let recip_sqrt_fp2_spec = do {
   out_ptr <- llvm_alloc vec384x_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384x_type;
-  crucible_precond {{ fp2_invariant inp }};
-  crucible_execute_func [out_ptr, inp_ptr];
-  crucible_points_to out_ptr (crucible_term
+  llvm_precond {{ fp2_invariant inp }};
+  llvm_execute_func [out_ptr, inp_ptr];
+  llvm_points_to out_ptr (llvm_term
       {{  fp2_rep (Fp_2.div(sqrt_fp2 (fp2_abs inp), fp2_abs inp)) }});
-  crucible_return (crucible_term {{ bool_to_limb (is_square_fp2 (fp2_abs inp)) }});
+  llvm_return (llvm_term {{ bool_to_limb (is_square_fp2 (fp2_abs inp)) }});
   };
 
 // ... and this version for the proofs for in map_to_g2.saw:
 let recip_sqrt_fp2_nonsquare_spec = do {
   out_ptr <- llvm_alloc vec384x_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384x_type;
-  crucible_precond {{ fp2_invariant inp }};
-  crucible_execute_func [out_ptr, inp_ptr];
-  crucible_points_to out_ptr (crucible_term
+  llvm_precond {{ fp2_invariant inp }};
+  llvm_execute_func [out_ptr, inp_ptr];
+  llvm_points_to out_ptr (llvm_term
         {{ if is_square_fp2 (fp2_abs inp)
            then fp2_rep (Fp_2.div(sqrt_fp2 (fp2_abs inp), fp2_abs inp))
            else fp2_rep (F_expt`{n=758} Fp_2 (fp2_abs inp) `((p^^2-9)/16))
         }});
-  crucible_return (crucible_term {{ bool_to_limb (is_square_fp2 (fp2_abs inp)) }});
+  llvm_return (llvm_term {{ bool_to_limb (is_square_fp2 (fp2_abs inp)) }});
   };
 
 // ... sqrt_fp2
 
 let sqrt_fp2_spec = do {
-    out_ptr <- crucible_alloc vec384x_type;
+    out_ptr <- llvm_alloc vec384x_type;
     (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384x_type;
-    crucible_precond {{ fp2_invariant inp }};
-    crucible_execute_func [out_ptr, inp_ptr];
-    crucible_points_to out_ptr (crucible_term {{ fp2_rep (sqrt_fp2 (fp2_abs inp)) }});
-    crucible_return (crucible_term {{ if is_square_fp2 (fp2_abs inp) then 1:Limb else 0 }});
+    llvm_precond {{ fp2_invariant inp }};
+    llvm_execute_func [out_ptr, inp_ptr];
+    llvm_points_to out_ptr (llvm_term {{ fp2_rep (sqrt_fp2 (fp2_abs inp)) }});
+    llvm_return (llvm_term {{ if is_square_fp2 (fp2_abs inp) then 1:Limb else 0 }});
     };
 
 let sqrt_fp2_alias_spec = do {
     (out, out_ptr) <- ptr_to_fresh "out" vec384x_type;
-    crucible_precond {{ fp2_invariant out }};
-    crucible_execute_func [out_ptr, out_ptr];
-    crucible_points_to out_ptr (crucible_term {{ fp2_rep (sqrt_fp2 (fp2_abs out)) }});
-    crucible_return (crucible_term {{ if is_square_fp2 (fp2_abs out) then 1:Limb else 0 }});
+    llvm_precond {{ fp2_invariant out }};
+    llvm_execute_func [out_ptr, out_ptr];
+    llvm_points_to out_ptr (llvm_term {{ fp2_rep (sqrt_fp2 (fp2_abs out)) }});
+    llvm_return (llvm_term {{ if is_square_fp2 (fp2_abs out) then 1:Limb else 0 }});
     };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/proof/fp12.saw
+++ b/proof/fp12.saw
@@ -18,53 +18,53 @@ let vec384fp4_type = llvm_array 2 vec384x_type; // only used in this file
 ///////////////////////////////////////////////////////////////////////////////
 
 let sqr_fp12_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp12_rep (Fp_12.sq (fp12_abs a)) }});
+  llvm_precond {{ fp12_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp12_rep (Fp_12.sq (fp12_abs a)) }});
 };
 
 let sqr_fp12_alias_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_execute_func [ret_ptr, ret_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp12_rep (Fp_12.sq (fp12_abs a)) }});
+  llvm_precond {{ fp12_invariant a }};
+  llvm_execute_func [ret_ptr, ret_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp12_rep (Fp_12.sq (fp12_abs a)) }});
 };
 
 let mul_fp12_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384fp12_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_precond {{ fp12_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp12_rep (Fp_12.mul (fp12_abs a, fp12_abs b)) }});
+  llvm_precond {{ fp12_invariant a }};
+  llvm_precond {{ fp12_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp12_rep (Fp_12.mul (fp12_abs a, fp12_abs b)) }});
 };
 
 let mul_fp12_alias_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384fp12_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_precond {{ fp12_invariant b }};
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp12_rep (Fp_12.mul (fp12_abs a, fp12_abs b)) }});
+  llvm_precond {{ fp12_invariant a }};
+  llvm_precond {{ fp12_invariant b }};
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp12_rep (Fp_12.mul (fp12_abs a, fp12_abs b)) }});
 };
 
 let conjugate_fp12_spec = do {
   (a, a_ptr) <- ptr_to_fresh "a" vec384fp12_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_execute_func [a_ptr];
-  crucible_points_to a_ptr (crucible_term {{ fp12_rep (fp12_conjugate (fp12_abs a)) }});
+  llvm_precond {{ fp12_invariant a }};
+  llvm_execute_func [a_ptr];
+  llvm_points_to a_ptr (llvm_term {{ fp12_rep (fp12_conjugate (fp12_abs a)) }});
 };
 
 
 let frobenius_map_fp12_spec n = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{ `n:[64] }}];
-  crucible_points_to ret_ptr (crucible_term
+  llvm_precond {{ fp12_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term {{ `n:[64] }}];
+  llvm_points_to ret_ptr (llvm_term
     (if eval_bool {{`n == 0x1}}
      then {{ fp12_rep (fp12_frobenius (fp12_abs a)) }}
      else if eval_bool {{ `n == 0x2 }}
@@ -74,9 +74,9 @@ let frobenius_map_fp12_spec n = do {
 
 let frobenius_map_fp12_alias_spec n = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term {{ `n:[64] }}];
-  crucible_points_to ret_ptr (crucible_term
+  llvm_precond {{ fp12_invariant a }};
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term {{ `n:[64] }}];
+  llvm_points_to ret_ptr (llvm_term
     (if eval_bool {{`n == 0x1}}
      then {{ fp12_rep (fp12_frobenius (fp12_abs a)) }}
      else if eval_bool {{ `n == 0x2 }}
@@ -88,124 +88,124 @@ let frobenius_map_fp12_alias_spec n = do {
 // The cyclotomic square returns the square of its input PROVIDED that input is in the
 // "cyclotomic subgroup" -- that is, its, `p^4-p^2+1` power is 1.
 let cyclotomic_sqr_fp12_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp12_rep (cyclotomic_sqr_fp12 (fp12_abs a)) }});
+  llvm_precond {{ fp12_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp12_rep (cyclotomic_sqr_fp12 (fp12_abs a)) }});
 };
 
 let cyclotomic_sqr_fp12_alias_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_execute_func [ret_ptr, ret_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp12_rep (cyclotomic_sqr_fp12 (fp12_abs a)) }});
+  llvm_precond {{ fp12_invariant a }};
+  llvm_execute_func [ret_ptr, ret_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp12_rep (cyclotomic_sqr_fp12 (fp12_abs a)) }});
 };
 
 
 let mul_by_xy00z0_fp12_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
   (xyz, xyz_ptr) <- ptr_to_fresh_readonly "xyz" vec384fp6_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_precond {{ fp6_invariant xyz }};
-  crucible_execute_func [ret_ptr, a_ptr, xyz_ptr];
-  crucible_points_to ret_ptr (crucible_term
+  llvm_precond {{ fp12_invariant a }};
+  llvm_precond {{ fp6_invariant xyz }};
+  llvm_execute_func [ret_ptr, a_ptr, xyz_ptr];
+  llvm_points_to ret_ptr (llvm_term
     {{ fp12_rep (Fp_12.mul (fp12_abs a, fp12_abs (xy00z0_expander xyz))) }});
   };
 
 let mul_by_xy00z0_fp12_alias_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "a" vec384fp12_type;
   (xyz, xyz_ptr) <- ptr_to_fresh_readonly "xyz" vec384fp6_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_precond {{ fp6_invariant xyz }};
-  crucible_execute_func [ret_ptr, ret_ptr, xyz_ptr];
-  crucible_points_to ret_ptr (crucible_term
+  llvm_precond {{ fp12_invariant a }};
+  llvm_precond {{ fp6_invariant xyz }};
+  llvm_execute_func [ret_ptr, ret_ptr, xyz_ptr];
+  llvm_points_to ret_ptr (llvm_term
     {{ fp12_rep (Fp_12.mul (fp12_abs a, fp12_abs (xy00z0_expander xyz))) }});
   };
 
 let inverse_fp12_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
-  crucible_precond {{ fp12_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term
+  llvm_precond {{ fp12_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term
    {{ fp12_rep (Fp_12.div (Fp_12.field_unit, fp12_abs a)) }});
 };
 
 // non-top-level specifications
 
 let mul_by_1_plus_i_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   // (p, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_precond {{ fp2_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr, crucible_global "BLS12_381_P"];
-  crucible_points_to ret_ptr (crucible_term {{ fp2_rep (Fp_2.mul (u_plus_1, fp2_abs a)) }});
+  llvm_precond {{ fp2_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr, llvm_global "BLS12_381_P"];
+  llvm_points_to ret_ptr (llvm_term {{ fp2_rep (Fp_2.mul (u_plus_1, fp2_abs a)) }});
 };
 
 let mul_by_1_plus_i_mod_384x_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   // (p, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_precond {{ fp2_invariant a }};
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_global "BLS12_381_P"];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term {{ fp2_rep (Fp_2.mul (u_plus_1, fp2_abs a)) }});
+  llvm_precond {{ fp2_invariant a }};
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_global "BLS12_381_P"];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term {{ fp2_rep (Fp_2.mul (u_plus_1, fp2_abs a)) }});
 };
 
 let frobenius_map_fp2_spec n = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
-  crucible_precond {{ fp2_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{ `n:[64] }}];
-  crucible_points_to ret_ptr (crucible_term {{ fp2_rep (nest fp2_frobenius (fp2_abs a) `n) }} );
+  llvm_precond {{ fp2_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term {{ `n:[64] }}];
+  llvm_points_to ret_ptr (llvm_term {{ fp2_rep (nest fp2_frobenius (fp2_abs a) `n) }} );
 };
 
 let frobenius_map_fp2_alias_spec n = do {
   (a, ret_ptr) <- ptr_to_fresh "a" vec384x_type;
-  crucible_precond {{ fp2_invariant a }};
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term {{ `n:[64] }}];
-  crucible_points_to ret_ptr (crucible_term {{ fp2_rep (nest fp2_frobenius (fp2_abs a) `n) }} );
+  llvm_precond {{ fp2_invariant a }};
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term {{ `n:[64] }}];
+  llvm_points_to ret_ptr (llvm_term {{ fp2_rep (nest fp2_frobenius (fp2_abs a) `n) }} );
 };
 
 let frobenius_map_fp6_spec n = do {
-  ret_ptr <- crucible_alloc vec384fp6_type;
+  ret_ptr <- llvm_alloc vec384fp6_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp6_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{ `n:[64] }}];
-  crucible_points_to ret_ptr (crucible_term {{ fp6_rep (nest fp6_frobenius (fp6_abs a) `n) }} );
+  llvm_precond {{ fp6_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term {{ `n:[64] }}];
+  llvm_points_to ret_ptr (llvm_term {{ fp6_rep (nest fp6_frobenius (fp6_abs a) `n) }} );
 };
 
 let frobenius_map_fp6_alias_spec n = do {
   (a, ret_ptr) <- ptr_to_fresh "a" vec384fp6_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term {{ `n:[64] }}];
-  crucible_points_to ret_ptr (crucible_term {{ fp6_rep (nest fp6_frobenius (fp6_abs a) `n) }} );
+  llvm_precond {{ fp6_invariant a }};
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term {{ `n:[64] }}];
+  llvm_points_to ret_ptr (llvm_term {{ fp6_rep (nest fp6_frobenius (fp6_abs a) `n) }} );
 };
 
 let sqr_fp4_spec = do {
-  ret_ptr <- crucible_alloc vec384fp4_type;
+  ret_ptr <- llvm_alloc vec384fp4_type;
   (a0, a0_ptr) <- ptr_to_fresh_readonly "a0" vec384x_type;
   (a1, a1_ptr) <- ptr_to_fresh_readonly "a1" vec384x_type;
-  crucible_precond {{ fp2_invariant a0 }};
-  crucible_precond {{ fp2_invariant a1 }};
-  crucible_execute_func [ret_ptr, a0_ptr, a1_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp4_rep (Fp_4.sq (fp4_abs [a0, a1])) }});
+  llvm_precond {{ fp2_invariant a0 }};
+  llvm_precond {{ fp2_invariant a1 }};
+  llvm_execute_func [ret_ptr, a0_ptr, a1_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp4_rep (Fp_4.sq (fp4_abs [a0, a1])) }});
 };
 
 let mul_by_u_plus_1_fp2_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a,a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
-  crucible_precond {{ fp2_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp2_rep (Fp_2.mul (u_plus_1, fp2_abs a)) }});
+  llvm_precond {{ fp2_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp2_rep (Fp_2.mul (u_plus_1, fp2_abs a)) }});
 };
 
 let mul_by_u_plus_1_fp2_alias_spec = do {
   (ret,ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
-  crucible_precond {{ fp2_invariant ret }};
-  crucible_execute_func [ret_ptr, ret_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp2_rep (Fp_2.mul (u_plus_1, fp2_abs ret)) }});
+  llvm_precond {{ fp2_invariant ret }};
+  llvm_execute_func [ret_ptr, ret_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp2_rep (Fp_2.mul (u_plus_1, fp2_abs ret)) }});
 };
 
 let {{
@@ -218,11 +218,11 @@ mul_by_u_plus_1_fp2x2_equiv_thm  <-
   prove_cryptol {{ \x ->  Fp_2x2.mul (x, u_plus_1x2) == mul_by_u_plus_1_fp2x2 x }} [];
 
 let mul_by_u_plus_1_fp2x2_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec768x_type;
-  crucible_precond {{ fp2x2_invariant a }} ;
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp2x2_rep (Fp_2x2.mul (fp2x2_abs a, u_plus_1x2)) }} );
+  llvm_precond {{ fp2x2_invariant a }} ;
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp2x2_rep (Fp_2x2.mul (fp2x2_abs a, u_plus_1x2)) }} );
   };
 
 // ... Fp2x2 operations
@@ -230,47 +230,47 @@ let mul_by_u_plus_1_fp2x2_spec = do {
 let add_fp2x2_spec a_aliased b_aliased = do {
   (ret, ret_ptr) <- if either a_aliased b_aliased
                     then ptr_to_fresh "ret" vec768x_type
-                    else do { ptr <- crucible_alloc vec768x_type;
+                    else do { ptr <- llvm_alloc vec768x_type;
                               return ({{zero: [2]Vec768}}, ptr);
                             };
   (a, a_ptr) <- if a_aliased then return (ret, ret_ptr) else ptr_to_fresh_readonly "a" vec768x_type;
   (b, b_ptr) <- if b_aliased then return (ret, ret_ptr) else ptr_to_fresh_readonly "b" vec768x_type;
-  crucible_precond {{ fp2x2_invariant a }};
-  crucible_precond {{ fp2x2_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp2x2_rep (Fp_2x2.add (fp2x2_abs a, fp2x2_abs b)) }});
+  llvm_precond {{ fp2x2_invariant a }};
+  llvm_precond {{ fp2x2_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp2x2_rep (Fp_2x2.add (fp2x2_abs a, fp2x2_abs b)) }});
 };
 
 let sub_fp2x2_spec a_aliased b_aliased = do {
   (ret, ret_ptr) <- if either a_aliased b_aliased
                     then ptr_to_fresh "ret" vec768x_type
-                    else do { ptr <- crucible_alloc vec768x_type;
+                    else do { ptr <- llvm_alloc vec768x_type;
                               return ({{zero: [2]Vec768}}, ptr);
                             };
   (a, a_ptr) <- if a_aliased then return (ret, ret_ptr) else ptr_to_fresh_readonly "a" vec768x_type;
   (b, b_ptr) <- if b_aliased then return (ret, ret_ptr) else ptr_to_fresh_readonly "b" vec768x_type;
-  crucible_precond {{ fp2x2_invariant a }};
-  crucible_precond {{ fp2x2_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp2x2_rep (Fp_2x2.sub (fp2x2_abs a, fp2x2_abs b)) }});
+  llvm_precond {{ fp2x2_invariant a }};
+  llvm_precond {{ fp2x2_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp2x2_rep (Fp_2x2.sub (fp2x2_abs a, fp2x2_abs b)) }});
 };
 
 let mul_fp2x2_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
-  crucible_precond {{ fp2_invariant a }}; // a is smallish
-  crucible_precond {{ fp2_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp2x2_rep (Fp_2x2.mul (abs_384x a, abs_384x b)) }});
+  llvm_precond {{ fp2_invariant a }}; // a is smallish
+  llvm_precond {{ fp2_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp2x2_rep (Fp_2x2.mul (abs_384x a, abs_384x b)) }});
 };
 
 let sqr_fp2x2_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
-  crucible_precond {{ fp2_invariant a }}; // a is smallish
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp2x2_rep (Fp_2x2.mul (abs_384x a, abs_384x a)) }});
+  llvm_precond {{ fp2_invariant a }}; // a is smallish
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp2x2_rep (Fp_2x2.mul (abs_384x a, abs_384x a)) }});
 };
 
 // ... Fp6x2 operations
@@ -278,14 +278,14 @@ let sqr_fp2x2_spec = do {
 let sub_fp6x2_spec a_aliased = do {
   (ret, ret_ptr) <- if a_aliased
                     then ptr_to_fresh "a" vec768fp6_type
-                    else do { r <- crucible_alloc vec768fp6_type;
+                    else do { r <- llvm_alloc vec768fp6_type;
                               return ( {{ zero: [3][2]Vec768 }}, r ); } ; // TODO fix Cryptol type?
   (a, a_ptr) <- if a_aliased then return (ret, ret_ptr) else ptr_to_fresh_readonly "a" vec768fp6_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec768fp6_type;
-  crucible_precond {{ fp6x2_invariant a }};
-  crucible_precond {{ fp6x2_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp6x2_rep (Fp_6x2.sub (fp6x2_abs a, fp6x2_abs b)) }});
+  llvm_precond {{ fp6x2_invariant a }};
+  llvm_precond {{ fp6x2_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp6x2_rep (Fp_6x2.sub (fp6x2_abs a, fp6x2_abs b)) }});
 };
 
 
@@ -303,74 +303,74 @@ let {{ fp12_abs_nom [x,y] =[fp6_abs_nom y, fp6_abs_nom x] }};
 let {{ fp12_rep_nom [x, y] = [fp6_rep_nom y, fp6_rep_nom x] }};
 
 let mul_fp6x2_spec = do {
-  ret_ptr <- crucible_alloc vec768fp6_type;
+  ret_ptr <- llvm_alloc vec768fp6_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp6_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384fp6_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_precond {{ fp6_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp6x2_rep (fp6x2_mul (fp6_abs_nom a) (fp6_abs_nom b)) }});
+  llvm_precond {{ fp6_invariant a }};
+  llvm_precond {{ fp6_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp6x2_rep (fp6x2_mul (fp6_abs_nom a) (fp6_abs_nom b)) }});
 };
 
 let redc_fp6x2_spec = do {
-  ret_ptr <- crucible_alloc vec384fp6_type;
+  ret_ptr <- llvm_alloc vec384fp6_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec768fp6_type;
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp6_rep_nom (redc_mont_fp6 (fp6x2_abs a)) }});
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp6_rep_nom (redc_mont_fp6 (fp6x2_abs a)) }});
   };
 
 let mul_fp6_spec a_aliased = do {
   (ret, ret_ptr) <- if a_aliased
                     then ptr_to_fresh "a" vec384fp6_type
-                    else do { r <- crucible_alloc vec384fp6_type;
+                    else do { r <- llvm_alloc vec384fp6_type;
                               return ( {{ zero: [3][2]Vec384 }}, r ); } ; // TODO fix Cryptol type?
   (a, a_ptr) <- if a_aliased then return (ret, ret_ptr) else ptr_to_fresh_readonly "a" vec384fp6_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384fp6_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_precond {{ fp6_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp6_rep (Fp_6.mul (fp6_abs a, fp6_abs b)) }});
+  llvm_precond {{ fp6_invariant a }};
+  llvm_precond {{ fp6_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp6_rep (Fp_6.mul (fp6_abs a, fp6_abs b)) }});
 };
 
 add_fp6_spec <- do {
-  ret_ptr <- crucible_alloc vec384fp6_type;
+  ret_ptr <- llvm_alloc vec384fp6_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp6_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384fp6_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_precond {{ fp6_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp6_rep (Fp_6.add (fp6_abs a, fp6_abs b)) }});
+  llvm_precond {{ fp6_invariant a }};
+  llvm_precond {{ fp6_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp6_rep (Fp_6.add (fp6_abs a, fp6_abs b)) }});
   };
 
 add_fp6_aliased_1_3_spec <- do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp6_type;
   (b, ret_ptr) <- ptr_to_fresh "b" vec384fp6_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_precond {{ fp6_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp6_rep (Fp_6.add (fp6_abs a, fp6_abs b)) }});
+  llvm_precond {{ fp6_invariant a }};
+  llvm_precond {{ fp6_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp6_rep (Fp_6.add (fp6_abs a, fp6_abs b)) }});
   };
 
 sub_fp6_spec <- do {
-  ret_ptr <- crucible_alloc vec384fp6_type;
+  ret_ptr <- llvm_alloc vec384fp6_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp6_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384fp6_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_precond {{ fp6_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp6_rep (Fp_6.sub (fp6_abs a, fp6_abs b)) }});
+  llvm_precond {{ fp6_invariant a }};
+  llvm_precond {{ fp6_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp6_rep (Fp_6.sub (fp6_abs a, fp6_abs b)) }});
   };
 
 // ... two subroutines for mul-by_xy00z0
 
 let mul_by_0y0_fp6x2_spec = do {
-  ret_ptr <- crucible_alloc vec768fp6_type;
+  ret_ptr <- llvm_alloc vec768fp6_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp6_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_precond {{ fp2_invariant b }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp6x2_rep (mul_by_0y0_fp6x2 (fp6_abs_nom a) (fp2_abs_nom b)) }});
+  llvm_precond {{ fp6_invariant a }};
+  llvm_precond {{ fp2_invariant b }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp6x2_rep (mul_by_0y0_fp6x2 (fp6_abs_nom a) (fp2_abs_nom b)) }});
 };
 
 // mul_by_xy0_fp6x2 is peculiar in one way: we get a Fp_6 input, but
@@ -379,62 +379,62 @@ let mul_by_0y0_fp6x2_spec = do {
 // the whole 3-element array being initialized; just the part we use.
 
 let mul_by_xy0_fp6x2_spec = do {
-  ret_ptr <- crucible_alloc vec768fp6_type;
+  ret_ptr <- llvm_alloc vec768fp6_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp6_type;
-  x <- crucible_fresh_var "x" vec384x_type;
-  y <- crucible_fresh_var "y" vec384x_type;
-  xy0_ptr <- crucible_alloc_readonly (llvm_array 2 vec384x_type);
-  crucible_points_to (crucible_elem xy0_ptr 0) (crucible_term x);
-  crucible_points_to (crucible_elem xy0_ptr 1) (crucible_term y);
-  crucible_precond {{ fp6_invariant a }};
-  crucible_precond {{ fp2_invariant x }};
-  crucible_precond {{ fp2_invariant y }};
-  crucible_execute_func [ret_ptr, a_ptr, xy0_ptr];
-  crucible_points_to ret_ptr (crucible_term
+  x <- llvm_fresh_var "x" vec384x_type;
+  y <- llvm_fresh_var "y" vec384x_type;
+  xy0_ptr <- llvm_alloc_readonly (llvm_array 2 vec384x_type);
+  llvm_points_to (llvm_elem xy0_ptr 0) (llvm_term x);
+  llvm_points_to (llvm_elem xy0_ptr 1) (llvm_term y);
+  llvm_precond {{ fp6_invariant a }};
+  llvm_precond {{ fp2_invariant x }};
+  llvm_precond {{ fp2_invariant y }};
+  llvm_execute_func [ret_ptr, a_ptr, xy0_ptr];
+  llvm_points_to ret_ptr (llvm_term
     {{ fp6x2_rep (mul_by_xy0_fp6x2 (fp6_abs_nom a) (fp2_abs_nom y) (fp2_abs_nom x)) }});
 };
 
 // .. inversion
 let eucl_inverse_fp_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  crucible_precond {{ fp_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term
+  llvm_precond {{ fp_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term
    {{ fp_rep (Fp.div (Fp.field_unit, fp_abs a)) }});
 };
 
 let inverse_fp2_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
-  crucible_precond {{ fp2_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term
+  llvm_precond {{ fp2_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term
    {{ fp2_rep (inverse_fp2_imp (fp2_abs a)) }});
 };
 
 let inverse_fp6_spec = do {
-  ret_ptr <- crucible_alloc vec384fp6_type;
+  ret_ptr <- llvm_alloc vec384fp6_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp6_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term
+  llvm_precond {{ fp6_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term
    {{ fp6_rep (inverse_fp6_imp (fp6_abs a)) }});
 };
 
 let sqr_fp6_spec = do {
-  ret_ptr <- crucible_alloc vec384fp6_type;
+  ret_ptr <- llvm_alloc vec384fp6_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp6_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp6_rep (Fp_6.sq (fp6_abs a)) }});
+  llvm_precond {{ fp6_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp6_rep (Fp_6.sq (fp6_abs a)) }});
 };
 
 let neg_fp6_alias_spec = do {
   (a, a_ptr) <- ptr_to_fresh "a" vec384fp6_type;
-  crucible_precond {{ fp6_invariant a }};
-  crucible_execute_func [a_ptr, a_ptr];
-  crucible_points_to a_ptr (crucible_term {{ fp6_rep (Fp_6.neg (fp6_abs a)) }});
+  llvm_precond {{ fp6_invariant a }};
+  llvm_execute_func [a_ptr, a_ptr];
+  llvm_points_to a_ptr (llvm_term {{ fp6_rep (Fp_6.neg (fp6_abs a)) }});
 };
 
 
@@ -1549,10 +1549,10 @@ let {{ redc_mont_fp4 [x, y] = [redc_mont_fp2 x, redc_mont_fp2 y] }};
 let {{ fp4_rep_nom [x, y] = [fp2_rep_nom y, fp2_rep_nom x] }};
 
 let redc_fp2x2_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec768x_type;
-  crucible_execute_func [ret_ptr, a_ptr];
-  crucible_points_to ret_ptr (crucible_term {{ fp2_rep_nom (redc_mont_fp2 (fp2x2_abs a)) }});
+  llvm_execute_func [ret_ptr, a_ptr];
+  llvm_points_to ret_ptr (llvm_term {{ fp2_rep_nom (redc_mont_fp2 (fp2x2_abs a)) }});
   };
 
 redc_fp2x2_ov <- custom_verify "redc_fp2x2" [redcx_mont_384_alt_ov] redc_fp2x2_spec z3;

--- a/proof/fp12_tower.saw
+++ b/proof/fp12_tower.saw
@@ -3,99 +3,99 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 let sqr_fp12_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
-  crucible_execute_func [ret_ptr, a_ptr];
-  new_sqr_fp12_ret <- crucible_fresh_var "new_sqr_fp12_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_fp12_ret);
+  llvm_execute_func [ret_ptr, a_ptr];
+  new_sqr_fp12_ret <- llvm_fresh_var "new_sqr_fp12_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_fp12_ret);
 };
 
 let sqr_fp12_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
-  crucible_execute_func [ret_ptr, ret_ptr];
-  new_sqr_fp12_alias_ret <- crucible_fresh_var "new_sqr_fp12_alias_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_fp12_alias_ret);
+  llvm_execute_func [ret_ptr, ret_ptr];
+  new_sqr_fp12_alias_ret <- llvm_fresh_var "new_sqr_fp12_alias_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_fp12_alias_ret);
 };
 
 
 let cyclotomic_sqr_fp12_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
-  crucible_execute_func [ret_ptr, a_ptr];
-  new_cyclotomic_sqr_fp12_ret <- crucible_fresh_var "new_cyclotomic_sqr_fp12_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_cyclotomic_sqr_fp12_ret);
+  llvm_execute_func [ret_ptr, a_ptr];
+  new_cyclotomic_sqr_fp12_ret <- llvm_fresh_var "new_cyclotomic_sqr_fp12_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_cyclotomic_sqr_fp12_ret);
 };
 
 let cyclotomic_sqr_fp12_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
-  crucible_execute_func [ret_ptr, ret_ptr];
-  new_cyclotomic_sqr_fp12_ret <- crucible_fresh_var "new_cyclotomic_sqr_fp12_alias_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_cyclotomic_sqr_fp12_ret);
+  llvm_execute_func [ret_ptr, ret_ptr];
+  new_cyclotomic_sqr_fp12_ret <- llvm_fresh_var "new_cyclotomic_sqr_fp12_alias_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_cyclotomic_sqr_fp12_ret);
 };
 
 
 let mul_fp12_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384fp12_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  new_mul_fp12_ret <- crucible_fresh_var "new_mul_fp12_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_fp12_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  new_mul_fp12_ret <- llvm_fresh_var "new_mul_fp12_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_fp12_ret);
 };
 
 let mul_fp12_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384fp12_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr];
-  new_ret <- crucible_fresh_var "new_mul_fp12_alias_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr];
+  new_ret <- llvm_fresh_var "new_mul_fp12_alias_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let mul_by_xy00z0_fp12_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
   (_, xy00z0_ptr) <- ptr_to_fresh_readonly "xy00z0" vec384fp6_type;
-  crucible_execute_func [ret_ptr, a_ptr, xy00z0_ptr];
-  new_mul_by_xy00z0_fp12_ret <- crucible_fresh_var "new_mul_by_xy00z0_fp12_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_by_xy00z0_fp12_ret);
+  llvm_execute_func [ret_ptr, a_ptr, xy00z0_ptr];
+  new_mul_by_xy00z0_fp12_ret <- llvm_fresh_var "new_mul_by_xy00z0_fp12_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_by_xy00z0_fp12_ret);
 };
 
 let mul_by_xy00z0_fp12_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "a" vec384fp12_type;
   (_, xy00z0_ptr) <- ptr_to_fresh_readonly "xy00z0" vec384fp6_type;
-  crucible_execute_func [ret_ptr, ret_ptr, xy00z0_ptr];
-  new_mul_by_xy00z0_fp12_alias_ret <- crucible_fresh_var "new_mul_by_xy00z0_fp12_alias_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_by_xy00z0_fp12_alias_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, xy00z0_ptr];
+  new_mul_by_xy00z0_fp12_alias_ret <- llvm_fresh_var "new_mul_by_xy00z0_fp12_alias_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_by_xy00z0_fp12_alias_ret);
 };
 
 let conjugate_fp12_spec = do {
   (_, a_ptr) <- ptr_to_fresh "a" vec384fp12_type;
-  crucible_execute_func [a_ptr];
-  new_conjugate_fp12_a <- crucible_fresh_var "new_conjugate_fp12_a" vec384fp12_type;
-  crucible_points_to a_ptr (crucible_term new_conjugate_fp12_a);
+  llvm_execute_func [a_ptr];
+  new_conjugate_fp12_a <- llvm_fresh_var "new_conjugate_fp12_a" vec384fp12_type;
+  llvm_points_to a_ptr (llvm_term new_conjugate_fp12_a);
 };
 
 let inverse_fp12_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
-  crucible_execute_func [ret_ptr, a_ptr];
-  new_inverse_fp12_ret <- crucible_fresh_var "new_inverse_fp12_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_inverse_fp12_ret);
+  llvm_execute_func [ret_ptr, a_ptr];
+  new_inverse_fp12_ret <- llvm_fresh_var "new_inverse_fp12_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_inverse_fp12_ret);
 };
 
 let frobenius_map_fp12_spec n = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384fp12_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{ `n:[64] }}];
-  new_frobenius_map_fp12_ret <- crucible_fresh_var "new_frobenius_map_fp12_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_frobenius_map_fp12_ret);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term {{ `n:[64] }}];
+  new_frobenius_map_fp12_ret <- llvm_fresh_var "new_frobenius_map_fp12_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_frobenius_map_fp12_ret);
 };
 
 let frobenius_map_fp12_alias_spec n = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384fp12_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term {{ `n:[64] }}];
-  new_frobenius_map_fp12_ret <- crucible_fresh_var "new_frobenius_map_fp12_ret" vec384fp12_type;
-  crucible_points_to ret_ptr (crucible_term new_frobenius_map_fp12_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term {{ `n:[64] }}];
+  new_frobenius_map_fp12_ret <- llvm_fresh_var "new_frobenius_map_fp12_ret" vec384fp12_type;
+  llvm_points_to ret_ptr (llvm_term new_frobenius_map_fp12_ret);
 };
 
 

--- a/proof/fp2_overrides.saw
+++ b/proof/fp2_overrides.saw
@@ -175,22 +175,22 @@ let mul_by_8_fp2_alias_1_2_spec =
 mul_by_8_fp2_alias_1_2_ov <- admit "mul_by_8_fp2" mul_by_8_fp2_alias_1_2_spec;
 
 let cneg_fp2_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
-  cbit <- crucible_fresh_var "cbit" limb_type;
-  crucible_precond {{ fp2_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term cbit];
-  crucible_points_to ret_ptr (crucible_term {{ if cbit != 0 then fp2_rep (Fp_2.neg (fp2_abs a)) else a }});
+  cbit <- llvm_fresh_var "cbit" limb_type;
+  llvm_precond {{ fp2_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term cbit];
+  llvm_points_to ret_ptr (llvm_term {{ if cbit != 0 then fp2_rep (Fp_2.neg (fp2_abs a)) else a }});
 };
 
 cneg_fp2_ov <- admit "cneg_fp2" cneg_fp2_spec;
 
 let cneg_fp2_alias_1_2_spec = do {
   (a, a_ptr) <- ptr_to_fresh "a" vec384x_type;
-  cbit <- crucible_fresh_var "cbit" limb_type;
-  crucible_precond {{ fp2_invariant a }};
-  crucible_execute_func [a_ptr, a_ptr, crucible_term cbit];
-  crucible_points_to a_ptr (crucible_term {{ if cbit != 0 then fp2_rep (Fp_2.neg (fp2_abs a)) else a }});
+  cbit <- llvm_fresh_var "cbit" limb_type;
+  llvm_precond {{ fp2_invariant a }};
+  llvm_execute_func [a_ptr, a_ptr, llvm_term cbit];
+  llvm_points_to a_ptr (llvm_term {{ if cbit != 0 then fp2_rep (Fp_2.neg (fp2_abs a)) else a }});
 };
 
 cneg_fp2_alias_1_2_ov <- admit "cneg_fp2" cneg_fp2_alias_1_2_spec;

--- a/proof/fp_overrides.saw
+++ b/proof/fp_overrides.saw
@@ -25,75 +25,75 @@ let use_concrete_method = true;
 
 // generic unary operation specification, pass-by-reference, no aliasing
 let unop_spec name llvm_type inv rep abs op = do {
-  ret_ptr <- crucible_alloc llvm_type;
+  ret_ptr <- llvm_alloc llvm_type;
   (x, x_ptr) <- ptr_to_fresh_readonly "x" llvm_type;
-  crucible_precond {{ inv x }};
-  crucible_execute_func [ret_ptr, x_ptr];
+  llvm_precond {{ inv x }};
+  llvm_execute_func [ret_ptr, x_ptr];
   if use_abs_method
   then do {
-    ret <- crucible_fresh_var (str_concat name "_ret") llvm_type;
-    crucible_points_to ret_ptr (crucible_term ret);
-    crucible_postcond {{inv ret }};
-    crucible_postcond {{ abs ret == op (abs x) }};
+    ret <- llvm_fresh_var (str_concat name "_ret") llvm_type;
+    llvm_points_to ret_ptr (llvm_term ret);
+    llvm_postcond {{inv ret }};
+    llvm_postcond {{ abs ret == op (abs x) }};
     }
   else if use_concrete_method
-  then crucible_points_to ret_ptr (crucible_term {{ rep (op (abs x)) }})
-  else crucible_points_to ret_ptr (crucible_term {{ op x }});
+  then llvm_points_to ret_ptr (llvm_term {{ rep (op (abs x)) }})
+  else llvm_points_to ret_ptr (llvm_term {{ op x }});
 };
 
 // generic unary operation specification, pass-by-reference, aliasing
 let unop_alias_1_2_spec name llvm_type inv rep abs op = do {
   (x, x_ptr) <- ptr_to_fresh_readonly "x" llvm_type;
-  crucible_precond {{ inv x }};
-  crucible_execute_func [x_ptr, x_ptr];
+  llvm_precond {{ inv x }};
+  llvm_execute_func [x_ptr, x_ptr];
   if use_abs_method
   then do {
-    ret <- crucible_fresh_var (str_concat name "_ret") llvm_type;
-    crucible_points_to x_ptr (crucible_term ret);
-    crucible_postcond {{inv ret }};
-    crucible_postcond {{ abs ret == op (abs x) }};
+    ret <- llvm_fresh_var (str_concat name "_ret") llvm_type;
+    llvm_points_to x_ptr (llvm_term ret);
+    llvm_postcond {{inv ret }};
+    llvm_postcond {{ abs ret == op (abs x) }};
     }
   else if use_concrete_method
-  then crucible_points_to x_ptr (crucible_term {{ rep (op (abs x)) }})
-  else crucible_points_to x_ptr (crucible_term {{ op x }});
+  then llvm_points_to x_ptr (llvm_term {{ rep (op (abs x)) }})
+  else llvm_points_to x_ptr (llvm_term {{ op x }});
 };
 
 // generic binary operation specification, pass-by-reference, no aliasing
 let binop_spec name llvm_type inv rep abs op = do {
-  ret_ptr <- crucible_alloc llvm_type;
+  ret_ptr <- llvm_alloc llvm_type;
   (x, x_ptr) <- ptr_to_fresh_readonly "x" llvm_type;
   (y, y_ptr) <- ptr_to_fresh_readonly "y" llvm_type;
-  crucible_precond {{ inv x /\ inv y }};
-  crucible_execute_func [ret_ptr, x_ptr, y_ptr];
+  llvm_precond {{ inv x /\ inv y }};
+  llvm_execute_func [ret_ptr, x_ptr, y_ptr];
   res <- if use_abs_method
   then do {
-    ret <- crucible_fresh_var (str_concat name "_ret") llvm_type;
-    crucible_postcond {{ abs ret == op (abs x, abs y) }};
+    ret <- llvm_fresh_var (str_concat name "_ret") llvm_type;
+    llvm_postcond {{ abs ret == op (abs x, abs y) }};
     return ret;
     }
   else if use_concrete_method
   then return {{ rep (op (abs x, abs y)) }}
   else return {{ op x y }};
-  crucible_points_to ret_ptr (crucible_term res);
-  crucible_postcond {{ inv res }};
+  llvm_points_to ret_ptr (llvm_term res);
+  llvm_postcond {{ inv res }};
 };
 
 let binop_alias_1_2_spec name llvm_type inv rep abs op = do {
   (x, x_ptr) <- ptr_to_fresh "x" llvm_type;
   (y, y_ptr) <- ptr_to_fresh_readonly "y" llvm_type;
-  crucible_precond {{ inv x /\ inv y }};
-  crucible_execute_func [x_ptr, x_ptr, y_ptr];
+  llvm_precond {{ inv x /\ inv y }};
+  llvm_execute_func [x_ptr, x_ptr, y_ptr];
   res <- if use_abs_method
   then do {
-    ret <- crucible_fresh_var (str_concat name "_ret") llvm_type;
-    crucible_postcond {{ abs ret == op (abs x, abs y) }};
+    ret <- llvm_fresh_var (str_concat name "_ret") llvm_type;
+    llvm_postcond {{ abs ret == op (abs x, abs y) }};
     return ret;
     }
   else if use_concrete_method
   then return {{ rep (op (abs x, abs y)) }}
   else return {{ op x y }};
-  crucible_points_to x_ptr (crucible_term res);
-  crucible_postcond {{ inv res }};
+  llvm_points_to x_ptr (llvm_term res);
+  llvm_postcond {{ inv res }};
 };
 
 // generic binary operation specification, pass-by-reference, aliasing return with second arg
@@ -101,20 +101,20 @@ let binop_alias_1_2_spec name llvm_type inv rep abs op = do {
 let binop_alias_1_3_spec name llvm_type inv rep abs op = do {
   (x, x_ptr) <- ptr_to_fresh_readonly "x" llvm_type;
   (y, y_ptr) <- ptr_to_fresh "y" llvm_type;
-  crucible_precond {{ inv x /\ inv y }};
-  crucible_execute_func [y_ptr, x_ptr, y_ptr];
+  llvm_precond {{ inv x /\ inv y }};
+  llvm_execute_func [y_ptr, x_ptr, y_ptr];
   let res = {{ rep (op (abs x, abs y)) }};
-  crucible_points_to y_ptr (crucible_term res);
-  crucible_postcond {{ inv res }};
+  llvm_points_to y_ptr (llvm_term res);
+  llvm_postcond {{ inv res }};
 };
 
 let binop_alias_1_2_3_spec name llvm_type inv rep abs op = do {
   (x, x_ptr) <- ptr_to_fresh "x" llvm_type;
-  crucible_precond {{ inv x }};
-  crucible_execute_func [x_ptr, x_ptr, x_ptr];
+  llvm_precond {{ inv x }};
+  llvm_execute_func [x_ptr, x_ptr, x_ptr];
   let res = {{ rep (op (abs x, abs x)) }};
-  crucible_points_to x_ptr (crucible_term res);
-  crucible_postcond {{ inv res }};
+  llvm_points_to x_ptr (llvm_term res);
+  llvm_postcond {{ inv res }};
 };
 
 ////////////////////////////////////////////////////////////////
@@ -355,22 +355,22 @@ mul_by_8_fp_alias_1_2_ov <- admit "mul_by_8_fp" mul_by_8_fp_alias_1_2_spec;
 
 // TODO: include the other possible forms of this spec (abstract_method etc.)
 let cneg_fp_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  cbit <- crucible_fresh_var "cbit" limb_type;
-  crucible_precond {{ fp_invariant a }};
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term cbit];
-  crucible_points_to ret_ptr (crucible_term {{ if cbit != 0 then fp_rep (Fp.neg (fp_abs a)) else a }});
+  cbit <- llvm_fresh_var "cbit" limb_type;
+  llvm_precond {{ fp_invariant a }};
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term cbit];
+  llvm_points_to ret_ptr (llvm_term {{ if cbit != 0 then fp_rep (Fp.neg (fp_abs a)) else a }});
 };
 
 cneg_fp_ov <- admit "cneg_fp" cneg_fp_spec;
 
 let cneg_fp_alias_1_2_spec = do {
   (a, a_ptr) <- ptr_to_fresh "a" vec384_type;
-  cbit <- crucible_fresh_var "cbit" limb_type;
-  crucible_precond {{ fp_invariant a }};
-  crucible_execute_func [a_ptr, a_ptr, crucible_term cbit];
-  crucible_points_to a_ptr (crucible_term {{ if cbit != 0 then fp_rep (Fp.neg (fp_abs a)) else a }});
+  cbit <- llvm_fresh_var "cbit" limb_type;
+  llvm_precond {{ fp_invariant a }};
+  llvm_execute_func [a_ptr, a_ptr, llvm_term cbit];
+  llvm_points_to a_ptr (llvm_term {{ if cbit != 0 then fp_rep (Fp.neg (fp_abs a)) else a }});
 };
 
 cneg_fp_alias_1_2_ov <- admit "cneg_fp" cneg_fp_alias_1_2_spec;

--- a/proof/group_test.saw
+++ b/proof/group_test.saw
@@ -8,7 +8,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 let blst_p1_affine_in_g1_spec = do {
-  (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_struct "struct.POINTonE1_affine");
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE1_affine");
   crucible_execute_func [p_ptr];
   ret <- crucible_fresh_var "ret" limb_type;
   crucible_return (crucible_term ret);
@@ -16,7 +16,7 @@ let blst_p1_affine_in_g1_spec = do {
 
 
 let blst_p2_affine_in_g2_spec = do {
-  (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_struct "struct.POINTonE2_affine");
+  (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE2_affine");
   crucible_execute_func [p_ptr];
   ret <- crucible_fresh_var "ret" limb_type;
   crucible_return (crucible_term ret);

--- a/proof/group_test.saw
+++ b/proof/group_test.saw
@@ -9,17 +9,17 @@
 
 let blst_p1_affine_in_g1_spec = do {
   (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE1_affine");
-  crucible_execute_func [p_ptr];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_return (crucible_term ret);
+  llvm_execute_func [p_ptr];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 
 
 let blst_p2_affine_in_g2_spec = do {
   (_, p_ptr) <- ptr_to_fresh_readonly "p" (llvm_alias "struct.POINTonE2_affine");
-  crucible_execute_func [p_ptr];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_return (crucible_term ret);
+  llvm_execute_func [p_ptr];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 
 let overrides = foldr concat [ec_ops_overrides, assembly_overrides] [];

--- a/proof/hash_to_field_memory_safety.saw
+++ b/proof/hash_to_field_memory_safety.saw
@@ -10,22 +10,22 @@
 import "../spec/ExpandMessage.cry";
 
 let expand_message_spec len_in_bytes aug_len msg_len DST_len = do {
-  bytes_ptr <- crucible_alloc_aligned 8 (llvm_array len_in_bytes (llvm_int 8));
+  bytes_ptr <- llvm_alloc_aligned 8 (llvm_array len_in_bytes (llvm_int 8));
   (aug, aug_ptr) <- ptr_to_fresh_readonly "aug" (llvm_array aug_len (llvm_int 8));
   (msg, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));
   (DST, DST_ptr) <- ptr_to_fresh_readonly "DST" (llvm_array DST_len (llvm_int 8));
-  crucible_execute_func [bytes_ptr, crucible_term {{ `len_in_bytes : [64] }}, aug_ptr, crucible_term {{ `aug_len : [64] }}, msg_ptr, crucible_term {{ `msg_len : [64] }}, DST_ptr, crucible_term {{ `DST_len : [64] }}];
-  crucible_points_to bytes_ptr (crucible_term {{ expand_message_xmd`{len_in_bytes=len_in_bytes} (aug # msg) DST }});
+  llvm_execute_func [bytes_ptr, llvm_term {{ `len_in_bytes : [64] }}, aug_ptr, llvm_term {{ `aug_len : [64] }}, msg_ptr, llvm_term {{ `msg_len : [64] }}, DST_ptr, llvm_term {{ `DST_len : [64] }}];
+  llvm_points_to bytes_ptr (llvm_term {{ expand_message_xmd`{len_in_bytes=len_in_bytes} (aug # msg) DST }});
 };
 
 let hash_to_field_spec nelems aug_len msg_len DST_len = do {
-  elems_ptr <- crucible_alloc (llvm_array nelems vec384_type);
+  elems_ptr <- llvm_alloc (llvm_array nelems vec384_type);
   (_, aug_ptr) <- ptr_to_fresh_readonly "aug" (llvm_array aug_len (llvm_int 8));
   (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array msg_len (llvm_int 8));
   (_, DST_ptr) <- ptr_to_fresh_readonly "DST" (llvm_array DST_len (llvm_int 8));
-  crucible_execute_func [elems_ptr, crucible_term {{ `nelems : [64] }}, aug_ptr, crucible_term {{ `aug_len : [64] }}, msg_ptr, crucible_term {{ `msg_len : [64] }}, DST_ptr, crucible_term {{ `DST_len : [64] }}];
-  new_elems <- crucible_fresh_var "new_elems" (llvm_array nelems vec384_type);
-  crucible_points_to elems_ptr (crucible_term new_elems);
+  llvm_execute_func [elems_ptr, llvm_term {{ `nelems : [64] }}, aug_ptr, llvm_term {{ `aug_len : [64] }}, msg_ptr, llvm_term {{ `msg_len : [64] }}, DST_ptr, llvm_term {{ `DST_len : [64] }}];
+  new_elems <- llvm_fresh_var "new_elems" (llvm_array nelems vec384_type);
+  llvm_points_to elems_ptr (llvm_term new_elems);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/hash_to_g1.saw
+++ b/proof/hash_to_g1.saw
@@ -83,11 +83,11 @@ let dbl_n_add_spec n = do {
 
 // we also need this:
 let recip_sqrt_fp_3mod4_spec = do {
-    out_ptr <- crucible_alloc vec384_type;
+    out_ptr <- llvm_alloc vec384_type;
     (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384_type;
-    crucible_precond {{ fp_invariant inp }};
-    crucible_execute_func [out_ptr, inp_ptr];
-    crucible_points_to out_ptr (crucible_term {{fp_rep (Fp.div (Fp.field_unit, sqrt_fp (fp_abs inp))) }});
+    llvm_precond {{ fp_invariant inp }};
+    llvm_execute_func [out_ptr, inp_ptr];
+    llvm_points_to out_ptr (llvm_term {{fp_rep (Fp.div (Fp.field_unit, sqrt_fp (fp_abs inp))) }});
     };
 
 // Proof copied from the proof of `recip_sqrt_fp` in `exp.saw`:

--- a/proof/helpers.saw
+++ b/proof/helpers.saw
@@ -8,46 +8,46 @@
 // Given a value `v` of type `ty`, allocates and returns a pointer to memory
 // storing `v`
 let alloc_init ty v = do {
-  p <- crucible_alloc ty;
-  crucible_points_to p v;
+  p <- llvm_alloc ty;
+  llvm_points_to p v;
   return p;
 };
 
 // Given a value `v` of type `ty`, allocates and returns a read only pointer to
 // memory storing `v`
 let alloc_init_readonly ty v = do {
-  p <- crucible_alloc_readonly ty;
-  crucible_points_to p v;
+  p <- llvm_alloc_readonly ty;
+  llvm_points_to p v;
   return p;
 };
 
 // Given a name `n` and a type `ty`, allocates a fresh variable `x` of type
 // `ty` and returns a tuple of `x` and a pointer to `x`.
 let ptr_to_fresh n ty = do {
-  x <- crucible_fresh_var n ty;
-  p <- alloc_init ty (crucible_term x);
+  x <- llvm_fresh_var n ty;
+  p <- alloc_init ty (llvm_term x);
   return (x, p);
 };
 
 // Given a name `n` and a type `ty`, allocates a fresh variable `x` of type
 // `ty` and returns a tuple of `x` and a read only pointer to `x`.
 let ptr_to_fresh_readonly n ty = do {
-  x <- crucible_fresh_var n ty;
-  p <- alloc_init_readonly ty (crucible_term x);
+  x <- llvm_fresh_var n ty;
+  p <- alloc_init_readonly ty (llvm_term x);
   return (x, p);
 };
 
 let global_points_to n v = do {
-  crucible_points_to (crucible_global n) (crucible_term v);
+  llvm_points_to (llvm_global n) (llvm_term v);
 };
 
 let global_alloc_init n v = do {
-  crucible_alloc_global n;
+  llvm_alloc_global n;
   global_points_to n v;
 };
 
 let points_to ty p n = do {
-  x <- crucible_fresh_var n ty;
-  crucible_points_to p (crucible_term x);
+  x <- llvm_fresh_var n ty;
+  llvm_points_to p (llvm_term x);
   return x;
 };

--- a/proof/keygen.saw
+++ b/proof/keygen.saw
@@ -39,28 +39,28 @@ let mul_mont_sparse_256_alias_spec = do { // NOTE: first two args are aliases
   (ret, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   (p, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_precond {{ p ==  BLS12_381_r }} ;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term {{ r0 }} ];
-  crucible_points_to ret_ptr (crucible_term {{mul_mont_256_rep ret b}});
+  llvm_precond {{ p ==  BLS12_381_r }} ;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term {{ r0 }} ];
+  llvm_points_to ret_ptr (llvm_term {{mul_mont_256_rep ret b}});
 };
 
 // All uses have p_ptr == BLS12_381_r and n0 == r0
 let redc_mont_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec512_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
-  crucible_precond {{ b ==  BLS12_381_r }} ;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term {{ r0 }}];
-  crucible_points_to ret_ptr (crucible_term {{ r_redc_rep a }});
+  llvm_precond {{ b ==  BLS12_381_r }} ;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, llvm_term {{ r0 }}];
+  llvm_points_to ret_ptr (llvm_term {{ r_redc_rep a }});
 };
 
 let redc_mont_256_alias_1_2_spec = do {
   (a, a_ptr) <- ptr_to_fresh "a" vec512_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
-  crucible_precond {{ b ==  BLS12_381_r }} ;
-  crucible_execute_func [a_ptr, a_ptr, b_ptr, crucible_term {{ r0 }}];
+  llvm_precond {{ b ==  BLS12_381_r }} ;
+  llvm_execute_func [a_ptr, a_ptr, b_ptr, llvm_term {{ r0 }}];
   // now only the first half of a is changed
-  crucible_points_to a_ptr (crucible_term {{ (r_redc_rep a) # (drop`{4} a) }});
+  llvm_points_to a_ptr (llvm_term {{ (r_redc_rep a) # (drop`{4} a) }});
 };
 
 // Now we give specs for the functions we verify:
@@ -69,81 +69,81 @@ let redc_mont_256_alias_1_2_spec = do {
 //import "../cryptol-specs/Primitive/Symmetric/KDF/HKDF256.cry";
 
 let HKDF_Extract_spec salt_len IKM_len = do {
-  PRK_ptr <- crucible_alloc (llvm_array 32 (llvm_int 8));
+  PRK_ptr <- llvm_alloc (llvm_array 32 (llvm_int 8));
 
-  salt <- crucible_fresh_var "salt" (llvm_array salt_len (llvm_int 8));
-  // salt_ptr <- crucible_alloc_readonly_aligned 8 (llvm_array salt_len (llvm_int 8));
-  salt_ptr <- crucible_alloc_readonly (llvm_array salt_len (llvm_int 8));
-  crucible_points_to salt_ptr (crucible_term salt);
+  salt <- llvm_fresh_var "salt" (llvm_array salt_len (llvm_int 8));
+  // salt_ptr <- llvm_alloc_readonly_aligned 8 (llvm_array salt_len (llvm_int 8));
+  salt_ptr <- llvm_alloc_readonly (llvm_array salt_len (llvm_int 8));
+  llvm_points_to salt_ptr (llvm_term salt);
 
-  IKM <- crucible_fresh_var "IKM" (llvm_array IKM_len (llvm_int 8));
-  // IKM_ptr <- crucible_alloc_readonly_aligned 8 (llvm_array IKM_len (llvm_int 8));
-  IKM_ptr <- crucible_alloc_readonly (llvm_array IKM_len (llvm_int 8));
-  crucible_points_to IKM_ptr (crucible_term IKM);
+  IKM <- llvm_fresh_var "IKM" (llvm_array IKM_len (llvm_int 8));
+  // IKM_ptr <- llvm_alloc_readonly_aligned 8 (llvm_array IKM_len (llvm_int 8));
+  IKM_ptr <- llvm_alloc_readonly (llvm_array IKM_len (llvm_int 8));
+  llvm_points_to IKM_ptr (llvm_term IKM);
 
-  ctx <- crucible_alloc (llvm_alias "struct.HMAC_SHA256_CTX");
+  ctx <- llvm_alloc (llvm_alias "struct.HMAC_SHA256_CTX");
 
-  crucible_execute_func [PRK_ptr, salt_ptr, crucible_term {{ `salt_len:[64]}}, IKM_ptr, crucible_term {{ `IKM_len:[64]}}, ctx];
-  crucible_points_to PRK_ptr (crucible_term {{ HKDF_Extract salt (IKM # [0]) }});
+  llvm_execute_func [PRK_ptr, salt_ptr, llvm_term {{ `salt_len:[64]}}, IKM_ptr, llvm_term {{ `IKM_len:[64]}}, ctx];
+  llvm_points_to PRK_ptr (llvm_term {{ HKDF_Extract salt (IKM # [0]) }});
 };
 
 let HKDF_Expand_spec info_len L = do {
   // OKM needs alignment as it is cast to a pointer to integer
-  OKM_ptr <- crucible_alloc_aligned 4 (llvm_array L (llvm_int 8));
+  OKM_ptr <- llvm_alloc_aligned 4 (llvm_array L (llvm_int 8));
 
   (PRK, PRK_ptr) <- ptr_to_fresh "PTR"  (llvm_array 32 (llvm_int 8));
 
-  info_ptr <- crucible_alloc_readonly (llvm_array info_len (llvm_int 8));
+  info_ptr <- llvm_alloc_readonly (llvm_array info_len (llvm_int 8));
 
   info <- if eval_bool {{ (`info_len:[64]) == 0 }} // need special case for pointing to 0-length; SAW issue
           then do { return {{ []: [0][8] }}; }
           else do {
-              info <- crucible_fresh_var "info" (llvm_array info_len (llvm_int 8));
-              crucible_points_to info_ptr (crucible_term info);
+              info <- llvm_fresh_var "info" (llvm_array info_len (llvm_int 8));
+              llvm_points_to info_ptr (llvm_term info);
               return info;
               };
 
-  //info <- crucible_fresh_var "info" (llvm_array info_len (llvm_int 8));
-  //crucible_conditional_points_to {{ `info_len == 0 }} info_ptr (crucible_term info);
+  //info <- llvm_fresh_var "info" (llvm_array info_len (llvm_int 8));
+  //llvm_conditional_points_to {{ `info_len == 0 }} info_ptr (llvm_term info);
   //if eval_bool {{ `info_len == (0:[64]) }} // need special case for pointing to 0-length; SAW issue
   //  then do { return (); }
-  //  else do {crucible_points_to info_ptr (crucible_term info);} ;
+  //  else do {llvm_points_to info_ptr (llvm_term info);} ;
 
-  ctx <- crucible_alloc (llvm_alias "struct.HMAC_SHA256_CTX");
+  ctx <- llvm_alloc (llvm_alias "struct.HMAC_SHA256_CTX");
 
-  crucible_execute_func [OKM_ptr, crucible_term {{ `L:[64]}}, PRK_ptr, info_ptr, crucible_term {{ `info_len:[64]}}, ctx];
-  crucible_points_to OKM_ptr (crucible_term {{ HKDF_Expand`{L=L} PRK  (info #  I2OSP`{xLen=2} `L) }});
+  llvm_execute_func [OKM_ptr, llvm_term {{ `L:[64]}}, PRK_ptr, info_ptr, llvm_term {{ `info_len:[64]}}, ctx];
+  llvm_points_to OKM_ptr (llvm_term {{ HKDF_Expand`{L=L} PRK  (info #  I2OSP`{xLen=2} `L) }});
 };
 
 
 let blst_keygen_spec IKM_len info_len = do {
-  SK_ptr <- crucible_alloc pow256_type;
+  SK_ptr <- llvm_alloc pow256_type;
 
-  IKM <- crucible_fresh_var "IKM" (llvm_array IKM_len (llvm_int 8));
-  IKM_ptr <- crucible_alloc_readonly_aligned 8 (llvm_array IKM_len (llvm_int 8));
-  crucible_points_to IKM_ptr (crucible_term IKM);
+  IKM <- llvm_fresh_var "IKM" (llvm_array IKM_len (llvm_int 8));
+  IKM_ptr <- llvm_alloc_readonly_aligned 8 (llvm_array IKM_len (llvm_int 8));
+  llvm_points_to IKM_ptr (llvm_term IKM);
 
-  info <- crucible_fresh_var "info" (llvm_array info_len (llvm_int 8));
-  info_ptr <- crucible_alloc_readonly_aligned 8 (llvm_array info_len (llvm_int 8));
-  crucible_points_to info_ptr (crucible_term info);
+  info <- llvm_fresh_var "info" (llvm_array info_len (llvm_int 8));
+  info_ptr <- llvm_alloc_readonly_aligned 8 (llvm_array info_len (llvm_int 8));
+  llvm_points_to info_ptr (llvm_term info);
 
-  crucible_execute_func [SK_ptr, IKM_ptr, crucible_term {{ `IKM_len:[64]}}, info_ptr, crucible_term {{ `info_len:[64]}}];
-  crucible_points_to SK_ptr (crucible_term {{ (KeyGen_rep (IKM, info)) }});
+  llvm_execute_func [SK_ptr, IKM_ptr, llvm_term {{ `IKM_len:[64]}}, info_ptr, llvm_term {{ `info_len:[64]}}];
+  llvm_points_to SK_ptr (llvm_term {{ (KeyGen_rep (IKM, info)) }});
 };
 
 // This may not be a necessary override
 let limbs_from_be_bytes_spec48 = do {
-  ret_p <-crucible_alloc (llvm_array 6 limb_type);
+  ret_p <- llvm_alloc (llvm_array 6 limb_type);
   (inx, in_ptr) <- ptr_to_fresh "limbs_from_be_bytes_in" (llvm_array 48 (llvm_int 8)); // "in" is a keyword
-  crucible_execute_func [ret_p, in_ptr, crucible_term {{ 48:[64] }}];
-  crucible_points_to ret_p (crucible_term {{limbs_from_be_bytes_rep48 inx}});
+  llvm_execute_func [ret_p, in_ptr, llvm_term {{ 48:[64] }}];
+  llvm_points_to ret_p (llvm_term {{limbs_from_be_bytes_rep48 inx}});
   };
 
 // ...and this is not needed
 let vec_is_zero_spec n = do { // n is size IN LIMBS
   (a, a_ptr) <- ptr_to_fresh "a" (llvm_array n limb_type);
-  crucible_execute_func [a_ptr, crucible_term {{ (8 * (`n:[64])) }}];
-  crucible_return (crucible_term {{ if a == (zero:[n][64]) then 1 else (0:[64]) }});
+  llvm_execute_func [a_ptr, llvm_term {{ (8 * (`n:[64])) }}];
+  llvm_return (llvm_term {{ if a == (zero:[n][64]) then 1 else (0:[64]) }});
   };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -152,27 +152,27 @@ let vec_is_zero_spec n = do { // n is size IN LIMBS
 
 
 // First create all the overrides
-mul_mont_sparse_256_alias_ov <- crucible_llvm_unsafe_assume_spec m "mulx_mont_sparse_256" mul_mont_sparse_256_alias_spec;
+mul_mont_sparse_256_alias_ov <- llvm_unsafe_assume_spec m "mulx_mont_sparse_256" mul_mont_sparse_256_alias_spec;
 
-redc_mont_256_ov <- crucible_llvm_unsafe_assume_spec m "redcx_mont_256" redc_mont_256_spec;
-redc_mont_256_alias_1_2_ov <- crucible_llvm_unsafe_assume_spec m "redcx_mont_256" redc_mont_256_alias_1_2_spec;
+redc_mont_256_ov <- llvm_unsafe_assume_spec m "redcx_mont_256" redc_mont_256_spec;
+redc_mont_256_alias_1_2_ov <- llvm_unsafe_assume_spec m "redcx_mont_256" redc_mont_256_alias_1_2_spec;
 
 let assumed_overrides = [ redc_mont_256_ov, redc_mont_256_alias_1_2_ov
                         , mul_mont_sparse_256_alias_ov
                         , blst_sha256_emit_ov, blst_sha256_hcopy_ov
                         ];
 
-limbs_from_be_bytes_ov_48 <- crucible_llvm_verify m "limbs_from_be_bytes" [] false (limbs_from_be_bytes_spec48) z3;
+limbs_from_be_bytes_ov_48 <- llvm_verify m "limbs_from_be_bytes" [] false (limbs_from_be_bytes_spec48) z3;
 
 // unused, but works:
-// vec_is_zero_ov_4 <- crucible_llvm_verify m "vec_is_zero" [] false (vec_is_zero_spec 4) z3;
+// vec_is_zero_ov_4 <- llvm_verify m "vec_is_zero" [] false (vec_is_zero_spec 4) z3;
 
 // finally we verify functions:
 
 // Function to verify the instance of HKDF_Extract needed for a call to keygen
 let verify_HKDF_Extract_for salt_len IKM_len = do {
   ovs <- make_block_data_order_ovs [salt_len, IKM_len];
-  r <- crucible_llvm_verify m "HKDF_Extract" (concat bcopy_ovs (concat ovs assumed_overrides)) false (HKDF_Extract_spec salt_len IKM_len) (w4_unint_z3 ["processBlock_Common"]);
+  r <- llvm_verify m "HKDF_Extract" (concat bcopy_ovs (concat ovs assumed_overrides)) false (HKDF_Extract_spec salt_len IKM_len) (w4_unint_z3 ["processBlock_Common"]);
   return r;
 };
 
@@ -188,7 +188,7 @@ verify_HKDF_Extract_for 32 5;
 let verify_HKDF_Expand_for info_len L = do {
   ovs <- make_block_data_order_ovs [eval_size {|info_len+3|}];
 
-  r <- crucible_llvm_verify m "HKDF_Expand" (concat bcopy_ovs (concat ovs assumed_overrides)) false (HKDF_Expand_spec info_len L) (w4_unint_z3 ["processBlock_Common"]);
+  r <- llvm_verify m "HKDF_Expand" (concat bcopy_ovs (concat ovs assumed_overrides)) false (HKDF_Expand_spec info_len L) (w4_unint_z3 ["processBlock_Common"]);
   return r;
   };
 
@@ -213,7 +213,7 @@ let verify_keygen_for IKM_len info_len = do {
   ov2 <- verify_HKDF_Expand_for info_len 48; // L = 48
   ov3 <- make_block_data_order_ovs [keygen_salt_len];
 
-  ret <- crucible_llvm_verify m "blst_keygen"
+  ret <- llvm_verify m "blst_keygen"
     (foldr concat [ [ ov1, ov2, limbs_from_be_bytes_ov_48
                     ]
                   , bcopy_ovs, ov3

--- a/proof/keygen.saw
+++ b/proof/keygen.saw
@@ -81,7 +81,7 @@ let HKDF_Extract_spec salt_len IKM_len = do {
   IKM_ptr <- crucible_alloc_readonly (llvm_array IKM_len (llvm_int 8));
   crucible_points_to IKM_ptr (crucible_term IKM);
 
-  ctx <- crucible_alloc (llvm_struct "struct.HMAC_SHA256_CTX");
+  ctx <- crucible_alloc (llvm_alias "struct.HMAC_SHA256_CTX");
 
   crucible_execute_func [PRK_ptr, salt_ptr, crucible_term {{ `salt_len:[64]}}, IKM_ptr, crucible_term {{ `IKM_len:[64]}}, ctx];
   crucible_points_to PRK_ptr (crucible_term {{ HKDF_Extract salt (IKM # [0]) }});
@@ -109,7 +109,7 @@ let HKDF_Expand_spec info_len L = do {
   //  then do { return (); }
   //  else do {crucible_points_to info_ptr (crucible_term info);} ;
 
-  ctx <- crucible_alloc (llvm_struct "struct.HMAC_SHA256_CTX");
+  ctx <- crucible_alloc (llvm_alias "struct.HMAC_SHA256_CTX");
 
   crucible_execute_func [OKM_ptr, crucible_term {{ `L:[64]}}, PRK_ptr, info_ptr, crucible_term {{ `info_len:[64]}}, ctx];
   crucible_points_to OKM_ptr (crucible_term {{ HKDF_Expand`{L=L} PRK  (info #  I2OSP`{xLen=2} `L) }});

--- a/proof/pairing.saw
+++ b/proof/pairing.saw
@@ -44,87 +44,87 @@
 // Only ever called with count=2, and aliased
 let lshift_mod_384_alias_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "x" vec384_type;
-  n_ptr <- crucible_alloc_readonly vec384_type;
-  crucible_precond {{ fp_invariant a}};
-  crucible_points_to n_ptr p_representation;
-  crucible_execute_func [a_ptr, a_ptr, crucible_term {{2:Size_t}} , n_ptr];
-  crucible_points_to a_ptr (crucible_term {{ fp_rep (lshift_fp (fp_abs a) 2) }});
+  n_ptr <- llvm_alloc_readonly vec384_type;
+  llvm_precond {{ fp_invariant a}};
+  llvm_points_to n_ptr p_representation;
+  llvm_execute_func [a_ptr, a_ptr, llvm_term {{2:Size_t}} , n_ptr];
+  llvm_points_to a_ptr (llvm_term {{ fp_rep (lshift_fp (fp_abs a) 2) }});
   };
 
 let lshift_fp2_alias_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "x" vec384x_type;
-  crucible_precond {{ fp2_invariant a}};
-  crucible_execute_func [a_ptr, a_ptr, crucible_term {{2:Size_t}}];
-  crucible_points_to a_ptr (crucible_term {{ fp2_rep (lshift_fp2 (fp2_abs a) 2) }});
+  llvm_precond {{ fp2_invariant a}};
+  llvm_execute_func [a_ptr, a_ptr, llvm_term {{2:Size_t}}];
+  llvm_points_to a_ptr (llvm_term {{ fp2_rep (lshift_fp2 (fp2_abs a) 2) }});
   };
 
 
 let line_by_Px2_spec = do {
     (line, line_ptr) <- ptr_to_fresh "line" vec384fp6_type;
     (Px2, Px2_ptr) <- ptr_to_fresh_readonly "Px2" POINTonE1_affine_type;
-    crucible_precond {{ POINTonE1_affine_invariant Px2 }};
-    crucible_precond {{ fp6_invariant line }};
-    crucible_execute_func [line_ptr, Px2_ptr];
-    crucible_points_to line_ptr (crucible_term
+    llvm_precond {{ POINTonE1_affine_invariant Px2 }};
+    llvm_precond {{ fp6_invariant line }};
+    llvm_execute_func [line_ptr, Px2_ptr];
+    llvm_points_to line_ptr (llvm_term
       {{ fp6_rep (line_by_Px2 (fp6_abs line) (POINTonE1_affine_abs Px2)) }});
 };
 
 let line_dbl_spec = do {
-  line_ptr <- crucible_alloc vec384fp6_type;
-  T_ptr <- crucible_alloc POINTonE2_type;
+  line_ptr <- llvm_alloc vec384fp6_type;
+  T_ptr <- llvm_alloc POINTonE2_type;
   (Q, Q_ptr) <- ptr_to_fresh_readonly "line_dbl_Q" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant Q }};
-  crucible_execute_func [line_ptr, T_ptr, Q_ptr];
-  crucible_points_to T_ptr (crucible_term {{ POINTonE2_rep (point_double Fp_2 (POINTonE2_abs Q)) }});
-  crucible_points_to line_ptr (crucible_term {{ fp6_rep (line_double_imp (POINTonE2_abs Q)) }});
+  llvm_precond {{ POINTonE2_invariant Q }};
+  llvm_execute_func [line_ptr, T_ptr, Q_ptr];
+  llvm_points_to T_ptr (llvm_term {{ POINTonE2_rep (point_double Fp_2 (POINTonE2_abs Q)) }});
+  llvm_points_to line_ptr (llvm_term {{ fp6_rep (line_double_imp (POINTonE2_abs Q)) }});
 };
 
 let line_dbl_alias_spec = do {
-  line_ptr <- crucible_alloc vec384fp6_type;
+  line_ptr <- llvm_alloc vec384fp6_type;
   (T, T_ptr) <- ptr_to_fresh "line_dbl_T" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant T }};
-  crucible_execute_func [line_ptr, T_ptr, T_ptr];
-  crucible_points_to T_ptr (crucible_term {{ POINTonE2_rep (point_double Fp_2 (POINTonE2_abs T)) }});
-  crucible_points_to line_ptr (crucible_term {{ fp6_rep (line_double_imp (POINTonE2_abs T)) }});
+  llvm_precond {{ POINTonE2_invariant T }};
+  llvm_execute_func [line_ptr, T_ptr, T_ptr];
+  llvm_points_to T_ptr (llvm_term {{ POINTonE2_rep (point_double Fp_2 (POINTonE2_abs T)) }});
+  llvm_points_to line_ptr (llvm_term {{ fp6_rep (line_double_imp (POINTonE2_abs T)) }});
 };
 
 let line_add_spec = do {
-  line_ptr <- crucible_alloc vec384fp6_type;
+  line_ptr <- llvm_alloc vec384fp6_type;
   (T, T_ptr) <- ptr_to_fresh "line_add_T" POINTonE2_type;
   (R, R_ptr) <- ptr_to_fresh_readonly "line_add_R" POINTonE2_type;
   (Q, Q_ptr) <- ptr_to_fresh_readonly "line_add_Q" POINTonE2_affine_type;
-  crucible_precond {{ POINTonE2_invariant R }};
-  crucible_precond {{ POINTonE2_affine_invariant Q }};
-  crucible_execute_func [line_ptr, T_ptr, R_ptr, Q_ptr];
-  crucible_points_to T_ptr (crucible_term
+  llvm_precond {{ POINTonE2_invariant R }};
+  llvm_precond {{ POINTonE2_affine_invariant Q }};
+  llvm_execute_func [line_ptr, T_ptr, R_ptr, Q_ptr];
+  llvm_points_to T_ptr (llvm_term
     {{ POINTonE2_rep (point_add_affine_alt Fp_2 (POINTonE2_abs R) (POINTonE2_affine_abs Q)) }});
-  crucible_points_to line_ptr (crucible_term
+  llvm_points_to line_ptr (llvm_term
     {{ fp6_rep (line_add_imp (POINTonE2_abs R) (POINTonE2_affine_abs Q)) }});
 };
 
 let line_add_alias_spec = do {
-  line_ptr <- crucible_alloc vec384fp6_type;
+  line_ptr <- llvm_alloc vec384fp6_type;
   (T, T_ptr) <- ptr_to_fresh "line_add_T" POINTonE2_type;
   (Q, Q_ptr) <- ptr_to_fresh_readonly "line_add_Q" POINTonE2_affine_type;
-  crucible_precond {{ POINTonE2_invariant T }};
-  crucible_precond {{ POINTonE2_affine_invariant Q }};
-  crucible_execute_func [line_ptr, T_ptr, T_ptr, Q_ptr];
-  crucible_points_to T_ptr (crucible_term
+  llvm_precond {{ POINTonE2_invariant T }};
+  llvm_precond {{ POINTonE2_affine_invariant Q }};
+  llvm_execute_func [line_ptr, T_ptr, T_ptr, Q_ptr];
+  llvm_points_to T_ptr (llvm_term
     {{ POINTonE2_rep (point_add_affine_alt Fp_2 (POINTonE2_abs T) (POINTonE2_affine_abs Q)) }});
-  crucible_points_to line_ptr (crucible_term
+  llvm_points_to line_ptr (llvm_term
     {{ fp6_rep (line_add_imp (POINTonE2_abs T) (POINTonE2_affine_abs Q)) }});
 };
 
 let start_dbl_n_spec n = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (T, T_ptr) <- ptr_to_fresh "T" (llvm_array n POINTonE2_type);
   (Px2, Px2_ptr) <- ptr_to_fresh_readonly "Px2" (llvm_array n POINTonE1_affine_type);
-  crucible_precond {{ all POINTonE2_invariant T }};
-  crucible_precond {{ all POINTonE1_affine_invariant Px2 }};
-  crucible_execute_func [ret_ptr, T_ptr, Px2_ptr, llvm_term {{ (`n:Size_t) }}];
-  crucible_points_to ret_ptr (llvm_term
+  llvm_precond {{ all POINTonE2_invariant T }};
+  llvm_precond {{ all POINTonE1_affine_invariant Px2 }};
+  llvm_execute_func [ret_ptr, T_ptr, Px2_ptr, llvm_term {{ (`n:Size_t) }}];
+  llvm_points_to ret_ptr (llvm_term
     {{ fp12_rep (start_dbl_n_imp (map POINTonE2_abs T) (map POINTonE1_affine_abs Px2)) }});
-  crucible_points_to T_ptr (crucible_term {{ map (\ Q -> POINTonE2_rep (point_double Fp_2 (POINTonE2_abs Q))) T }});
+  llvm_points_to T_ptr (llvm_term {{ map (\ Q -> POINTonE2_rep (point_double Fp_2 (POINTonE2_abs Q))) T }});
   };
 
 let add_n_dbl_n_1_spec k = do {
@@ -132,15 +132,15 @@ let add_n_dbl_n_1_spec k = do {
   (T, T_ptr) <- ptr_to_fresh "T" POINTonE2_type;
   (Q, Q_ptr) <- ptr_to_fresh_readonly "line_add_Q" POINTonE2_affine_type;
   (Px2, Px2_ptr) <- ptr_to_fresh_readonly "Px2" POINTonE1_affine_type;
-  crucible_precond {{ fp12_invariant ret }};
-  crucible_precond {{ POINTonE2_invariant T }};
-  crucible_precond {{ POINTonE2_affine_invariant Q }};
-  crucible_precond {{ POINTonE1_affine_invariant Px2 }};
-  crucible_execute_func [ret_ptr, T_ptr, Q_ptr, Px2_ptr, llvm_term {{ (1:Size_t) }}
+  llvm_precond {{ fp12_invariant ret }};
+  llvm_precond {{ POINTonE2_invariant T }};
+  llvm_precond {{ POINTonE2_affine_invariant Q }};
+  llvm_precond {{ POINTonE1_affine_invariant Px2 }};
+  llvm_execute_func [ret_ptr, T_ptr, Q_ptr, Px2_ptr, llvm_term {{ (1:Size_t) }}
                         , llvm_term {{ (`k:Size_t) }}];
-  crucible_points_to ret_ptr (llvm_term
+  llvm_points_to ret_ptr (llvm_term
     {{ fp12_rep (add_n_dbl_ret`{k} (fp12_abs ret) (POINTonE2_abs T) (POINTonE2_affine_abs Q) (POINTonE1_affine_abs Px2)) }});
-  crucible_points_to T_ptr (llvm_term
+  llvm_points_to T_ptr (llvm_term
     {{ POINTonE2_rep (add_n_dbl_alt`{k}  (POINTonE2_abs T) (POINTonE2_affine_abs Q)) }});
   };
 
@@ -149,16 +149,16 @@ let add_n_dbl_n_spec n k = do {
   (T, T_ptr) <- ptr_to_fresh "T" (llvm_array n POINTonE2_type);
   (Q, Q_ptr) <- ptr_to_fresh_readonly "line_add_Q" (llvm_array n POINTonE2_affine_type);
   (Px2, Px2_ptr) <- ptr_to_fresh_readonly "Px2" (llvm_array n POINTonE1_affine_type);
-  crucible_precond {{ fp12_invariant ret }};
-  crucible_precond {{ all POINTonE2_invariant T }};
-  crucible_precond {{ all POINTonE2_affine_invariant Q }};
-  crucible_precond {{ all POINTonE1_affine_invariant Px2 }};
-  crucible_execute_func [ret_ptr, T_ptr, Q_ptr, Px2_ptr, llvm_term {{ (`n:Size_t) }}
+  llvm_precond {{ fp12_invariant ret }};
+  llvm_precond {{ all POINTonE2_invariant T }};
+  llvm_precond {{ all POINTonE2_affine_invariant Q }};
+  llvm_precond {{ all POINTonE1_affine_invariant Px2 }};
+  llvm_execute_func [ret_ptr, T_ptr, Q_ptr, Px2_ptr, llvm_term {{ (`n:Size_t) }}
                         , llvm_term {{ (`k:Size_t) }}];
-  crucible_points_to ret_ptr (llvm_term
+  llvm_points_to ret_ptr (llvm_term
     {{ fp12_rep (add_n_dbl_n_ret`{n,k} (fp12_abs ret) (map POINTonE2_abs T)
                                        (map POINTonE2_affine_abs Q) (map POINTonE1_affine_abs Px2)) }});
-  crucible_points_to T_ptr (llvm_term
+  llvm_points_to T_ptr (llvm_term
     {{ [ POINTonE2_rep (add_n_dbl_alt`{k} (POINTonE2_abs Ti) (POINTonE2_affine_abs Qi)) | Ti <- T | Qi <- Q ] }});
   };
 
@@ -166,25 +166,25 @@ let add_n_dbl_n_spec n k = do {
 // differently when n=1.  So here I have separated out that case into a separate spec.
 
 let miller_loop_n_1_spec = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (Q, Q_ptr) <- ptr_to_fresh_readonly "Q" POINTonE2_affine_type; // array in general
   (P, P_ptr) <- ptr_to_fresh_readonly "P" POINTonE1_affine_type; // array in general
-  crucible_precond {{ POINTonE2_affine_invariant Q }};
-  crucible_precond {{ POINTonE1_affine_invariant P }};
-  crucible_execute_func [ret_ptr, Q_ptr, P_ptr, llvm_term {{ (1:Size_t) }}];
-  crucible_points_to ret_ptr (llvm_term
+  llvm_precond {{ POINTonE2_affine_invariant Q }};
+  llvm_precond {{ POINTonE1_affine_invariant P }};
+  llvm_execute_func [ret_ptr, Q_ptr, P_ptr, llvm_term {{ (1:Size_t) }}];
+  llvm_points_to ret_ptr (llvm_term
     {{ fp12_rep (miller_loop_opt_checked (POINTonE1_affine_abs P) (POINTonE2_affine_abs Q)) }});
   };
 
 // In the general case, n >= 2, we get the product of several Miller loop results.
 let miller_loop_n_spec n = do {
-  ret_ptr <- crucible_alloc vec384fp12_type;
+  ret_ptr <- llvm_alloc vec384fp12_type;
   (Qs, Q_ptr) <- ptr_to_fresh "Q" (llvm_array n POINTonE2_affine_type);
   (Ps, P_ptr) <- ptr_to_fresh_readonly "P" (llvm_array n POINTonE1_affine_type);
-  crucible_precond {{ all POINTonE2_affine_invariant Qs }};
-  crucible_precond {{ all POINTonE1_affine_invariant Ps }};
-  crucible_execute_func [ret_ptr, Q_ptr, P_ptr, llvm_term {{ (`n:Size_t) }}];
-  crucible_points_to ret_ptr (llvm_term
+  llvm_precond {{ all POINTonE2_affine_invariant Qs }};
+  llvm_precond {{ all POINTonE1_affine_invariant Ps }};
+  llvm_execute_func [ret_ptr, Q_ptr, P_ptr, llvm_term {{ (`n:Size_t) }}];
+  llvm_points_to ret_ptr (llvm_term
     {{ fp12_rep (F_prod Fp_12 [miller_loop_opt P Q | Q <- map POINTonE2_affine_abs Qs
                                                    | P <- map POINTonE1_affine_abs Ps ]) }});
   };

--- a/proof/proof-helpers.saw
+++ b/proof/proof-helpers.saw
@@ -40,29 +40,29 @@ let prover = w4_unint_z3;
 
 let verify_unint func overrides unints spec =
   if do_prove
-  then crucible_llvm_verify m func overrides false spec (prover unints)
-  else crucible_llvm_unsafe_assume_spec m func spec;
+  then llvm_verify m func overrides false spec (prover unints)
+  else llvm_unsafe_assume_spec m func spec;
 
 let verify func overrides spec =
   verify_unint func overrides [] spec;
 
 let test func overrides spec =
   if do_prove
-  then crucible_llvm_verify m func overrides false spec (quickcheck 100)
-  else crucible_llvm_unsafe_assume_spec m func spec;
+  then llvm_verify m func overrides false spec (quickcheck 100)
+  else llvm_unsafe_assume_spec m func spec;
 
 let custom_verify func overrides spec custom_tactic =
   if do_prove
-  then crucible_llvm_verify m func overrides false spec custom_tactic
-  else crucible_llvm_unsafe_assume_spec m func spec;
+  then llvm_verify m func overrides false spec custom_tactic
+  else llvm_unsafe_assume_spec m func spec;
 
 let custom_verify_path_sat func overrides spec custom_tactic =
   if do_prove
-  then crucible_llvm_verify m func overrides true spec custom_tactic
-  else crucible_llvm_unsafe_assume_spec m func spec;
+  then llvm_verify m func overrides true spec custom_tactic
+  else llvm_unsafe_assume_spec m func spec;
 
 let admit func spec =
-  crucible_llvm_unsafe_assume_spec m func spec;
+  llvm_unsafe_assume_spec m func spec;
 
 // ... and for Cryptol theorems
 
@@ -90,23 +90,23 @@ let test_cryptol thm =
 // ... for code proofs
 
 let really_verify_unint func overrides unints spec =
-    crucible_llvm_verify m func overrides false spec (prover unints);
+    llvm_verify m func overrides false spec (prover unints);
 
 let really_verify func overrides spec =
     really_verify_unint func overrides [] spec;
 
 let really_test func overrides spec =
-    crucible_llvm_verify m func overrides false spec (quickcheck 100);
+    llvm_verify m func overrides false spec (quickcheck 100);
 
 let really_custom_verify func overrides spec custom_tactic =
-  crucible_llvm_verify m func overrides false spec custom_tactic;
+  llvm_verify m func overrides false spec custom_tactic;
 
 let show_admit func overrides spec =
-   crucible_llvm_verify m func overrides false spec
+   llvm_verify m func overrides false spec
      (do { simplify basic_ss; simplify (cryptol_ss()); print_goal; assume_unsat; });
 
 let show_goal func overrides unints spec transformations =
-    crucible_llvm_verify m func overrides false spec do {
+    llvm_verify m func overrides false spec do {
         transformations;
         print_goal;
         prover unints;

--- a/proof/psi.saw
+++ b/proof/psi.saw
@@ -43,18 +43,18 @@ qi_x_spec_equiv_thm <- custom_prove_cryptol
        w4_unint_z3 (concat fp2_unints fp_unints); };
 
 let qi_x_iwsc_spec = do {
-  out_ptr <- crucible_alloc vec384x_type;
+  out_ptr <- llvm_alloc vec384x_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384x_type;
-  crucible_precond {{ fp2_invariant inp }};
-  crucible_execute_func [out_ptr, inp_ptr];
-  crucible_points_to out_ptr (crucible_term {{fp2_rep (qi_x_abs (fp2_abs inp))}});
+  llvm_precond {{ fp2_invariant inp }};
+  llvm_execute_func [out_ptr, inp_ptr];
+  llvm_points_to out_ptr (llvm_term {{fp2_rep (qi_x_abs (fp2_abs inp))}});
   };
 
 let qi_x_iwsc_alias_spec = do {
   (inp, inp_ptr) <- ptr_to_fresh "inp" vec384x_type;
-  crucible_precond {{ fp2_invariant inp }};
-  crucible_execute_func [inp_ptr, inp_ptr];
-  crucible_points_to inp_ptr (crucible_term {{fp2_rep (qi_x_abs (fp2_abs inp))}});
+  llvm_precond {{ fp2_invariant inp }};
+  llvm_execute_func [inp_ptr, inp_ptr];
+  llvm_points_to inp_ptr (llvm_term {{fp2_rep (qi_x_abs (fp2_abs inp))}});
   };
 
 // Need theorems about the constants
@@ -169,18 +169,18 @@ qi_y_spec_equiv_thm <- custom_prove_cryptol
        w4_unint_z3 fp2_unints; };
 
 let qi_y_iwsc_spec = do {
-  out_ptr <- crucible_alloc vec384x_type;
+  out_ptr <- llvm_alloc vec384x_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384x_type;
-  crucible_precond {{ fp2_invariant inp }};
-  crucible_execute_func [out_ptr, inp_ptr];
-  crucible_points_to out_ptr (crucible_term {{fp2_rep (qi_y_abs (fp2_abs inp))}});
+  llvm_precond {{ fp2_invariant inp }};
+  llvm_execute_func [out_ptr, inp_ptr];
+  llvm_points_to out_ptr (llvm_term {{fp2_rep (qi_y_abs (fp2_abs inp))}});
   };
 
 let qi_y_iwsc_alias_spec = do {
   (inp, inp_ptr) <- ptr_to_fresh "inp" vec384x_type;
-  crucible_precond {{ fp2_invariant inp }};
-  crucible_execute_func [inp_ptr, inp_ptr];
-  crucible_points_to inp_ptr (crucible_term {{fp2_rep (qi_y_abs (fp2_abs inp))}});
+  llvm_precond {{ fp2_invariant inp }};
+  llvm_execute_func [inp_ptr, inp_ptr];
+  llvm_points_to inp_ptr (llvm_term {{fp2_rep (qi_y_abs (fp2_abs inp))}});
   };
 
 qi_y_iwsc_ov <- custom_verify "qi_y_iwsc"
@@ -213,37 +213,37 @@ POINT_on_E2_fp2_rep_thm <- custom_prove_cryptol
   do { unfolding ["POINTonE2_abs"]; simplify fp2_simpset; w4_unint_z3 fp2_unints; } ;
 
 let psi_spec = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant inp }};
-  crucible_execute_func [out_ptr, inp_ptr];
-  out <-  crucible_fresh_var "out_psi" POINTonE2_type;
-  crucible_points_to out_ptr (crucible_term out);
-  crucible_postcond {{ affinify E' (POINTonE2_abs out) == psi (affinify E' (POINTonE2_abs inp)) }};
+  llvm_precond {{ POINTonE2_invariant inp }};
+  llvm_execute_func [out_ptr, inp_ptr];
+  out <-  llvm_fresh_var "out_psi" POINTonE2_type;
+  llvm_points_to out_ptr (llvm_term out);
+  llvm_postcond {{ affinify E' (POINTonE2_abs out) == psi (affinify E' (POINTonE2_abs inp)) }};
   };
 
 let psi_alias_1_2_spec = do {
   (inp, inp_ptr) <- ptr_to_fresh "inp" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant inp }};
-  crucible_execute_func [inp_ptr, inp_ptr];
-  out <-  crucible_fresh_var "out_psi" POINTonE2_type;
-  crucible_points_to inp_ptr (crucible_term out);
-  crucible_postcond {{ affinify E' (POINTonE2_abs out) == psi (affinify E' (POINTonE2_abs inp)) }};
+  llvm_precond {{ POINTonE2_invariant inp }};
+  llvm_execute_func [inp_ptr, inp_ptr];
+  out <-  llvm_fresh_var "out_psi" POINTonE2_type;
+  llvm_points_to inp_ptr (llvm_term out);
+  llvm_postcond {{ affinify E' (POINTonE2_abs out) == psi (affinify E' (POINTonE2_abs inp)) }};
   };
 
 let psi_spec' = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant inp }};
-  crucible_execute_func [out_ptr, inp_ptr];
-  crucible_points_to out_ptr (crucible_term {{ POINTonE2_rep (psi_imp (POINTonE2_abs inp)) }});
+  llvm_precond {{ POINTonE2_invariant inp }};
+  llvm_execute_func [out_ptr, inp_ptr];
+  llvm_points_to out_ptr (llvm_term {{ POINTonE2_rep (psi_imp (POINTonE2_abs inp)) }});
   };
 
 let psi_alias_1_2_spec' = do {
   (inp, inp_ptr) <- ptr_to_fresh "inp" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant inp }};
-  crucible_execute_func [inp_ptr, inp_ptr];
-  crucible_points_to inp_ptr (crucible_term {{ POINTonE2_rep (psi_imp (POINTonE2_abs inp)) }});
+  llvm_precond {{ POINTonE2_invariant inp }};
+  llvm_execute_func [inp_ptr, inp_ptr];
+  llvm_points_to inp_ptr (llvm_term {{ POINTonE2_rep (psi_imp (POINTonE2_abs inp)) }});
   };
 
 psi_ov <- custom_verify "psi"

--- a/proof/sgn0.saw
+++ b/proof/sgn0.saw
@@ -8,13 +8,13 @@ enable_experimental;
 let verify_x86 name spec tactic =
   if do_prove
   then
-  crucible_llvm_verify_x86 m "../build/x86/libblst.so" name
+  llvm_verify_x86 m "../build/x86/libblst.so" name
     []
     false
     spec
     tactic
   else
-  crucible_llvm_unsafe_assume_spec m name spec;
+  llvm_unsafe_assume_spec m name spec;
 
 import "../spec/implementation/Types.cry";
 import "../spec/implementation/Field.cry";
@@ -27,8 +27,8 @@ let sgn0x_pty_mont_384_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   llvm_precond {{ fp_invariant a }};
   p_ptr <- alloc_init_readonly vec384_type (llvm_term {{ vec384_rep (from_Fp `p) }});
-  llvm_execute_func [a_ptr, p_ptr, crucible_term {{ 0x89f3fffcfffcfffd }}];
-  crucible_return (crucible_term {{ (zext [sign_F_p (fp_abs a), HE1::sgn0 (fp_abs a)]):[64] }});
+  llvm_execute_func [a_ptr, p_ptr, llvm_term {{ 0x89f3fffcfffcfffd }}];
+  llvm_return (llvm_term {{ (zext [sign_F_p (fp_abs a), HE1::sgn0 (fp_abs a)]):[64] }});
 };
 
 // TODO: prove (not so easy because of the Montgomery representation)
@@ -38,8 +38,8 @@ let sgn0x_pty_mont_384x_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   llvm_precond {{ fp2_invariant a }};
   p_ptr <- alloc_init_readonly vec384_type (llvm_term {{ vec384_rep (from_Fp `p) }});
-  llvm_execute_func [a_ptr, p_ptr, crucible_term {{ 0x89f3fffcfffcfffd }}];
-  crucible_return (crucible_term {{ (zext [sign_F_p_2 (fp2_abs a), HE2::sgn0 (fp2_abs a)]):[64] }});
+  llvm_execute_func [a_ptr, p_ptr, llvm_term {{ 0x89f3fffcfffcfffd }}];
+  llvm_return (llvm_term {{ (zext [sign_F_p_2 (fp2_abs a), HE2::sgn0 (fp2_abs a)]):[64] }});
 };
 
 // TODO: prove (not so easy because of the Montgomery representation)

--- a/proof/sha_overrides.saw
+++ b/proof/sha_overrides.saw
@@ -20,17 +20,17 @@ let {{
 let blst_sha256_emit_spec = do {
   (h, h_ptr) <- ptr_to_fresh_readonly "h" (llvm_array 8 (llvm_int 32)); // should always be initialized
   let md_type = (llvm_array 32 (llvm_int 8));
-  md_ptr <- crucible_alloc md_type;
-  crucible_execute_func [md_ptr, h_ptr];
-  crucible_points_to md_ptr (crucible_term {{ (split (join h)) : [32][8]}} );
+  md_ptr <- llvm_alloc md_type;
+  llvm_execute_func [md_ptr, h_ptr];
+  llvm_points_to md_ptr (llvm_term {{ (split (join h)) : [32][8]}} );
 };
 
 let blst_sha256_hcopy_spec = do {
   let h_type = (llvm_array 8 (llvm_int 32));
-  dst_ptr <- crucible_alloc h_type;
+  dst_ptr <- llvm_alloc h_type;
   (src, src_ptr) <- ptr_to_fresh_readonly "src" h_type;
-  crucible_execute_func [dst_ptr, src_ptr];
-  crucible_points_to dst_ptr (crucible_term src);
+  llvm_execute_func [dst_ptr, src_ptr];
+  llvm_points_to dst_ptr (llvm_term src);
 };
 
 // blocks is a number of 512-bit blocks, which corresponds to 64 bytes
@@ -38,16 +38,16 @@ let blst_sha256_block_data_order_spec blocks = do {
   let h_type = (llvm_array 8 (llvm_int 32));
   (h, h_ptr) <- ptr_to_fresh "h" h_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" (llvm_array (eval_size {| 64*blocks |}) (llvm_int 8));
-  crucible_execute_func [h_ptr, inp_ptr, crucible_term {{ `blocks : [64] }}];
-  crucible_points_to h_ptr (crucible_term {{ SHA256foo`{blocks} h inp }});
+  llvm_execute_func [h_ptr, inp_ptr, llvm_term {{ `blocks : [64] }}];
+  llvm_points_to h_ptr (llvm_term {{ SHA256foo`{blocks} h inp }});
 };
 
 let blst_sha256_bcopy_spec len = do {
   let buf_type = (llvm_array len (llvm_int 8));
-  buf_ptr <- crucible_alloc buf_type;
+  buf_ptr <- llvm_alloc buf_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" buf_type;
-  crucible_execute_func [buf_ptr, inp_ptr, crucible_term {{ `len : [64] }}];
-  crucible_points_to buf_ptr (crucible_term inp);
+  llvm_execute_func [buf_ptr, inp_ptr, llvm_term {{ `len : [64] }}];
+  llvm_points_to buf_ptr (llvm_term inp);
 };
 
 // blst_keygen calls sha256_block_data_order and sha256_update_bcopy, which are

--- a/proof/sign.saw
+++ b/proof/sign.saw
@@ -8,20 +8,20 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 let blst_sign_pk_in_g2_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
-  (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_struct "struct.POINTonE1");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_alias "struct.POINTonE1");
   (_, sk_ptr) <- ptr_to_fresh_readonly "SK" pow256_type;
   crucible_execute_func [out_ptr, msg_ptr, sk_ptr];
-  new_out <- crucible_fresh_var "new_out" (llvm_struct "struct.POINTonE1");
+  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE1");
   crucible_points_to out_ptr (crucible_term new_out);
 };
 
 let blst_sign_pk_in_g1_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2");
-  (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_struct "struct.POINTonE2");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_alias "struct.POINTonE2");
   (_, sk_ptr) <- ptr_to_fresh_readonly "SK" pow256_type;
   crucible_execute_func [out_ptr, msg_ptr, sk_ptr];
-  new_out <- crucible_fresh_var "new_out" (llvm_struct "struct.POINTonE2");
+  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE2");
   crucible_points_to out_ptr (crucible_term new_out);
 };
 

--- a/proof/sign.saw
+++ b/proof/sign.saw
@@ -8,21 +8,21 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 let blst_sign_pk_in_g2_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_alias "struct.POINTonE1");
   (_, sk_ptr) <- ptr_to_fresh_readonly "SK" pow256_type;
-  crucible_execute_func [out_ptr, msg_ptr, sk_ptr];
-  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE1");
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, msg_ptr, sk_ptr];
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE1");
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 
 let blst_sign_pk_in_g1_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   (_, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_alias "struct.POINTonE2");
   (_, sk_ptr) <- ptr_to_fresh_readonly "SK" pow256_type;
-  crucible_execute_func [out_ptr, msg_ptr, sk_ptr];
-  new_out <- crucible_fresh_var "new_out" (llvm_alias "struct.POINTonE2");
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, msg_ptr, sk_ptr];
+  new_out <- llvm_fresh_var "new_out" (llvm_alias "struct.POINTonE2");
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/sk_to_pk.saw
+++ b/proof/sk_to_pk.saw
@@ -8,19 +8,19 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 let blst_sk_to_pk_in_g1_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE1");
   (_, SK_ptr) <- ptr_to_fresh_readonly "SK" vec256_type;
-  crucible_execute_func [out_ptr, SK_ptr];
-  new_SK <- crucible_fresh_var "new_SK" vec256_type;
-  crucible_points_to SK_ptr (crucible_term new_SK);
+  llvm_execute_func [out_ptr, SK_ptr];
+  new_SK <- llvm_fresh_var "new_SK" vec256_type;
+  llvm_points_to SK_ptr (llvm_term new_SK);
 };
 
 let blst_sk_to_pk_in_g2_spec = do {
-  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
+  out_ptr <- llvm_alloc (llvm_alias "struct.POINTonE2");
   (_, SK_ptr) <- ptr_to_fresh_readonly "SK" vec256_type;
-  crucible_execute_func [out_ptr, SK_ptr];
-  new_SK <- crucible_fresh_var "new_SK" vec256_type;
-  crucible_points_to SK_ptr (crucible_term new_SK);
+  llvm_execute_func [out_ptr, SK_ptr];
+  new_SK <- llvm_fresh_var "new_SK" vec256_type;
+  llvm_points_to SK_ptr (llvm_term new_SK);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/sk_to_pk.saw
+++ b/proof/sk_to_pk.saw
@@ -8,7 +8,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 let blst_sk_to_pk_in_g1_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE1");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE1");
   (_, SK_ptr) <- ptr_to_fresh_readonly "SK" vec256_type;
   crucible_execute_func [out_ptr, SK_ptr];
   new_SK <- crucible_fresh_var "new_SK" vec256_type;
@@ -16,7 +16,7 @@ let blst_sk_to_pk_in_g1_spec = do {
 };
 
 let blst_sk_to_pk_in_g2_spec = do {
-  out_ptr <- crucible_alloc (llvm_struct "struct.POINTonE2");
+  out_ptr <- crucible_alloc (llvm_alias "struct.POINTonE2");
   (_, SK_ptr) <- ptr_to_fresh_readonly "SK" vec256_type;
   crucible_execute_func [out_ptr, SK_ptr];
   new_SK <- crucible_fresh_var "new_SK" vec256_type;

--- a/proof/subgroup_check_g1.saw
+++ b/proof/subgroup_check_g1.saw
@@ -22,11 +22,11 @@ let {{
 
 
 let sigma_spec = do {
-  out_ptr <- crucible_alloc POINTonE1_type;
+  out_ptr <- llvm_alloc POINTonE1_type;
   (x, x_ptr) <- ptr_to_fresh_readonly "in"  POINTonE1_affine_type;
-  crucible_precond {{ POINTonE1_affine_invariant x }};
-  crucible_execute_func [out_ptr, x_ptr];
-  crucible_points_to out_ptr (crucible_term {{ POINTonE1_rep (projectify E (sigma (POINTonE1_affine_abs x))) }});
+  llvm_precond {{ POINTonE1_affine_invariant x }};
+  llvm_execute_func [out_ptr, x_ptr];
+  llvm_points_to out_ptr (llvm_term {{ POINTonE1_rep (projectify E (sigma (POINTonE1_affine_abs x))) }});
   };
 
 sigma_ov <- custom_verify "sigma"
@@ -74,15 +74,15 @@ let {{
 // the effect of this function
 
 let POINTonE1_times_zz_minus_1_div_by_3_spec = do {
-  out_ptr <- crucible_alloc POINTonE1_type;
+  out_ptr <- llvm_alloc POINTonE1_type;
   (x, x_ptr) <- ptr_to_fresh_readonly "in"  POINTonE1_type;
-  crucible_precond {{ POINTonE1_invariant x }};
-  crucible_execute_func [out_ptr, x_ptr];
-  out <- crucible_fresh_var "out_POINTonE1_times_zz_minus_1_div_by_3" POINTonE1_type;
-  crucible_points_to out_ptr (crucible_term out);
+  llvm_precond {{ POINTonE1_invariant x }};
+  llvm_execute_func [out_ptr, x_ptr];
+  out <- llvm_fresh_var "out_POINTonE1_times_zz_minus_1_div_by_3" POINTonE1_type;
+  llvm_points_to out_ptr (llvm_term out);
   };
 
-POINTonE1_times_zz_minus_1_div_by_3_ov <- crucible_llvm_compositional_extract m
+POINTonE1_times_zz_minus_1_div_by_3_ov <- llvm_compositional_extract m
     "POINTonE1_times_zz_minus_1_div_by_3"
     "POINTonE1_times_c"
     (concat  point_op_overrides fp_overrides)
@@ -147,11 +147,11 @@ vec_is_zero_call_thm <- prove_cryptol
 
 let POINTonE1_in_G1_spec = do {
   (p, p_ptr) <- ptr_to_fresh_readonly "p"  POINTonE1_affine_type;
-  crucible_precond {{ POINTonE1_affine_invariant p }};
-  crucible_precond {{ is_point_affine E (POINTonE1_affine_abs p) }}; // on the curve
-  crucible_precond {{ ~ (is_point_O E (POINTonE1_affine_abs p)) }};  // and not at infinity, i.e. (0,0)
-  crucible_execute_func [p_ptr];
-  crucible_return (crucible_term {{ bool_to_limb (is_in_g1_impl (POINTonE1_affine_abs p)) }});
+  llvm_precond {{ POINTonE1_affine_invariant p }};
+  llvm_precond {{ is_point_affine E (POINTonE1_affine_abs p) }}; // on the curve
+  llvm_precond {{ ~ (is_point_O E (POINTonE1_affine_abs p)) }};  // and not at infinity, i.e. (0,0)
+  llvm_execute_func [p_ptr];
+  llvm_return (llvm_term {{ bool_to_limb (is_in_g1_impl (POINTonE1_affine_abs p)) }});
   };
 
 affinify_projectify_thm <- test_cryptol {{ \P -> affinify E (projectify E P) == normalize_affine_point Fp P }};

--- a/proof/subgroup_check_g2.saw
+++ b/proof/subgroup_check_g2.saw
@@ -41,15 +41,15 @@ enable_experimental;
 
 // we use the following spec to extract a term
 let POINTonE2_times_minus_z_spec_ = do {
-  out_ptr <- crucible_alloc POINTonE2_type;
+  out_ptr <- llvm_alloc POINTonE2_type;
   (in_, in_ptr) <- ptr_to_fresh_readonly "in" POINTonE2_type;
-  crucible_precond {{ POINTonE2_invariant in_ }};
-  crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_POINTonE2_times_minus_z_spec_out" POINTonE2_type;
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_precond {{ POINTonE2_invariant in_ }};
+  llvm_execute_func [out_ptr, in_ptr];
+  new_out <- llvm_fresh_var "new_POINTonE2_times_minus_z_spec_out" POINTonE2_type;
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 
-POINTonE2_times_minus_z_ov_ <- crucible_llvm_compositional_extract m
+POINTonE2_times_minus_z_ov_ <- llvm_compositional_extract m
   "POINTonE2_times_minus_z"
   "POINTonE2_times_minus_z"
   (foldr concat [vec_fp2_overrides, fp2_overrides, curve_operations_e2_ovs] [])
@@ -93,11 +93,11 @@ is_point_projective_POINTonE2_times_minus_z <- custom_prove_cryptol
 
 let POINTonE2_in_g2_spec = do {
   (p, p_ptr) <- ptr_to_fresh_readonly "p" POINTonE2_affine_type;
-  crucible_precond {{ POINTonE2_affine_invariant p }};
-  crucible_precond {{ is_point_affine E' (POINTonE2_affine_abs p) }}; // on the curve
-  crucible_precond {{ ~ (is_point_O E' (POINTonE2_affine_abs p)) }};  // and not at infinity
-  crucible_execute_func [p_ptr];
-  crucible_return (crucible_term {{ bool_to_limb (is_in_g2_impl (POINTonE2_affine_abs p)) }});
+  llvm_precond {{ POINTonE2_affine_invariant p }};
+  llvm_precond {{ is_point_affine E' (POINTonE2_affine_abs p) }}; // on the curve
+  llvm_precond {{ ~ (is_point_O E' (POINTonE2_affine_abs p)) }};  // and not at infinity
+  llvm_execute_func [p_ptr];
+  llvm_return (llvm_term {{ bool_to_limb (is_in_g2_impl (POINTonE2_affine_abs p)) }});
 };
 
 affinify_projectify_thm <- test_cryptol

--- a/proof/types.saw
+++ b/proof/types.saw
@@ -21,8 +21,8 @@ let vec384fp12_type = (llvm_array 2 vec384fp6_type);
 
 //let POINTonE1_type = llvm_type "{i384, i384, i384}" ;
 //let POINTonE1_affine_type = llvm_type "{i384, i384}";
-let POINTonE1_type = llvm_struct "struct.POINTonE1";
-let POINTonE1_affine_type = llvm_struct "struct.POINTonE1_affine";
+let POINTonE1_type = llvm_alias "struct.POINTonE1";
+let POINTonE1_affine_type = llvm_alias "struct.POINTonE1_affine";
 
-let POINTonE2_type = llvm_struct "struct.POINTonE2";
-let POINTonE2_affine_type = llvm_struct "struct.POINTonE2_affine";
+let POINTonE2_type = llvm_alias "struct.POINTonE2";
+let POINTonE2_affine_type = llvm_alias "struct.POINTonE2_affine";

--- a/proof/vect.saw
+++ b/proof/vect.saw
@@ -12,28 +12,28 @@
 
 // ... vec_select
 let vec_select_asm_spec (bytes:Int) = do {
-  ret_ptr <- crucible_alloc (llvm_array bytes (llvm_int 8));
+  ret_ptr <- llvm_alloc (llvm_array bytes (llvm_int 8));
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array bytes (llvm_int 8));
   (b, b_ptr) <- ptr_to_fresh_readonly "b" (llvm_array bytes (llvm_int 8));
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term sel_a];
-  crucible_points_to ret_ptr (crucible_term {{ if (sel_a != 0) then a else b }});
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, llvm_term sel_a];
+  llvm_points_to ret_ptr (llvm_term {{ if (sel_a != 0) then a else b }});
 };
 
 let vec_select_asm_alias_1_2_spec bytes = do {
   (ret, ret_ptr) <- ptr_to_fresh "ret" (llvm_array bytes (llvm_int 8));
   (b, b_ptr) <- ptr_to_fresh_readonly "b" (llvm_array bytes (llvm_int 8));
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, crucible_term sel_a];
-  crucible_points_to ret_ptr (crucible_term {{ if (sel_a != 0) then ret else b }});
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, llvm_term sel_a];
+  llvm_points_to ret_ptr (llvm_term {{ if (sel_a != 0) then ret else b }});
 };
 
 let vec_select_asm_alias_1_3_spec bytes = do {
   (ret, ret_ptr) <- ptr_to_fresh "ret" (llvm_array bytes (llvm_int 8));
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array bytes (llvm_int 8));
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, crucible_term sel_a];
-  crucible_points_to ret_ptr (crucible_term {{ if (sel_a != 0) then a else ret }});
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, llvm_term sel_a];
+  llvm_points_to ret_ptr (llvm_term {{ if (sel_a != 0) then a else ret }});
 };
 
 let mk_vec_select_asm_ov bytes = admit (str_concat "vec_select_" (show bytes)) (vec_select_asm_spec bytes);
@@ -49,28 +49,28 @@ vec_select_asm_ovs <- do {
   };
 
 let vec_select_spec bytes ty = do {
-  ret_ptr <- crucible_alloc ty;
+  ret_ptr <- llvm_alloc ty;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" ty;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" ty;
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term {{`bytes:Size_t }}, crucible_term sel_a];
-  crucible_points_to ret_ptr (crucible_term {{ select a b (sel_a != 0)}});
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, llvm_term {{`bytes:Size_t }}, llvm_term sel_a];
+  llvm_points_to ret_ptr (llvm_term {{ select a b (sel_a != 0)}});
 };
 
 let vec_select_alias_1_2_spec bytes ty = do {
   (ret, ret_ptr) <- ptr_to_fresh "ret" ty;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" ty;
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, crucible_term {{`bytes:Size_t}}, crucible_term sel_a];
-  crucible_points_to ret_ptr (crucible_term {{ select ret b (sel_a != 0)}});
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, llvm_term {{`bytes:Size_t}}, llvm_term sel_a];
+  llvm_points_to ret_ptr (llvm_term {{ select ret b (sel_a != 0)}});
 };
 
 let vec_select_alias_1_3_spec bytes ty = do {
   (ret, ret_ptr) <- ptr_to_fresh "ret" ty;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" ty;
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, crucible_term {{`bytes:Size_t}}, crucible_term sel_a];
-  crucible_points_to ret_ptr (crucible_term {{ select a ret (sel_a != 0)}});
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, llvm_term {{`bytes:Size_t}}, llvm_term sel_a];
+  llvm_points_to ret_ptr (llvm_term {{ select a ret (sel_a != 0)}});
 };
 
 vec_select_POINTonE1_ov <- verify "vec_select" vec_select_asm_ovs (vec_select_spec 144 POINTonE1_type);
@@ -100,33 +100,33 @@ let vec_select_overrides = [vec_select_POINTonE1_ov, vec_select_alias_1_2_POINTo
 /*
 let vec_is_zero_spec n = do { // n is size IN LIMBS; routine takes size in bytes
   (a, a_ptr) <- ptr_to_fresh "a" (llvm_array n limb_type);
-  crucible_execute_func [a_ptr, crucible_term {{ (8 * (`n:Size_t)) }}]; // Non-portable
-  crucible_return (crucible_term {{ if a == (zero:[n]Limb) then 1 else (0:Limb) }});
-  // crucible_return (crucible_term {{ if fp_equal_rep a Fp_rep.field_zero then 1 else (0:Limb) }});
-  // crucible_return (crucible_term {{ if xeq a (zero:[n]Limb) then 1 else (0:Limb) }});
+  llvm_execute_func [a_ptr, llvm_term {{ (8 * (`n:Size_t)) }}]; // Non-portable
+  llvm_return (llvm_term {{ if a == (zero:[n]Limb) then 1 else (0:Limb) }});
+  // llvm_return (llvm_term {{ if fp_equal_rep a Fp_rep.field_zero then 1 else (0:Limb) }});
+  // llvm_return (llvm_term {{ if xeq a (zero:[n]Limb) then 1 else (0:Limb) }});
   };
 
-// vec_is_zero_48_ov <- crucible_llvm_verify m "vec_is_zero" [] false (vec_is_zero_spec 6) z3;
+// vec_is_zero_48_ov <- llvm_verify m "vec_is_zero" [] false (vec_is_zero_spec 6) z3;
 */
 
 // ... we actually want the is-0 test in the abstract domain
 let vec_is_zero_fp_spec use_fp_is_equal = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  crucible_precond {{ fp_invariant a }};
-  crucible_execute_func [a_ptr, crucible_term {{ (48:Size_t) }}]; // Non-portable
-  // crucible_return (crucible_term {{ if fp_equal_rep a Fp_rep.field_zero then 1 else (0:Limb) }});
+  llvm_precond {{ fp_invariant a }};
+  llvm_execute_func [a_ptr, llvm_term {{ (48:Size_t) }}]; // Non-portable
+  // llvm_return (llvm_term {{ if fp_equal_rep a Fp_rep.field_zero then 1 else (0:Limb) }});
   if use_fp_is_equal then do {
-    crucible_return (crucible_term {{ if Fp.is_equal ((fp_abs a), Fp.field_zero) then 1 else (0:Limb) }});
+    llvm_return (llvm_term {{ if Fp.is_equal ((fp_abs a), Fp.field_zero) then 1 else (0:Limb) }});
   } else do {
-    crucible_return (crucible_term {{ if (fp_abs a) ==  Fp.field_zero then 1 else (0:Limb) }});
+    llvm_return (llvm_term {{ if (fp_abs a) ==  Fp.field_zero then 1 else (0:Limb) }});
   };
 };
 
 let vec_is_zero_fp2_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
-  crucible_precond {{ fp2_invariant a }};
-  crucible_execute_func [a_ptr, crucible_term {{ (96:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ if (Fp_2.is_equal (fp2_abs a, Fp_2.field_zero)) then 1 else (0:Limb) }});
+  llvm_precond {{ fp2_invariant a }};
+  llvm_execute_func [a_ptr, llvm_term {{ (96:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ if (Fp_2.is_equal (fp2_abs a, Fp_2.field_zero)) then 1 else (0:Limb) }});
   };
 
 // TODO: Prove
@@ -138,30 +138,30 @@ vec_is_zero_fp2_ov <- test "vec_is_zero" [] vec_is_zero_fp2_spec;
 
 let vec_is_zero_2fp_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array 2 vec384_type);
-  crucible_precond {{ fp_invariant (a@0) /\ fp_invariant (a@1) }};
-  crucible_execute_func [a_ptr, crucible_term {{ (96:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ if fp_abs a0 == Fp.field_zero /\ fp_abs a1 == Fp.field_zero then 1 else (0:Limb) where [a0,a1]=a }});
+  llvm_precond {{ fp_invariant (a@0) /\ fp_invariant (a@1) }};
+  llvm_execute_func [a_ptr, llvm_term {{ (96:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ if fp_abs a0 == Fp.field_zero /\ fp_abs a1 == Fp.field_zero then 1 else (0:Limb) where [a0,a1]=a }});
   };
 
 // TODO: let's settle on whether we use is_equal or not...
 let vec_is_zero_2fp_is_equal_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array 2 vec384_type);
-  crucible_precond {{ fp_invariant (a@0) /\ fp_invariant (a@1) }};
-  crucible_execute_func [a_ptr, crucible_term {{ (96:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ bool_to_limb (Fp.is_equal(fp_abs a0, Fp.field_zero) /\ Fp.is_equal(fp_abs a1, Fp.field_zero)) where [a0,a1]=a }});
+  llvm_precond {{ fp_invariant (a@0) /\ fp_invariant (a@1) }};
+  llvm_execute_func [a_ptr, llvm_term {{ (96:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ bool_to_limb (Fp.is_equal(fp_abs a0, Fp.field_zero) /\ Fp.is_equal(fp_abs a1, Fp.field_zero)) where [a0,a1]=a }});
   };
 
 let vec_is_zero_2fp2_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array 2 vec384x_type);
-  crucible_precond {{ fp2_invariant (a@0) /\ fp2_invariant (a@1) }};
-  crucible_execute_func [a_ptr, crucible_term {{ (192:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ (if ((Fp_2.is_equal (fp2_abs a0, Fp_2.field_zero)) /\ (Fp_2.is_equal (fp2_abs a1, Fp_2.field_zero))) then 1 else (0:Limb)) where [a0,a1] = a }});
+  llvm_precond {{ fp2_invariant (a@0) /\ fp2_invariant (a@1) }};
+  llvm_execute_func [a_ptr, llvm_term {{ (192:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ (if ((Fp_2.is_equal (fp2_abs a0, Fp_2.field_zero)) /\ (Fp_2.is_equal (fp2_abs a1, Fp_2.field_zero))) then 1 else (0:Limb)) where [a0,a1] = a }});
   };
 
 let vec_is_zero_10fp_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array 10 vec384_type);
-  crucible_execute_func [a_ptr, crucible_term {{ (480:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ bool_to_limb (all (\x -> Fp.is_equal (fp_abs x, Fp.field_zero)) a) }});
+  llvm_execute_func [a_ptr, llvm_term {{ (480:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ bool_to_limb (all (\x -> Fp.is_equal (fp_abs x, Fp.field_zero)) a) }});
   };
 
 // TODO: prove
@@ -175,8 +175,8 @@ vec_is_zero_10fp_ov <- test "vec_is_zero" []  vec_is_zero_10fp_spec;
 let vec_is_equal_48_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [a_ptr, b_ptr, crucible_term {{ (48:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ if a == b then 1 else (0:Limb) }});
+  llvm_execute_func [a_ptr, b_ptr, llvm_term {{ (48:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ if a == b then 1 else (0:Limb) }});
   };
 
 vec_is_equal_48_ov <- verify "vec_is_equal" []  vec_is_equal_48_spec;
@@ -184,8 +184,8 @@ vec_is_equal_48_ov <- verify "vec_is_equal" []  vec_is_equal_48_spec;
 let vec_is_equal_48_vec_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [a_ptr, b_ptr, crucible_term {{ (48:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ if (vec384_abs a) == (vec384_abs b) then 1 else (0:Limb) }});
+  llvm_execute_func [a_ptr, b_ptr, llvm_term {{ (48:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ if (vec384_abs a) == (vec384_abs b) then 1 else (0:Limb) }});
   };
 
 vec_is_equal_48_vec_ov <- verify "vec_is_equal" []  vec_is_equal_48_spec;
@@ -193,25 +193,25 @@ vec_is_equal_48_vec_ov <- verify "vec_is_equal" []  vec_is_equal_48_spec;
 let vec_is_equal_fp_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_precond {{ fp_invariant a /\  fp_invariant b }};
-  crucible_execute_func [a_ptr, b_ptr, crucible_term {{ (48:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ if fp_abs a ==  fp_abs b then 1 else (0:Limb) }});
+  llvm_precond {{ fp_invariant a /\  fp_invariant b }};
+  llvm_execute_func [a_ptr, b_ptr, llvm_term {{ (48:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ if fp_abs a ==  fp_abs b then 1 else (0:Limb) }});
   };
 
 let vec_is_equal_fp2_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
-  crucible_precond {{ fp2_invariant a /\  fp2_invariant b }};
-  crucible_execute_func [a_ptr, b_ptr, crucible_term {{ (96:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ bool_to_limb (Fp_2.is_equal (fp2_abs a, fp2_abs b)) }});
+  llvm_precond {{ fp2_invariant a /\  fp2_invariant b }};
+  llvm_execute_func [a_ptr, b_ptr, llvm_term {{ (96:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ bool_to_limb (Fp_2.is_equal (fp2_abs a, fp2_abs b)) }});
   };
 
 // let vec_is_equal_fp2_spec_ = do {
   // (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   // (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
-  // crucible_precond {{ fp2_invariant a /\  fp2_invariant b }}; // TODO: remove
-  // crucible_execute_func [a_ptr, b_ptr, crucible_term {{ (96:Size_t) }}]; // Non-portable
-  // crucible_return (crucible_term {{ if a ==  b then 1 else (0:Limb) }});
+  // llvm_precond {{ fp2_invariant a /\  fp2_invariant b }}; // TODO: remove
+  // llvm_execute_func [a_ptr, b_ptr, llvm_term {{ (96:Size_t) }}]; // Non-portable
+  // llvm_return (llvm_term {{ if a ==  b then 1 else (0:Limb) }});
   // };
 
 //TODO: prove
@@ -222,20 +222,20 @@ vec_is_equal_fp2_ov <- test "vec_is_equal" [] vec_is_equal_fp2_spec;
 let vec_is_equal_2fp_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array 2 vec384_type);
   (b, b_ptr) <- ptr_to_fresh_readonly "b" (llvm_array 2 vec384_type);
-  crucible_precond {{     fp_invariant (a@0) /\ fp_invariant (a@1)
+  llvm_precond {{     fp_invariant (a@0) /\ fp_invariant (a@1)
                       /\  fp_invariant (b@0) /\ fp_invariant (b@1) }};
-  crucible_execute_func [a_ptr, b_ptr, crucible_term {{ (96:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ if fp_abs a0 ==  fp_abs b0 /\ fp_abs a1 ==  fp_abs b1
+  llvm_execute_func [a_ptr, b_ptr, llvm_term {{ (96:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ if fp_abs a0 ==  fp_abs b0 /\ fp_abs a1 ==  fp_abs b1
                                     then 1 else (0:Limb) where [a0,a1]=a; [b0,b1]=b}});
   };
 
 let vec_is_equal_2fp2_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array 2 vec384x_type);
   (b, b_ptr) <- ptr_to_fresh_readonly "b" (llvm_array 2 vec384x_type);
-  crucible_precond {{     fp2_invariant (a@0) /\ fp2_invariant (a@1)
+  llvm_precond {{     fp2_invariant (a@0) /\ fp2_invariant (a@1)
                       /\  fp2_invariant (b@0) /\ fp2_invariant (b@1) }};
-  crucible_execute_func [a_ptr, b_ptr, crucible_term {{ (192:Size_t) }}]; // Non-portable
-  crucible_return (crucible_term {{ if Fp_2.is_equal(fp2_abs a0, fp2_abs b0) /\ Fp_2.is_equal(fp2_abs a1, fp2_abs b1)
+  llvm_execute_func [a_ptr, b_ptr, llvm_term {{ (192:Size_t) }}]; // Non-portable
+  llvm_return (llvm_term {{ if Fp_2.is_equal(fp2_abs a0, fp2_abs b0) /\ Fp_2.is_equal(fp2_abs a1, fp2_abs b1)
                                     then 1 else (0:Limb)  where [a0,a1]=a; [b0,b1]=b }}); // TODO: is this specification okay?
   };
 
@@ -246,10 +246,10 @@ vec_is_equal_2fp2_ov <- test "vec_is_equal" []  vec_is_equal_2fp2_spec;
 // .. vec_copy
 
 let vec_copy_spec bytes  ty = do {
-  ret_ptr <- crucible_alloc ty;
+  ret_ptr <- llvm_alloc ty;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" ty;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{`bytes:Size_t }}];
-  crucible_points_to ret_ptr (crucible_term a);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term {{`bytes:Size_t }}];
+  llvm_points_to ret_ptr (llvm_term a);
 };
 
 vec_copy_fp_ov <- verify "vec_copy" [] (vec_copy_spec 48 vec384_type);

--- a/proof/x86/correctness.saw
+++ b/proof/x86/correctness.saw
@@ -9,13 +9,13 @@ let do_prove_x86 = true;
 let verify_x86_helper path module name spec tactic =
   if do_prove_x86
   then
-  crucible_llvm_verify_x86 module path name
+  llvm_verify_x86 module path name
     [("BLS12_381_P", 384)]
     false
     spec
     tactic
   else
-  crucible_llvm_unsafe_assume_spec module name spec;
+  llvm_unsafe_assume_spec module name spec;
 let verify_x86 = verify_x86_helper "../../../build/x86/libblst.so" m;
 let verify_x86_noadx = verify_x86_helper "../../../build/x86_noadx/libblst.so" m_noadx;
 let verify_x86_recent = verify_x86_helper "../../../build/x86_recent/libblst.so" m_recent;

--- a/proof/x86/correctness/add_mod_256.saw
+++ b/proof/x86/correctness/add_mod_256.saw
@@ -9,15 +9,15 @@
 
 // add_mod_256
 let add_mod_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
   lt_modulus256 b;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
   let new_ret = {{ vec256_rep ((vec256_abs a + vec256_abs b) % vec256_abs modulus256) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_256_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
@@ -25,9 +25,9 @@ let add_mod_256_alias_ret_a_spec = do {
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
   lt_modulus256 b;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
   let new_ret = {{ vec256_rep ((vec256_abs a + vec256_abs b) % vec256_abs modulus256) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_256_alias_ret_b_spec = do {
   (b, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
@@ -35,46 +35,46 @@ let add_mod_256_alias_ret_b_spec = do {
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
   lt_modulus256 b;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
   let new_ret = {{ vec256_rep ((vec256_abs a + vec256_abs b) % vec256_abs modulus256) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_256_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (ab, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 ab;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
   let new_ret = {{ vec256_rep ((vec256_abs ab + vec256_abs ab) % vec256_abs modulus256) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_256_alias_ret_a_b_spec = do {
   (ab, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 ab;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
   let new_ret = {{ vec256_rep ((vec256_abs ab + vec256_abs ab) % vec256_abs modulus256) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_3_mod_256
 let mul_by_3_mod_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
   let new_ret = {{ vec256_rep ((((vec256_abs a + vec256_abs a) % vec256_abs modulus256) + vec256_abs a) % vec256_abs modulus256) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let mul_by_3_mod_256_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
   let new_ret = {{ vec256_rep ((((vec256_abs a + vec256_abs a) % vec256_abs modulus256) + vec256_abs a) % vec256_abs modulus256) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let {{
@@ -84,42 +84,42 @@ let {{
 
 // lshift_mod_256
 let lshift_mod_256_spec count = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term count, p_ptr];
   let new_ret = {{ vec256_rep (repeat_double_mod_256 count (vec256_abs a)) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let lshift_mod_256_alias_ret_a_spec count = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term count, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term count, p_ptr];
   let new_ret = {{ vec256_rep (repeat_double_mod_256 count (vec256_abs a)) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // cneg_mod_256
 let cneg_mod_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
-  flag <- crucible_fresh_var "flag" limb_type;
+  flag <- llvm_fresh_var "flag" limb_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term flag, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term flag, p_ptr];
   let new_ret = {{ if (vec256_abs a != 0) && (flag != 0) then vec256_rep (vec256_abs modulus256 - vec256_abs a) else a : Vec256 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let cneg_mod_256_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
-  flag <- crucible_fresh_var "flag" limb_type;
+  flag <- llvm_fresh_var "flag" limb_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term flag, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term flag, p_ptr];
   let new_ret = {{ if (vec256_abs a != 0) && (flag != 0) then vec256_rep (vec256_abs modulus256 - vec256_abs a) else a : Vec256 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let {{
@@ -129,15 +129,15 @@ let {{
 
 // sub_mod_256
 let sub_mod_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
   lt_modulus256 b;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
   let new_ret = {{ vec256_rep (sub_mod_256 a b) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_256_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
@@ -145,10 +145,10 @@ let sub_mod_256_alias_ret_a_spec = do {
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
   lt_modulus256 b;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
   let new_ret = {{ vec256_rep (sub_mod_256 a b) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_256_alias_ret_b_spec = do {
   (b, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
@@ -156,26 +156,26 @@ let sub_mod_256_alias_ret_b_spec = do {
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 a;
   lt_modulus256 b;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
   let new_ret = {{ vec256_rep (sub_mod_256 a b) : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_256_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (ab, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 ab;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
   let new_ret = {{ vec256_rep 0 : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_256_alias_ret_a_b_spec = do {
   (ab, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   p_ptr <- ptr_to_modulus256;
   lt_modulus256 ab;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
   let new_ret = {{ vec256_rep 0 : Vec256}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/correctness/add_mod_384.saw
+++ b/proof/x86/correctness/add_mod_384.saw
@@ -9,15 +9,15 @@
 
 // add_mod_384
 let add_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
   lt_modulus384 b;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
   let new_ret = {{ vec384_rep ((vec384_abs a + vec384_abs b) % vec384_abs modulus384) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
@@ -25,9 +25,9 @@ let add_mod_384_alias_ret_a_spec = do {
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
   lt_modulus384 b;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
   let new_ret = {{ vec384_rep ((vec384_abs a + vec384_abs b) % vec384_abs modulus384) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384_alias_ret_b_spec = do {
   (b, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
@@ -35,31 +35,31 @@ let add_mod_384_alias_ret_b_spec = do {
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
   lt_modulus384 b;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
   let new_ret = {{ vec384_rep ((vec384_abs a + vec384_abs b) % vec384_abs modulus384) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (ab, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 ab;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
   let new_ret = {{ vec384_rep ((vec384_abs ab + vec384_abs ab) % vec384_abs modulus384) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384_alias_ret_a_b_spec = do {
   (ab, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 ab;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
   let new_ret = {{ vec384_rep ((vec384_abs ab + vec384_abs ab) % vec384_abs modulus384) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // add_mod_384x
 let add_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a_r, a_i, a_ptr) <- ptr_to_fresh_vec384x_readonly "a";
   (b_r, b_i, b_ptr) <- ptr_to_fresh_vec384x_readonly "b";
   p_ptr <- ptr_to_modulus384;
@@ -67,7 +67,7 @@ let add_mod_384x_spec = do {
   lt_modulus384 a_i;
   lt_modulus384 b_r;
   lt_modulus384 b_i;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep ((vec384_abs a_r + vec384_abs b_r) % vec384_abs modulus384) : Vec384}};
   let new_ret_i = {{ vec384_rep ((vec384_abs a_i + vec384_abs b_i) % vec384_abs modulus384) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -80,7 +80,7 @@ let add_mod_384x_alias_ret_a_spec = do {
   lt_modulus384 a_i;
   lt_modulus384 b_r;
   lt_modulus384 b_i;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep ((vec384_abs a_r + vec384_abs b_r) % vec384_abs modulus384) : Vec384}};
   let new_ret_i = {{ vec384_rep ((vec384_abs a_i + vec384_abs b_i) % vec384_abs modulus384) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -93,7 +93,7 @@ let add_mod_384x_alias_ret_b_spec = do {
   lt_modulus384 a_i;
   lt_modulus384 b_r;
   lt_modulus384 b_i;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep ((vec384_abs a_r + vec384_abs b_r) % vec384_abs modulus384) : Vec384}};
   let new_ret_i = {{ vec384_rep ((vec384_abs a_i + vec384_abs b_i) % vec384_abs modulus384) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -104,7 +104,7 @@ let add_mod_384x_alias_ret_a_b_spec = do {
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 ab_r;
   lt_modulus384 ab_i;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep ((vec384_abs ab_r + vec384_abs ab_r) % vec384_abs modulus384) : Vec384}};
   let new_ret_i = {{ vec384_rep ((vec384_abs ab_i + vec384_abs ab_i) % vec384_abs modulus384) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -117,96 +117,96 @@ let {{
 
 // lshift_mod_384
 let lshift_mod_384_spec count = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term count, p_ptr];
   let new_ret = {{ vec384_rep (repeat_double_mod count (vec384_abs a)) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let lshift_mod_384_alias_ret_a_spec count = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term count, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term count, p_ptr];
   let new_ret = {{ vec384_rep (repeat_double_mod count (vec384_abs a)) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_3_mod_384
 let mul_by_3_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
   let new_ret = {{ vec384_rep ((((vec384_abs a + vec384_abs a) % vec384_abs modulus384) + vec384_abs a) % vec384_abs modulus384) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let mul_by_3_mod_384_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
   let new_ret = {{ vec384_rep ((((vec384_abs a + vec384_abs a) % vec384_abs modulus384) + vec384_abs a) % vec384_abs modulus384) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_8_mod_384
 let mul_by_8_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
   let new_ret = {{ vec384_rep (repeat_double_mod 3 (vec384_abs a)) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let mul_by_8_mod_384_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
   let new_ret = {{ vec384_rep (repeat_double_mod 3 (vec384_abs a)) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_b_onE1
 let mul_by_b_onE1_spec = do {
-  crucible_alloc_global "BLS12_381_P";
-  crucible_points_to
-    (crucible_global "BLS12_381_P")
-    (crucible_term modulus384);
+  llvm_alloc_global "BLS12_381_P";
+  llvm_points_to
+    (llvm_global "BLS12_381_P")
+    (llvm_term modulus384);
 
-  out_ptr <- crucible_alloc vec384_type;
+  out_ptr <- llvm_alloc vec384_type;
   (in_, in_ptr) <- ptr_to_fresh_readonly "in" vec384_type;
   lt_modulus384 in_;
-  crucible_execute_func [out_ptr, in_ptr];
+  llvm_execute_func [out_ptr, in_ptr];
   let new_out = {{ vec384_rep (repeat_double_mod 2 (vec384_abs in_)) : Vec384}};
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 let mul_by_b_onE1_alias_out_in_spec = do {
-  crucible_alloc_global "BLS12_381_P";
-  crucible_points_to
-    (crucible_global "BLS12_381_P")
-    (crucible_term modulus384);
+  llvm_alloc_global "BLS12_381_P";
+  llvm_points_to
+    (llvm_global "BLS12_381_P")
+    (llvm_term modulus384);
 
   (in_, out_ptr) <- ptr_to_fresh "out" vec384_type;
   lt_modulus384 in_;
-  crucible_execute_func [out_ptr, out_ptr];
+  llvm_execute_func [out_ptr, out_ptr];
   let new_out = {{ vec384_rep (repeat_double_mod 2 (vec384_abs in_)) : Vec384}};
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 
 // mul_by_3_mod_384x
 let mul_by_3_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a_r, a_i, a_ptr) <- ptr_to_fresh_vec384x_readonly "a";
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a_r;
   lt_modulus384 a_i;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep ((((vec384_abs a_r + vec384_abs a_r) % vec384_abs modulus384) + vec384_abs a_r) % vec384_abs modulus384) : Vec384}};
   let new_ret_i = {{ vec384_rep ((((vec384_abs a_i + vec384_abs a_i) % vec384_abs modulus384) + vec384_abs a_i) % vec384_abs modulus384) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -216,7 +216,7 @@ let mul_by_3_mod_384x_alias_ret_a_spec = do {
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a_r;
   lt_modulus384 a_i;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep ((((vec384_abs a_r + vec384_abs a_r) % vec384_abs modulus384) + vec384_abs a_r) % vec384_abs modulus384) : Vec384}};
   let new_ret_i = {{ vec384_rep ((((vec384_abs a_i + vec384_abs a_i) % vec384_abs modulus384) + vec384_abs a_i) % vec384_abs modulus384) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -224,12 +224,12 @@ let mul_by_3_mod_384x_alias_ret_a_spec = do {
 
 // mul_by_8_mod_384x
 let mul_by_8_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a_r, a_i, a_ptr) <- ptr_to_fresh_vec384x_readonly "a";
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a_r;
   lt_modulus384 a_i;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep (repeat_double_mod 3 (vec384_abs a_r)) : Vec384}};
   let new_ret_i = {{ vec384_rep (repeat_double_mod 3 (vec384_abs a_i)) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -239,7 +239,7 @@ let mul_by_8_mod_384x_alias_ret_a_spec = do {
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a_r;
   lt_modulus384 a_i;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep (repeat_double_mod 3 (vec384_abs a_r)) : Vec384}};
   let new_ret_i = {{ vec384_rep (repeat_double_mod 3 (vec384_abs a_i)) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -252,31 +252,31 @@ let {{
 
 // mul_by_b_onE2
 let mul_by_b_onE2_spec = do {
-  crucible_alloc_global "BLS12_381_P";
-  crucible_points_to
-    (crucible_global "BLS12_381_P")
-    (crucible_term modulus384);
+  llvm_alloc_global "BLS12_381_P";
+  llvm_points_to
+    (llvm_global "BLS12_381_P")
+    (llvm_term modulus384);
 
-  out_ptr <- crucible_alloc vec384x_type;
+  out_ptr <- llvm_alloc vec384x_type;
 
   (in_r, in_i, in_ptr) <- ptr_to_fresh_vec384x_readonly "in";
   lt_modulus384 in_r;
   lt_modulus384 in_i;
-  crucible_execute_func [out_ptr, in_ptr];
+  llvm_execute_func [out_ptr, in_ptr];
   let new_out_r = {{ vec384_rep (repeat_double_mod 2 (sub_mod in_r in_i)) : Vec384}};
   let new_out_i = {{ vec384_rep (repeat_double_mod 2 ((vec384_abs in_r + vec384_abs in_i) % vec384_abs modulus384)) : Vec384}};
   points_to_vec384x out_ptr new_out_r new_out_i;
 };
 let mul_by_b_onE2_alias_out_in_spec = do {
-  crucible_alloc_global "BLS12_381_P";
-  crucible_points_to
-    (crucible_global "BLS12_381_P")
-    (crucible_term modulus384);
+  llvm_alloc_global "BLS12_381_P";
+  llvm_points_to
+    (llvm_global "BLS12_381_P")
+    (llvm_term modulus384);
 
   (in_r, in_i, out_ptr) <- ptr_to_fresh_vec384x "in";
   lt_modulus384 in_r;
   lt_modulus384 in_i;
-  crucible_execute_func [out_ptr, out_ptr];
+  llvm_execute_func [out_ptr, out_ptr];
   let new_out_r = {{ vec384_rep (repeat_double_mod 2 (sub_mod in_r in_i)) : Vec384}};
   let new_out_i = {{ vec384_rep (repeat_double_mod 2 ((vec384_abs in_r + vec384_abs in_i) % vec384_abs modulus384)) : Vec384}};
   points_to_vec384x out_ptr new_out_r new_out_i;
@@ -284,36 +284,36 @@ let mul_by_b_onE2_alias_out_in_spec = do {
 
 // cneg_mod_384
 let cneg_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  flag <- crucible_fresh_var "flag" limb_type;
+  flag <- llvm_fresh_var "flag" limb_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term flag, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term flag, p_ptr];
   let new_ret = {{ if (vec_abs a != 0) && (flag != 0) then vec384_rep (vec_abs modulus384 - vec_abs a) else a : Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let cneg_mod_384_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "a" vec384_type;
-  flag <- crucible_fresh_var "flag" limb_type;
+  flag <- llvm_fresh_var "flag" limb_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term flag, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term flag, p_ptr];
   let new_ret = {{ if (vec_abs a != 0) && (flag != 0) then vec384_rep (vec_abs modulus384 - vec_abs a) else a : Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sub_mod_384
 let sub_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
   lt_modulus384 b;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
   let new_ret = {{ vec384_rep (sub_mod a b) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "a" vec384_type;
@@ -321,9 +321,9 @@ let sub_mod_384_alias_ret_a_spec = do {
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
   lt_modulus384 b;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
   let new_ret = {{ vec384_rep (sub_mod a b) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384_alias_ret_b_spec = do {
   (b, ret_ptr) <- ptr_to_fresh "b" vec384_type;
@@ -331,31 +331,31 @@ let sub_mod_384_alias_ret_b_spec = do {
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
   lt_modulus384 b;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
   let new_ret = {{ vec384_rep (sub_mod a b) : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (ab, a_ptr) <- ptr_to_fresh_readonly "ab" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 ab;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
   let new_ret = {{ vec384_rep 0 : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384_alias_ret_a_b_spec = do {
   (ab, ret_ptr) <- ptr_to_fresh "ab" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 ab;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
   let new_ret = {{ vec384_rep 0 : Vec384}};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sub_mod_384x
 let sub_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a_r, a_i, a_ptr) <- ptr_to_fresh_vec384x_readonly "a";
   (b_r, b_i, b_ptr) <- ptr_to_fresh_vec384x_readonly "b";
   p_ptr <- ptr_to_modulus384;
@@ -363,7 +363,7 @@ let sub_mod_384x_spec = do {
   lt_modulus384 a_i;
   lt_modulus384 b_r;
   lt_modulus384 b_i;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep (sub_mod a_r b_r) : Vec384}};
   let new_ret_i = {{ vec384_rep (sub_mod a_i b_i) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -376,8 +376,8 @@ let sub_mod_384x_alias_ret_a_spec = do {
   lt_modulus384 a_i;
   lt_modulus384 b_r;
   lt_modulus384 b_i;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
   let new_ret_r = {{ vec384_rep (sub_mod a_r b_r) : Vec384}};
   let new_ret_i = {{ vec384_rep (sub_mod a_i b_i) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -390,19 +390,19 @@ let sub_mod_384x_alias_ret_b_spec = do {
   lt_modulus384 a_i;
   lt_modulus384 b_r;
   lt_modulus384 b_i;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
   let new_ret_r = {{ vec384_rep (sub_mod a_r b_r) : Vec384}};
   let new_ret_i = {{ vec384_rep (sub_mod a_i b_i) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
 };
 let sub_mod_384x_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (ab_r, ab_i, a_ptr) <- ptr_to_fresh_vec384x_readonly "ab";
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 ab_r;
   lt_modulus384 ab_i;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep 0 : Vec384}};
   let new_ret_i = {{ vec384_rep 0 : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -412,7 +412,7 @@ let sub_mod_384x_alias_ret_a_b_spec = do {
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 ab_r;
   lt_modulus384 ab_i;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep 0 : Vec384}};
   let new_ret_i = {{ vec384_rep 0 : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -420,12 +420,12 @@ let sub_mod_384x_alias_ret_a_b_spec = do {
 
 // mul_by_1_plus_i_mod_384x
 let mul_by_1_plus_i_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a_r, a_i, a_ptr) <- ptr_to_fresh_vec384x_readonly "a";
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a_r;
   lt_modulus384 a_i;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep (sub_mod a_r a_i) : Vec384}};
   let new_ret_i = {{ vec384_rep ((vec384_abs a_r + vec384_abs a_i) % vec384_abs modulus384) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -435,7 +435,7 @@ let mul_by_1_plus_i_mod_384x_alias_ret_a_spec = do {
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a_r;
   lt_modulus384 a_i;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
   let new_ret_r = {{ vec384_rep (sub_mod a_r a_i) : Vec384}};
   let new_ret_i = {{ vec384_rep ((vec384_abs a_r + vec384_abs a_i) % vec384_abs modulus384) : Vec384}};
   points_to_vec384x ret_ptr new_ret_r new_ret_i;
@@ -451,9 +451,9 @@ let sgn0_pty_mod_384_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a;
-  crucible_execute_func [a_ptr, p_ptr];
+  llvm_execute_func [a_ptr, p_ptr];
   let return_value = {{ zero # [sgn_mod (vec384_abs a), pty_mod (vec384_abs a)] : [64] }};
-  crucible_return (crucible_term return_value);
+  llvm_return (llvm_term return_value);
 };
 
 // sgn0_pty_mod_384x
@@ -462,46 +462,46 @@ let sgn0_pty_mod_384x_spec = do {
   p_ptr <- ptr_to_modulus384;
   lt_modulus384 a_r;
   lt_modulus384 a_i;
-  crucible_execute_func [a_ptr, p_ptr];
+  llvm_execute_func [a_ptr, p_ptr];
   let return_value = {{
     zero #
     [ if vec384_abs a_i == 0 then sgn_mod (vec384_abs a_r) else sgn_mod (vec384_abs a_i)
     , if vec384_abs a_r == 0 then pty_mod (vec384_abs a_i) else pty_mod (vec384_abs a_r)
     ] : [64]
   }};
-  crucible_return (crucible_term return_value);
+  llvm_return (llvm_term return_value);
 };
 
 // vec_select
 let vec_select_spec (bytes:Int) = do {
-  ret_ptr <- crucible_alloc (llvm_array bytes (llvm_int 8));
+  ret_ptr <- llvm_alloc (llvm_array bytes (llvm_int 8));
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array bytes (llvm_int 8));
   (b, b_ptr) <- ptr_to_fresh_readonly "b" (llvm_array bytes (llvm_int 8));
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_precond {{ sel_a == 0 \/ sel_a == 1 }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term sel_a];
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_precond {{ sel_a == 0 \/ sel_a == 1 }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, llvm_term sel_a];
   let ret = {{ if sel_a == 1 then a else b : [bytes][8] }};
-  crucible_points_to ret_ptr (crucible_term ret);
+  llvm_points_to ret_ptr (llvm_term ret);
 };
 
 let vec_select_alias_1_3_spec bytes = do {
   (b, ret_ptr) <- ptr_to_fresh "b" (llvm_array bytes (llvm_int 8));
   (a, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array bytes (llvm_int 8));
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_precond {{ sel_a == 0 \/ sel_a == 1 }};
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, crucible_term sel_a];
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_precond {{ sel_a == 0 \/ sel_a == 1 }};
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, llvm_term sel_a];
   let ret = {{ if sel_a == 1 then a else b : [bytes][8] }};
-  crucible_points_to ret_ptr (crucible_term ret);
+  llvm_points_to ret_ptr (llvm_term ret);
 };
 
 let vec_select_alias_1_2_spec bytes = do {
   (a, ret_ptr) <- ptr_to_fresh "a" (llvm_array bytes (llvm_int 8));
   (b, b_ptr) <- ptr_to_fresh_readonly "b" (llvm_array bytes (llvm_int 8));
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_precond {{ sel_a == 0 \/ sel_a == 1 }};
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, crucible_term sel_a];
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_precond {{ sel_a == 0 \/ sel_a == 1 }};
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, llvm_term sel_a];
   let ret = {{ if sel_a == 1 then a else b : [bytes][8] }};
-  crucible_points_to ret_ptr (crucible_term ret);
+  llvm_points_to ret_ptr (llvm_term ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/correctness/add_mod_384x384.saw
+++ b/proof/x86/correctness/add_mod_384x384.saw
@@ -23,94 +23,94 @@ let {{
 
 // add_mod_384x384
 let add_mod_384x384_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec768_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_precond {{ vec768_abs a < modulus768 }};
-  crucible_precond {{ vec768_abs b < modulus768 }};
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_precond {{ vec768_abs a < modulus768 }};
+  llvm_precond {{ vec768_abs b < modulus768 }};
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
   let new_ret = {{ add_mod_768 a b }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384x384_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec768_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_precond {{ vec768_abs a < modulus768 }};
-  crucible_precond {{ vec768_abs b < modulus768 }};
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  llvm_precond {{ vec768_abs a < modulus768 }};
+  llvm_precond {{ vec768_abs b < modulus768 }};
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
   let new_ret = {{ add_mod_768 a b }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384x384_alias_ret_b_spec = do {
   (b, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_precond {{ vec768_abs a < modulus768 }};
-  crucible_precond {{ vec768_abs b < modulus768 }};
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  llvm_precond {{ vec768_abs a < modulus768 }};
+  llvm_precond {{ vec768_abs b < modulus768 }};
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
   let new_ret = {{ add_mod_768 a b }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384x384_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (ab, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_precond {{ vec768_abs ab < modulus768 }};
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  llvm_precond {{ vec768_abs ab < modulus768 }};
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
   let new_ret = {{ add_mod_768 ab ab }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384x384_alias_ret_a_b_spec = do {
   (ab, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_precond {{ vec768_abs ab < modulus768 }};
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  llvm_precond {{ vec768_abs ab < modulus768 }};
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
   let new_ret = {{ add_mod_768 ab ab }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sub_mod_384x384
 let sub_mod_384x384_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x384_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x384_alias_ret_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x384_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x384_alias_ret_a_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/correctness/ctx_inverse_mod_384.saw
+++ b/proof/x86/correctness/ctx_inverse_mod_384.saw
@@ -9,12 +9,12 @@
 
 // ct_inverse_mod_383
 let ct_inverse_mod_383_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (inp, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384_type;
   mod_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, inp_ptr, mod_ptr];
+  llvm_execute_func [ret_ptr, inp_ptr, mod_ptr];
   let new_ret = {{ ctx_inverse_mod_383 inp modulus384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/correctness/helpers.saw
+++ b/proof/x86/correctness/helpers.saw
@@ -16,11 +16,11 @@ let modulus384 = {{ [ 0xb9feffffffffaaab, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624
 // BLS12_381_p0
 let mont384_p0 = {{ 0x89f3fffcfffcfffd : [64] }};
 
-let lt_modulus384 x = crucible_precond {{ vec384_abs x < vec384_abs modulus384 }};
+let lt_modulus384 x = llvm_precond {{ vec384_abs x < vec384_abs modulus384 }};
 
 let ptr_to_modulus384 = do {
-  ptr <- crucible_alloc vec384_type;
-  crucible_points_to ptr (crucible_term modulus384);
+  ptr <- llvm_alloc vec384_type;
+  llvm_points_to ptr (llvm_term modulus384);
   return ptr;
 };
 
@@ -30,25 +30,25 @@ let modulus256 = {{ [ 0xffffffff00000001, 0x53bda402fffe5bfe, 0x3339d80809a1d805
 // r0
 let mont256_r0 = {{ 0xfffffffeffffffff : [64] }};
 
-let lt_modulus256 x = crucible_precond {{ vec256_abs x < vec256_abs modulus256 }};
+let lt_modulus256 x = llvm_precond {{ vec256_abs x < vec256_abs modulus256 }};
 
 let ptr_to_modulus256 = do {
-  ptr <- crucible_alloc vec256_type;
-  crucible_points_to ptr (crucible_term modulus256);
+  ptr <- llvm_alloc vec256_type;
+  llvm_points_to ptr (llvm_term modulus256);
   return ptr;
 };
 
 let ptr_to_fresh_vec384x_helper mutable nm = do {
-  ptr <- (if mutable then crucible_alloc else crucible_alloc_readonly) vec384x_type;
-  r <- crucible_fresh_var (str_concat nm "_r") vec384_type;
-  i <- crucible_fresh_var (str_concat nm "_i") vec384_type;
-  crucible_points_to ptr (crucible_term {{ [r, i] : [2]Vec384 }});
+  ptr <- (if mutable then llvm_alloc else llvm_alloc_readonly) vec384x_type;
+  r <- llvm_fresh_var (str_concat nm "_r") vec384_type;
+  i <- llvm_fresh_var (str_concat nm "_i") vec384_type;
+  llvm_points_to ptr (llvm_term {{ [r, i] : [2]Vec384 }});
   return (r, i, ptr);
 };
 let ptr_to_fresh_vec384x = ptr_to_fresh_vec384x_helper true;
 let ptr_to_fresh_vec384x_readonly = ptr_to_fresh_vec384x_helper false;
 
-let points_to_vec384x ptr r i = crucible_points_to ptr (crucible_term {{ [r, i] : [2]Vec384 }});
+let points_to_vec384x ptr r i = llvm_points_to ptr (llvm_term {{ [r, i] : [2]Vec384 }});
 
 let prove_folding_theorem t = prove_print w4 (rewrite (cryptol_ss ()) t);
 bvAdd_64_commutes <- prove_folding_theorem {{ \(a : [64]) (b : [64]) -> a + b == b + a }};

--- a/proof/x86/correctness/mulx_mont_256.saw
+++ b/proof/x86/correctness/mulx_mont_256.saw
@@ -9,52 +9,52 @@
 
 // mulx_mont_sparse_256
 let mulx_mont_sparse_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   p_ptr <- ptr_to_modulus256;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term mont256_r0];
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, llvm_term mont256_r0];
   let new_ret = {{ mulx_mont_sparse_256 a b modulus256 mont256_r0 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let mulx_mont_sparse_256_alias_ret_a_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   p_ptr <- ptr_to_modulus256;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term mont256_r0];
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term mont256_r0];
   let new_ret = {{ mulx_mont_sparse_256 a b modulus256 mont256_r0 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sqrx_mont_sparse_256
 let sqrx_mont_sparse_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   p_ptr <- ptr_to_modulus256;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term mont256_r0];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term mont256_r0];
   let new_ret = {{ mulx_mont_sparse_256 a a modulus256 mont256_r0 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // fromx_mont_256
 let fromx_mont_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   p_ptr <- ptr_to_modulus256;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term mont256_r0];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term mont256_r0];
   let new_ret = {{ fromx_mont_256 a modulus256 mont256_r0 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // redcx_mont_256
 let redcx_mont_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec512_type;
   p_ptr <- ptr_to_modulus256;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term mont256_r0];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term mont256_r0];
   let new_ret = {{ redcx_mont_256 a modulus256 mont256_r0 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/correctness/mulx_mont_384.saw
+++ b/proof/x86/correctness/mulx_mont_384.saw
@@ -15,194 +15,194 @@ import "../../../cryptol-specs/Common/bv.cry";
 
 // mulx_mont_384x
 let mulx_mont_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ split (mulx_mont_384x (join a) (join b) modulus384 mont384_p0) : [2]Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let mulx_mont_384x_alias_ret_ret_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ split (mulx_mont_384x (join a) (join b) modulus384 mont384_p0) : [2]Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let mulx_mont_384x_alias_ret_a_ret_spec = do {
   (b, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ split (mulx_mont_384x (join a) (join b) modulus384 mont384_p0) : [2]Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 
 // sqrx_mont_384x
 let sqrx_mont_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ split (sqrx_mont_384x (join a) modulus384 mont384_p0) : [2]Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let sqrx_mont_384x_alias_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ split (sqrx_mont_384x (join a) modulus384 mont384_p0) : [2]Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mulx_382x
 let mulx_382x_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
   let new_ret = {{ mulx_382x (join a) (join b) modulus384 : [2]Vec768 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sqrx_382x
 let sqrx_382x_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
   let new_ret = {{ sqrx_382x (join a) modulus384 : [2]Vec768 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // redcx_mont_384
 let redcx_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ redcx_mont_384 a modulus384 mont384_p0 : Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // fromx_mont_384
 let fromx_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ fromx_mont_384 a modulus384 mont384_p0 : Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sqn0x_pty_mont_384
 let sgn0x_pty_mont_384_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [a_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [a_ptr, p_ptr, llvm_term mont384_p0];
   let ret = {{ sgn0x_pty_mont_384 a modulus384 mont384_p0 }};
-  crucible_return (crucible_term ret);
+  llvm_return (llvm_term ret);
 };
 
 // sqn0x_pty_mont_384x
 let sgn0x_pty_mont_384x_spec = do {
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [a_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [a_ptr, p_ptr, llvm_term mont384_p0];
   let ret = {{ sgn0x_pty_mont_384x (join a) modulus384 mont384_p0 }};
-  crucible_return (crucible_term ret);
+  llvm_return (llvm_term ret);
 };
 
 // mulx_mont_384
 let mulx_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ mulx_mont_384 a b modulus384 mont384_p0 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let mulx_mont_384_ret_ret_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "a" vec384_type;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ mulx_mont_384 a b modulus384 mont384_p0 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let mulx_mont_384_ret_a_ret_spec = do {
   (b, ret_ptr) <- ptr_to_fresh "b" vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ mulx_mont_384 a b modulus384 mont384_p0 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sqrx_mont_384
 let sqrx_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ mulx_mont_384 a a modulus384 mont384_p0 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let sqrx_mont_384_alias_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ mulx_mont_384 a a modulus384 mont384_p0 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sqrx_n_mul_mont_383
 let sqrx_n_mul_mont_383_spec count = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   p_ptr <- ptr_to_modulus384;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{ `count : [64] }}, p_ptr, crucible_term mont384_p0, b_ptr];
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term {{ `count : [64] }}, p_ptr, llvm_term mont384_p0, b_ptr];
   let new_ret = {{ sqrx_n_mul_mont_383 a `count modulus384 mont384_p0 b }};
-  crucible_points_to_untyped ret_ptr (crucible_term new_ret);
+  llvm_points_to_untyped ret_ptr (llvm_term new_ret);
 };
 
 let sqrx_n_mul_mont_383_alias_1_2_spec count = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   p_ptr <- ptr_to_modulus384;
   (b, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term {{ `count : [64] }}, p_ptr, crucible_term mont384_p0, b_ptr];
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term {{ `count : [64] }}, p_ptr, llvm_term mont384_p0, b_ptr];
   let new_ret = {{ sqrx_n_mul_mont_383 a `count modulus384 mont384_p0 b }};
-  crucible_points_to_untyped ret_ptr (crucible_term new_ret);
+  llvm_points_to_untyped ret_ptr (llvm_term new_ret);
 };
 
 // sqrx_mont_382x
 let sqrx_mont_382x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (a, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ split (sqrx_mont_382x (join a) modulus384 mont384_p0) : [2]Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let sqrx_mont_382x_alias_spec = do {
   (a, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   p_ptr <- ptr_to_modulus384;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term mont384_p0];
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, llvm_term mont384_p0];
   let new_ret = {{ split (sqrx_mont_382x (join a) modulus384 mont384_p0) : [2]Vec384 }};
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/correctness_add.saw
+++ b/proof/x86/correctness_add.saw
@@ -7,13 +7,13 @@ let do_prove_x86 = true;
 let verify_x86_helper path module name spec tactic =
   if do_prove_x86
   then
-  crucible_llvm_verify_x86 module path name
+  llvm_verify_x86 module path name
     [("BLS12_381_P", 384)]
     false
     spec
     tactic
   else
-  crucible_llvm_unsafe_assume_spec module name spec;
+  llvm_unsafe_assume_spec module name spec;
 let verify_x86 = verify_x86_helper "../../../build/x86/libblst.so" m;
 let verify_x86_noadx = verify_x86_helper "../../../build/x86_noadx/libblst.so" m_noadx;
 let verify_x86_recent = verify_x86_helper "../../../build/x86_recent/libblst.so" m_recent;

--- a/proof/x86/memory_safety.saw
+++ b/proof/x86/memory_safety.saw
@@ -14,13 +14,13 @@ let do_prove_x86 = true;
 let verify_x86_helper path module name spec =
   if do_prove_x86
   then
-  crucible_llvm_verify_x86 module path name
+  llvm_verify_x86 module path name
     []
     false
     spec
     x86_tactic
   else
-  crucible_llvm_unsafe_assume_spec module name spec;
+  llvm_unsafe_assume_spec module name spec;
 let verify_x86 = verify_x86_helper "../../../build/x86/libblst.so" m;
 let verify_x86_noadx = verify_x86_helper "../../../build/x86_noadx/libblst.so" m_noadx;
 let verify_x86_recent = verify_x86_helper "../../../build/x86_recent/libblst.so" m_recent;

--- a/proof/x86/memory_safety/add_mod_256.saw
+++ b/proof/x86/memory_safety/add_mod_256.saw
@@ -9,156 +9,156 @@
 
 // add_mod_256
 let add_mod_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_256_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_256_alias_ret_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_256_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_256_alias_ret_a_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_3_mod_256
 let mul_by_3_mod_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let mul_by_3_mod_256_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // lshift_mod_256
 let lshift_mod_256_spec count = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term count, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let lshift_mod_256_alias_ret_a_spec count = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term count, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term count, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // rshift_mod_256
 let rshift_mod_256_spec count = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term count, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let rshift_mod_256_alias_ret_a_spec count = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term count, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term count, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // cneg_mod_256
 let cneg_mod_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
-  flag <- crucible_fresh_var "flag" limb_type;
+  flag <- llvm_fresh_var "flag" limb_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term flag, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term flag, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let cneg_mod_256_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
-  flag <- crucible_fresh_var "flag" limb_type;
+  flag <- llvm_fresh_var "flag" limb_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term flag, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term flag, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sub_mod_256
 let sub_mod_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_256_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_256_alias_ret_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_256_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_256_alias_ret_a_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/memory_safety/add_mod_384.saw
+++ b/proof/x86/memory_safety/add_mod_384.saw
@@ -9,415 +9,415 @@
 
 // add_mod_384
 let add_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384_alias_ret_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384_alias_ret_a_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // add_mod_384x
 let add_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384x_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384x_alias_ret_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 let add_mod_384x_alias_ret_a_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // lshift_mod_384
 let lshift_mod_384_spec count = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term count, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let lshift_mod_384_alias_ret_a_spec count = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term count, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term count, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_3_mod_384
 let mul_by_3_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let mul_by_3_mod_384_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_8_mod_384
 let mul_by_8_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let mul_by_8_mod_384_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_b_onE1
 let mul_by_b_onE1_spec = do {
-  crucible_alloc_global "BLS12_381_P";
-  BLS12_381_P <- crucible_fresh_var "BLS12_381_P" vec384_type;
-  crucible_points_to
-    (crucible_global "BLS12_381_P")
-    (crucible_term BLS12_381_P);
+  llvm_alloc_global "BLS12_381_P";
+  BLS12_381_P <- llvm_fresh_var "BLS12_381_P" vec384_type;
+  llvm_points_to
+    (llvm_global "BLS12_381_P")
+    (llvm_term BLS12_381_P);
 
-  out_ptr <- crucible_alloc vec384_type;
+  out_ptr <- llvm_alloc vec384_type;
   (_, in_ptr) <- ptr_to_fresh_readonly "in" vec384_type;
-  crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_out" vec384_type;
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, in_ptr];
+  new_out <- llvm_fresh_var "new_out" vec384_type;
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 let mul_by_b_onE1_alias_out_in_spec = do {
-  crucible_alloc_global "BLS12_381_P";
-  BLS12_381_P <- crucible_fresh_var "BLS12_381_P" vec384_type;
-  crucible_points_to
-    (crucible_global "BLS12_381_P")
-    (crucible_term BLS12_381_P);
+  llvm_alloc_global "BLS12_381_P";
+  BLS12_381_P <- llvm_fresh_var "BLS12_381_P" vec384_type;
+  llvm_points_to
+    (llvm_global "BLS12_381_P")
+    (llvm_term BLS12_381_P);
 
   (_, out_ptr) <- ptr_to_fresh "out" vec384_type;
-  crucible_execute_func [out_ptr, out_ptr];
-  new_out <- crucible_fresh_var "new_out" vec384_type;
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, out_ptr];
+  new_out <- llvm_fresh_var "new_out" vec384_type;
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 
 // mul_by_4b_onE1
 let mul_by_4b_onE1_spec = do {
-  out_ptr <- crucible_alloc vec384_type;
+  out_ptr <- llvm_alloc vec384_type;
   (_, in_ptr) <- ptr_to_fresh_readonly "in" vec384_type;
-  crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_out" vec384_type;
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, in_ptr];
+  new_out <- llvm_fresh_var "new_out" vec384_type;
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 let mul_by_4b_onE1_alias_out_in_spec = do {
   (_, out_ptr) <- ptr_to_fresh "out" vec384_type;
-  crucible_execute_func [out_ptr, out_ptr];
-  new_out <- crucible_fresh_var "new_out" vec384_type;
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, out_ptr];
+  new_out <- llvm_fresh_var "new_out" vec384_type;
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 
 // mul_by_3_mod_384x
 let mul_by_3_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let mul_by_3_mod_384x_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_8_mod_384x
 let mul_by_8_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let mul_by_8_mod_384x_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_b_onE2
 let mul_by_b_onE2_spec = do {
-  crucible_alloc_global "BLS12_381_P";
-  BLS12_381_P <- crucible_fresh_var "BLS12_381_P" vec384_type;
-  crucible_points_to
-    (crucible_global "BLS12_381_P")
-    (crucible_term BLS12_381_P);
+  llvm_alloc_global "BLS12_381_P";
+  BLS12_381_P <- llvm_fresh_var "BLS12_381_P" vec384_type;
+  llvm_points_to
+    (llvm_global "BLS12_381_P")
+    (llvm_term BLS12_381_P);
 
-  out_ptr <- crucible_alloc vec384x_type;
+  out_ptr <- llvm_alloc vec384x_type;
   (_, in_ptr) <- ptr_to_fresh_readonly "in" vec384x_type;
-  crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_out" vec384x_type;
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, in_ptr];
+  new_out <- llvm_fresh_var "new_out" vec384x_type;
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 let mul_by_b_onE2_alias_out_in_spec = do {
-  crucible_alloc_global "BLS12_381_P";
-  BLS12_381_P <- crucible_fresh_var "BLS12_381_P" vec384_type;
-  crucible_points_to
-    (crucible_global "BLS12_381_P")
-    (crucible_term BLS12_381_P);
+  llvm_alloc_global "BLS12_381_P";
+  BLS12_381_P <- llvm_fresh_var "BLS12_381_P" vec384_type;
+  llvm_points_to
+    (llvm_global "BLS12_381_P")
+    (llvm_term BLS12_381_P);
 
   (_, out_ptr) <- ptr_to_fresh "out" vec384x_type;
-  crucible_execute_func [out_ptr, out_ptr];
-  new_out <- crucible_fresh_var "new_out" vec384x_type;
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, out_ptr];
+  new_out <- llvm_fresh_var "new_out" vec384x_type;
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 
 // mul_by_4b_onE2
 let mul_by_4b_onE2_spec = do {
-  out_ptr <- crucible_alloc vec384x_type;
+  out_ptr <- llvm_alloc vec384x_type;
   (_, in_ptr) <- ptr_to_fresh_readonly "in" vec384x_type;
-  crucible_execute_func [out_ptr, in_ptr];
-  new_out <- crucible_fresh_var "new_out" vec384x_type;
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, in_ptr];
+  new_out <- llvm_fresh_var "new_out" vec384x_type;
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 let mul_by_4b_onE2_alias_out_in_spec = do {
   (_, out_ptr) <- ptr_to_fresh "out" vec384x_type;
-  crucible_execute_func [out_ptr, out_ptr];
-  new_out <- crucible_fresh_var "new_out" vec384x_type;
-  crucible_points_to out_ptr (crucible_term new_out);
+  llvm_execute_func [out_ptr, out_ptr];
+  new_out <- llvm_fresh_var "new_out" vec384x_type;
+  llvm_points_to out_ptr (llvm_term new_out);
 };
 
 // cneg_mod_384
 let cneg_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  flag <- crucible_fresh_var "flag" limb_type;
+  flag <- llvm_fresh_var "flag" limb_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term flag, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term flag, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let cneg_mod_384_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
-  flag <- crucible_fresh_var "flag" limb_type;
+  flag <- llvm_fresh_var "flag" limb_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term flag, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term flag, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sub_mod_384
 let sub_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384_alias_ret_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384_alias_ret_a_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sub_mod_384x
 let sub_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x_alias_ret_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x_alias_ret_a_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // mul_by_1_plus_i_mod_384x
 let mul_by_1_plus_i_mod_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let mul_by_1_plus_i_mod_384x_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sgn0_pty_mod_384
 let sgn0_pty_mod_384_spec = do {
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [a_ptr, p_ptr];
-  return_value <- crucible_fresh_var "return_value" limb_type;
-  crucible_return (crucible_term return_value);
+  llvm_execute_func [a_ptr, p_ptr];
+  return_value <- llvm_fresh_var "return_value" limb_type;
+  llvm_return (llvm_term return_value);
 };
 
 // sgn0_pty_mod_384x
 let sgn0_pty_mod_384x_spec = do {
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [a_ptr, p_ptr];
-  return_value <- crucible_fresh_var "return_value" limb_type;
-  crucible_return (crucible_term return_value);
+  llvm_execute_func [a_ptr, p_ptr];
+  return_value <- llvm_fresh_var "return_value" limb_type;
+  llvm_return (llvm_term return_value);
 };
 
 // vec_select
 let vec_select_spec (bytes:Int) = do {
-  ret_ptr <- crucible_alloc (llvm_array bytes (llvm_int 8));
+  ret_ptr <- llvm_alloc (llvm_array bytes (llvm_int 8));
   (_, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array bytes (llvm_int 8));
   (_, b_ptr) <- ptr_to_fresh_readonly "b" (llvm_array bytes (llvm_int 8));
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term sel_a];
-  new_vec_select_ret <- crucible_fresh_var "new_vec_select_ret" (llvm_array bytes (llvm_int 8));
-  crucible_points_to ret_ptr (crucible_term new_vec_select_ret);
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, llvm_term sel_a];
+  new_vec_select_ret <- llvm_fresh_var "new_vec_select_ret" (llvm_array bytes (llvm_int 8));
+  llvm_points_to ret_ptr (llvm_term new_vec_select_ret);
 };
 
 let vec_select_alias_1_3_spec bytes = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" (llvm_array bytes (llvm_int 8));
   (_, a_ptr) <- ptr_to_fresh_readonly "a" (llvm_array bytes (llvm_int 8));
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, crucible_term sel_a];
-  new_vec_select_alias_1_3_ret <- crucible_fresh_var "new_vec_select_alias_1_3_ret" (llvm_array bytes (llvm_int 8));
-  crucible_points_to ret_ptr (crucible_term new_vec_select_alias_1_3_ret);
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, llvm_term sel_a];
+  new_vec_select_alias_1_3_ret <- llvm_fresh_var "new_vec_select_alias_1_3_ret" (llvm_array bytes (llvm_int 8));
+  llvm_points_to ret_ptr (llvm_term new_vec_select_alias_1_3_ret);
 };
 
 let vec_select_alias_1_2_spec bytes = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" (llvm_array bytes (llvm_int 8));
   (_, b_ptr) <- ptr_to_fresh_readonly "b" (llvm_array bytes (llvm_int 8));
-  sel_a <- crucible_fresh_var "sel_a" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, crucible_term sel_a];
-  new_vec_select_alias_1_2_ret <- crucible_fresh_var "new_vec_select_alias_1_2_ret" (llvm_array bytes (llvm_int 8));
-  crucible_points_to ret_ptr (crucible_term new_vec_select_alias_1_2_ret);
+  sel_a <- llvm_fresh_var "sel_a" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, llvm_term sel_a];
+  new_vec_select_alias_1_2_ret <- llvm_fresh_var "new_vec_select_alias_1_2_ret" (llvm_array bytes (llvm_int 8));
+  llvm_points_to ret_ptr (llvm_term new_vec_select_alias_1_2_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/memory_safety/add_mod_384x384.saw
+++ b/proof/x86/memory_safety/add_mod_384x384.saw
@@ -9,86 +9,86 @@
 
 // add_mod_384x384
 let add_mod_384x384_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384x384_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384x384_alias_ret_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384x384_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let add_mod_384x384_alias_ret_a_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 // sub_mod_384x384
 let sub_mod_384x384_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x384_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x384_alias_ret_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x384_alias_a_b_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, a_ptr, a_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 let sub_mod_384x384_alias_ret_a_b_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec768_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, ret_ptr, p_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/memory_safety/ctq_inverse_mod_384.saw
+++ b/proof/x86/memory_safety/ctq_inverse_mod_384.saw
@@ -9,12 +9,12 @@
 
 // ct_inverse_mod_383
 let ct_inverse_mod_383_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384_type;
   (_, mod_ptr) <- ptr_to_fresh_readonly "mod" vec384_type;
-  crucible_execute_func [ret_ptr, inp_ptr, mod_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, inp_ptr, mod_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/memory_safety/ctx_inverse_mod_384.saw
+++ b/proof/x86/memory_safety/ctx_inverse_mod_384.saw
@@ -9,12 +9,12 @@
 
 // ct_inverse_mod_383
 let ct_inverse_mod_383_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, inp_ptr) <- ptr_to_fresh_readonly "inp" vec384_type;
   (_, mod_ptr) <- ptr_to_fresh_readonly "mod" vec384_type;
-  crucible_execute_func [ret_ptr, inp_ptr, mod_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec768_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
+  llvm_execute_func [ret_ptr, inp_ptr, mod_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec768_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/memory_safety/inverse_mod_384.saw
+++ b/proof/x86/memory_safety/inverse_mod_384.saw
@@ -9,25 +9,25 @@
 
 // eucl_inverse_mod_384
 let eucl_inverse_mod_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
   (_, one_ptr) <- ptr_to_fresh_readonly "one" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, one_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
-  ret <- crucible_fresh_var "eucl_inverse_mod_384_ret" limb_type;
-  crucible_return (crucible_term ret);
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, one_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
+  ret <- llvm_fresh_var "eucl_inverse_mod_384_ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 let eucl_inverse_mod_384_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
   (_, one_ptr) <- ptr_to_fresh_readonly "one" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, one_ptr];
-  new_ret <- crucible_fresh_var "new_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_ret);
-  ret <- crucible_fresh_var "eucl_inverse_mod_384_ret" limb_type;
-  crucible_return (crucible_term ret);
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, one_ptr];
+  new_ret <- llvm_fresh_var "new_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_ret);
+  ret <- llvm_fresh_var "eucl_inverse_mod_384_ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/memory_safety/mulq_mont_256.saw
+++ b/proof/x86/memory_safety/mulq_mont_256.saw
@@ -13,20 +13,20 @@ let mulq_mont_sparse_256_spec = do {
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_sparse_256_ret <- crucible_fresh_var "new_mul_mont_sparse_256_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_sparse_256_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_sparse_256_ret <- llvm_fresh_var "new_mul_mont_sparse_256_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_sparse_256_ret);
 };
 
 let mulq_mont_sparse_256_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_sparse_256_alias_ret <- crucible_fresh_var "new_mul_mont_sparse_256_alias_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_sparse_256_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_sparse_256_alias_ret <- llvm_fresh_var "new_mul_mont_sparse_256_alias_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_sparse_256_alias_ret);
 };
 
 // sqrq_mont_sparse_256
@@ -34,10 +34,10 @@ let sqrq_mont_sparse_256_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_sparse_256_ret <- crucible_fresh_var "new_sqr_mont_sparse_256_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_sparse_256_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_sparse_256_ret <- llvm_fresh_var "new_sqr_mont_sparse_256_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_sparse_256_ret);
 };
 
 // fromq_mont_256
@@ -45,30 +45,30 @@ let fromq_mont_256_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_from_mont_256_ret <- crucible_fresh_var "new_from_mont_256_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_from_mont_256_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_from_mont_256_ret <- llvm_fresh_var "new_from_mont_256_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_from_mont_256_ret);
 };
 
 // redcq_mont_256
 let redcq_mont_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec512_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term n0];
-  new_redc_mont_256_ret <- crucible_fresh_var "new_redc_mont_256_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_redc_mont_256_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, llvm_term n0];
+  new_redc_mont_256_ret <- llvm_fresh_var "new_redc_mont_256_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_redc_mont_256_ret);
 };
 
 let redcq_mont_256_alias_ret_a_spec = do {
   (_, a_ptr) <- ptr_to_fresh "a" vec512_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [a_ptr, a_ptr, b_ptr, crucible_term n0];
-  new_redc_mont_256_alias_1_2_a <- crucible_fresh_var "new_redc_mont_256_alias_1_2_a" vec512_type;
-  crucible_points_to a_ptr (crucible_term new_redc_mont_256_alias_1_2_a);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [a_ptr, a_ptr, b_ptr, llvm_term n0];
+  new_redc_mont_256_alias_1_2_a <- llvm_fresh_var "new_redc_mont_256_alias_1_2_a" vec512_type;
+  llvm_points_to a_ptr (llvm_term new_redc_mont_256_alias_1_2_a);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/memory_safety/mulq_mont_384.saw
+++ b/proof/x86/memory_safety/mulq_mont_384.saw
@@ -9,106 +9,106 @@
 
 // mulq_mont_384x
 let mulq_mont_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384x_ret <- crucible_fresh_var "new_mul_mont_384x_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384x_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384x_ret <- llvm_fresh_var "new_mul_mont_384x_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384x_ret);
 };
 
 let mulq_mont_384x_alias_ret_ret_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384x_alias_ret <- crucible_fresh_var "new_mul_mont_384x_alias_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384x_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384x_alias_ret <- llvm_fresh_var "new_mul_mont_384x_alias_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384x_alias_ret);
 };
 
 let mulq_mont_384x_alias_ret_a_ret_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384x_alias_ret <- crucible_fresh_var "new_mul_mont_384x_alias_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384x_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384x_alias_ret <- llvm_fresh_var "new_mul_mont_384x_alias_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384x_alias_ret);
 };
 
 
 // sqrq_mont_384x
 let sqrq_mont_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_384x_ret <- crucible_fresh_var "new_sqr_mont_384x_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384x_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_384x_ret <- llvm_fresh_var "new_sqr_mont_384x_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_384x_ret);
 };
 
 let sqrq_mont_384x_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_384x_alias_ret <- crucible_fresh_var "new_sqr_mont_384x_alias_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384x_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_384x_alias_ret <- llvm_fresh_var "new_sqr_mont_384x_alias_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_384x_alias_ret);
 };
 
 // mulq_382x
 let mulq_382x_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_mul_382x_ret <- crucible_fresh_var "new_mul_382x_ret" vec768x_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_382x_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_mul_382x_ret <- llvm_fresh_var "new_mul_382x_ret" vec768x_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_382x_ret);
 };
 
 // sqrq_382x
 let sqrq_382x_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
-  new_sqr_382x_ret <- crucible_fresh_var "new_sqr_382x_ret" vec768x_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_382x_ret);
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
+  new_sqr_382x_ret <- llvm_fresh_var "new_sqr_382x_ret" vec768x_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_382x_ret);
 };
 
 // mulq_384
 let mulq_384_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  new_mul_384_ret <- crucible_fresh_var "new_mul_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_384_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  new_mul_384_ret <- llvm_fresh_var "new_mul_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_384_ret);
 };
 
 // sqrq_384
 let sqrq_384_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr];
-  new_sqr_384_ret <- crucible_fresh_var "new_sqr_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_384_ret);
+  llvm_execute_func [ret_ptr, a_ptr];
+  new_sqr_384_ret <- llvm_fresh_var "new_sqr_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_384_ret);
 };
 
 // redcq_mont_384
 let redcq_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term n0];
-  new_redc_mont_384_ret <- crucible_fresh_var "new_redc_mont_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_redc_mont_384_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, llvm_term n0];
+  new_redc_mont_384_ret <- llvm_fresh_var "new_redc_mont_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_redc_mont_384_ret);
 };
 
 // fromq_mont_384
@@ -116,137 +116,137 @@ let fromq_mont_384_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_from_mont_384_ret <- crucible_fresh_var "new_from_mont_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_from_mont_384_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_from_mont_384_ret <- llvm_fresh_var "new_from_mont_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_from_mont_384_ret);
 };
 
 // sqn0x_pty_mont_384
 let sgn0q_pty_mont_384_spec = do {
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [a_ptr, p_ptr, crucible_term n0];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_return (crucible_term ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [a_ptr, p_ptr, llvm_term n0];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 
 // sqn0x_pty_mont_384x
 let sgn0q_pty_mont_384x_spec = do {
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [a_ptr, p_ptr, crucible_term n0];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_return (crucible_term ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [a_ptr, p_ptr, llvm_term n0];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 
 // mulq_mont_384
 let mulq_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384_ret <- crucible_fresh_var "new_mul_mont_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384_ret <- llvm_fresh_var "new_mul_mont_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384_ret);
 };
 
 let mulq_mont_384_ret_ret_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384_alias_ret <- crucible_fresh_var "new_mul_mont_384_alias_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384_alias_ret <- llvm_fresh_var "new_mul_mont_384_alias_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384_alias_ret);
 };
 
 let mulq_mont_384_ret_a_ret_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384_alias_ret <- crucible_fresh_var "new_mul_mont_384_alias_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384_alias_ret <- llvm_fresh_var "new_mul_mont_384_alias_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384_alias_ret);
 };
 
 // sqrq_mont_384
 let sqrq_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_384_ret <- crucible_fresh_var "new_sqr_mont_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_384_ret <- llvm_fresh_var "new_sqr_mont_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_384_ret);
 };
 
 let sqrq_mont_384_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_384_alias_ret <- crucible_fresh_var "new_sqr_mont_384_alias_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_384_alias_ret <- llvm_fresh_var "new_sqr_mont_384_alias_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_384_alias_ret);
 };
 
 // sqrq_n_mul_mont_384
 let sqrq_n_mul_mont_384_spec  = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  count <- crucible_fresh_var "count" size_type;
+  count <- llvm_fresh_var "count" size_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
+  n0 <- llvm_fresh_var "n0" limb_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term count, p_ptr, crucible_term n0, b_ptr];
-  new_sqr_n_mul_mont_384_ret <- crucible_fresh_var "new_sqr_n_mul_mont_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_384_ret);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term count, p_ptr, llvm_term n0, b_ptr];
+  new_sqr_n_mul_mont_384_ret <- llvm_fresh_var "new_sqr_n_mul_mont_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_n_mul_mont_384_ret);
 };
 
 // sqrq_n_mul_mont_383
 let sqrq_n_mul_mont_383_spec count = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
+  n0 <- llvm_fresh_var "n0" limb_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{ `count : [64] }}, p_ptr, crucible_term n0, b_ptr];
-  new_sqr_n_mul_mont_383_ret <- crucible_fresh_var "new_sqr_n_mul_mont_383_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_383_ret);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term {{ `count : [64] }}, p_ptr, llvm_term n0, b_ptr];
+  new_sqr_n_mul_mont_383_ret <- llvm_fresh_var "new_sqr_n_mul_mont_383_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_n_mul_mont_383_ret);
 };
 
 let sqrq_n_mul_mont_383_alias_1_2_spec count = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
+  n0 <- llvm_fresh_var "n0" limb_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term {{ `count : [64] }}, p_ptr, crucible_term n0, b_ptr];
-  new_sqr_n_mul_mont_383_alias_1_2_ret <- crucible_fresh_var "new_sqr_n_mul_mont_383_alias_1_2_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_383_alias_1_2_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term {{ `count : [64] }}, p_ptr, llvm_term n0, b_ptr];
+  new_sqr_n_mul_mont_383_alias_1_2_ret <- llvm_fresh_var "new_sqr_n_mul_mont_383_alias_1_2_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_n_mul_mont_383_alias_1_2_ret);
 };
 
 // sqrq_mont_382x
 let sqrq_mont_382x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_382x_ret <- crucible_fresh_var "new_sqr_mont_382x_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_382x_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_382x_ret <- llvm_fresh_var "new_sqr_mont_382x_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_382x_ret);
 };
 
 let sqrq_mont_382x_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_382x_alias_ret <- crucible_fresh_var "new_sqr_mont_382x_alias_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_382x_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_382x_alias_ret <- llvm_fresh_var "new_sqr_mont_382x_alias_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_382x_alias_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/memory_safety/mulx_mont_256.saw
+++ b/proof/x86/memory_safety/mulx_mont_256.saw
@@ -13,20 +13,20 @@ let mulx_mont_sparse_256_spec = do {
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_sparse_256_ret <- crucible_fresh_var "new_mul_mont_sparse_256_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_sparse_256_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_sparse_256_ret <- llvm_fresh_var "new_mul_mont_sparse_256_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_sparse_256_ret);
 };
 
 let mulx_mont_sparse_256_alias_ret_a_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_sparse_256_alias_ret <- crucible_fresh_var "new_mul_mont_sparse_256_alias_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_sparse_256_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_sparse_256_alias_ret <- llvm_fresh_var "new_mul_mont_sparse_256_alias_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_sparse_256_alias_ret);
 };
 
 // sqrx_mont_sparse_256
@@ -34,10 +34,10 @@ let sqrx_mont_sparse_256_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_sparse_256_ret <- crucible_fresh_var "new_sqr_mont_sparse_256_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_sparse_256_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_sparse_256_ret <- llvm_fresh_var "new_sqr_mont_sparse_256_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_sparse_256_ret);
 };
 
 // fromx_mont_256
@@ -45,30 +45,30 @@ let fromx_mont_256_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec256_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_from_mont_256_ret <- crucible_fresh_var "new_from_mont_256_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_from_mont_256_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_from_mont_256_ret <- llvm_fresh_var "new_from_mont_256_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_from_mont_256_ret);
 };
 
 // redcx_mont_256
 let redcx_mont_256_spec = do {
-  ret_ptr <- crucible_alloc vec256_type;
+  ret_ptr <- llvm_alloc vec256_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec512_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term n0];
-  new_redc_mont_256_ret <- crucible_fresh_var "new_redc_mont_256_ret" vec256_type;
-  crucible_points_to ret_ptr (crucible_term new_redc_mont_256_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, llvm_term n0];
+  new_redc_mont_256_ret <- llvm_fresh_var "new_redc_mont_256_ret" vec256_type;
+  llvm_points_to ret_ptr (llvm_term new_redc_mont_256_ret);
 };
 
 let redcx_mont_256_alias_ret_a_spec = do {
   (_, a_ptr) <- ptr_to_fresh "a" vec512_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec256_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [a_ptr, a_ptr, b_ptr, crucible_term n0];
-  new_redc_mont_256_alias_1_2_a <- crucible_fresh_var "new_redc_mont_256_alias_1_2_a" vec512_type;
-  crucible_points_to a_ptr (crucible_term new_redc_mont_256_alias_1_2_a);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [a_ptr, a_ptr, b_ptr, llvm_term n0];
+  new_redc_mont_256_alias_1_2_a <- llvm_fresh_var "new_redc_mont_256_alias_1_2_a" vec512_type;
+  llvm_points_to a_ptr (llvm_term new_redc_mont_256_alias_1_2_a);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proof/x86/memory_safety/mulx_mont_384.saw
+++ b/proof/x86/memory_safety/mulx_mont_384.saw
@@ -9,106 +9,106 @@
 
 // mulx_mont_384x
 let mulx_mont_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384x_ret <- crucible_fresh_var "new_mul_mont_384x_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384x_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384x_ret <- llvm_fresh_var "new_mul_mont_384x_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384x_ret);
 };
 
 let mulx_mont_384x_alias_ret_ret_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384x_alias_ret <- crucible_fresh_var "new_mul_mont_384x_alias_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384x_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384x_alias_ret <- llvm_fresh_var "new_mul_mont_384x_alias_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384x_alias_ret);
 };
 
 let mulx_mont_384x_alias_ret_a_ret_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384x_alias_ret <- crucible_fresh_var "new_mul_mont_384x_alias_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384x_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384x_alias_ret <- llvm_fresh_var "new_mul_mont_384x_alias_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384x_alias_ret);
 };
 
 
 // sqrx_mont_384x
 let sqrx_mont_384x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_384x_ret <- crucible_fresh_var "new_sqr_mont_384x_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384x_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_384x_ret <- llvm_fresh_var "new_sqr_mont_384x_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_384x_ret);
 };
 
 let sqrx_mont_384x_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_384x_alias_ret <- crucible_fresh_var "new_sqr_mont_384x_alias_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384x_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_384x_alias_ret <- llvm_fresh_var "new_sqr_mont_384x_alias_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_384x_alias_ret);
 };
 
 // mulx_382x
 let mulx_382x_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
-  new_mul_382x_ret <- crucible_fresh_var "new_mul_382x_ret" vec768x_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_382x_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr];
+  new_mul_382x_ret <- llvm_fresh_var "new_mul_382x_ret" vec768x_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_382x_ret);
 };
 
 // sqrx_382x
 let sqrx_382x_spec = do {
-  ret_ptr <- crucible_alloc vec768x_type;
+  ret_ptr <- llvm_alloc vec768x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr];
-  new_sqr_382x_ret <- crucible_fresh_var "new_sqr_382x_ret" vec768x_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_382x_ret);
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr];
+  new_sqr_382x_ret <- llvm_fresh_var "new_sqr_382x_ret" vec768x_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_382x_ret);
 };
 
 // mulx_384
 let mulx_384_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr];
-  new_mul_384_ret <- crucible_fresh_var "new_mul_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_384_ret);
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr];
+  new_mul_384_ret <- llvm_fresh_var "new_mul_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_384_ret);
 };
 
 // sqrx_384
 let sqrx_384_spec = do {
-  ret_ptr <- crucible_alloc vec768_type;
+  ret_ptr <- llvm_alloc vec768_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr];
-  new_sqr_384_ret <- crucible_fresh_var "new_sqr_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_384_ret);
+  llvm_execute_func [ret_ptr, a_ptr];
+  new_sqr_384_ret <- llvm_fresh_var "new_sqr_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_384_ret);
 };
 
 // redcx_mont_384
 let redcx_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec768_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, crucible_term n0];
-  new_redc_mont_384_ret <- crucible_fresh_var "new_redc_mont_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_redc_mont_384_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, llvm_term n0];
+  new_redc_mont_384_ret <- llvm_fresh_var "new_redc_mont_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_redc_mont_384_ret);
 };
 
 // fromx_mont_384
@@ -116,124 +116,124 @@ let fromx_mont_384_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_from_mont_384_ret <- crucible_fresh_var "new_from_mont_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_from_mont_384_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_from_mont_384_ret <- llvm_fresh_var "new_from_mont_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_from_mont_384_ret);
 };
 
 // sqn0x_pty_mont_384
 let sgn0x_pty_mont_384_spec = do {
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [a_ptr, p_ptr, crucible_term n0];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_return (crucible_term ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [a_ptr, p_ptr, llvm_term n0];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 
 // sqn0x_pty_mont_384x
 let sgn0x_pty_mont_384x_spec = do {
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [a_ptr, p_ptr, crucible_term n0];
-  ret <- crucible_fresh_var "ret" limb_type;
-  crucible_return (crucible_term ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [a_ptr, p_ptr, llvm_term n0];
+  ret <- llvm_fresh_var "ret" limb_type;
+  llvm_return (llvm_term ret);
 };
 
 // mulx_mont_384
 let mulx_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384_ret <- crucible_fresh_var "new_mul_mont_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384_ret <- llvm_fresh_var "new_mul_mont_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384_ret);
 };
 
 let mulx_mont_384_ret_ret_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384_alias_ret <- crucible_fresh_var "new_mul_mont_384_alias_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, b_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384_alias_ret <- llvm_fresh_var "new_mul_mont_384_alias_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384_alias_ret);
 };
 
 let mulx_mont_384_ret_a_ret_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, crucible_term n0];
-  new_mul_mont_384_alias_ret <- crucible_fresh_var "new_mul_mont_384_alias_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_mul_mont_384_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, ret_ptr, p_ptr, llvm_term n0];
+  new_mul_mont_384_alias_ret <- llvm_fresh_var "new_mul_mont_384_alias_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_mul_mont_384_alias_ret);
 };
 
 // sqrx_mont_384
 let sqrx_mont_384_spec = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_384_ret <- crucible_fresh_var "new_sqr_mont_384_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_384_ret <- llvm_fresh_var "new_sqr_mont_384_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_384_ret);
 };
 
 let sqrx_mont_384_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_384_alias_ret <- crucible_fresh_var "new_sqr_mont_384_alias_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_384_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_384_alias_ret <- llvm_fresh_var "new_sqr_mont_384_alias_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_384_alias_ret);
 };
 
 // sqrx_n_mul_mont_383
 let sqrx_n_mul_mont_383_spec count = do {
-  ret_ptr <- crucible_alloc vec384_type;
+  ret_ptr <- llvm_alloc vec384_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
+  n0 <- llvm_fresh_var "n0" limb_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, a_ptr, crucible_term {{ `count : [64] }}, p_ptr, crucible_term n0, b_ptr];
-  new_sqr_n_mul_mont_383_ret <- crucible_fresh_var "new_sqr_n_mul_mont_383_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_383_ret);
+  llvm_execute_func [ret_ptr, a_ptr, llvm_term {{ `count : [64] }}, p_ptr, llvm_term n0, b_ptr];
+  new_sqr_n_mul_mont_383_ret <- llvm_fresh_var "new_sqr_n_mul_mont_383_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_n_mul_mont_383_ret);
 };
 
 let sqrx_n_mul_mont_383_alias_1_2_spec count = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
+  n0 <- llvm_fresh_var "n0" limb_type;
   (_, b_ptr) <- ptr_to_fresh_readonly "b" vec384_type;
-  crucible_execute_func [ret_ptr, ret_ptr, crucible_term {{ `count : [64] }}, p_ptr, crucible_term n0, b_ptr];
-  new_sqr_n_mul_mont_383_alias_1_2_ret <- crucible_fresh_var "new_sqr_n_mul_mont_383_alias_1_2_ret" vec384_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_n_mul_mont_383_alias_1_2_ret);
+  llvm_execute_func [ret_ptr, ret_ptr, llvm_term {{ `count : [64] }}, p_ptr, llvm_term n0, b_ptr];
+  new_sqr_n_mul_mont_383_alias_1_2_ret <- llvm_fresh_var "new_sqr_n_mul_mont_383_alias_1_2_ret" vec384_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_n_mul_mont_383_alias_1_2_ret);
 };
 
 // sqrx_mont_382x
 let sqrx_mont_382x_spec = do {
-  ret_ptr <- crucible_alloc vec384x_type;
+  ret_ptr <- llvm_alloc vec384x_type;
   (_, a_ptr) <- ptr_to_fresh_readonly "a" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, a_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_382x_ret <- crucible_fresh_var "new_sqr_mont_382x_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_382x_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, a_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_382x_ret <- llvm_fresh_var "new_sqr_mont_382x_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_382x_ret);
 };
 
 let sqrx_mont_382x_alias_spec = do {
   (_, ret_ptr) <- ptr_to_fresh "ret" vec384x_type;
   (_, p_ptr) <- ptr_to_fresh_readonly "p" vec384_type;
-  n0 <- crucible_fresh_var "n0" limb_type;
-  crucible_execute_func [ret_ptr, ret_ptr, p_ptr, crucible_term n0];
-  new_sqr_mont_382x_alias_ret <- crucible_fresh_var "new_sqr_mont_382x_alias_ret" vec384x_type;
-  crucible_points_to ret_ptr (crucible_term new_sqr_mont_382x_alias_ret);
+  n0 <- llvm_fresh_var "n0" limb_type;
+  llvm_execute_func [ret_ptr, ret_ptr, p_ptr, llvm_term n0];
+  new_sqr_mont_382x_alias_ret <- llvm_fresh_var "new_sqr_mont_382x_alias_ret" vec384x_type;
+  llvm_points_to ret_ptr (llvm_term new_sqr_mont_382x_alias_ret);
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This will still work with the SAW 1.3 release this tree is now using, but also not break on nightly.