### PR TITLE
Bump `cryptol-specs` submodule commit

### DIFF
--- a/proof/cryptol_imports.saw
+++ b/proof/cryptol_imports.saw
@@ -22,7 +22,7 @@ import "../spec/implementation/Field.cry";
 
 // Key generation
 import "../spec/rfc8017.cry";
-import "../cryptol-specs/Primitive/Symmetric/KDF/HKDF256.cry";
+import "../spec/SHA2Internal/HKDF256.cry";
 import "../spec/KeyGen.cry";
 import "../spec/implementation/Keygen.cry";
 

--- a/proof/cryptol_imports.saw
+++ b/proof/cryptol_imports.saw
@@ -27,7 +27,7 @@ import "../spec/KeyGen.cry";
 import "../spec/implementation/Keygen.cry";
 
 // hashing
-import "../cryptol-specs/Primitive/Keyless/Hash/SHA256.cry";
+import "../cryptol-specs/Primitive/Keyless/Hash/SHA2Internal/SHA256.cry";
 import "../spec/ExpandMessage.cry";
 HE1 <- cryptol_load "../spec/HashToCurveE1.cry";
 HE1Aux <- cryptol_load "../spec/HashToCurveE1Aux.cry";

--- a/proof/keygen.saw
+++ b/proof/keygen.saw
@@ -66,7 +66,7 @@ let redc_mont_256_alias_1_2_spec = do {
 // Now we give specs for the functions we verify:
 
 //import "../spec/rfc8017.cry";
-//import "../cryptol-specs/Primitive/Symmetric/KDF/HKDF256.cry";
+//import "../spec/SHA2Internal/HKDF256.cry";
 
 let HKDF_Extract_spec salt_len IKM_len = do {
   PRK_ptr <- llvm_alloc (llvm_array 32 (llvm_int 8));

--- a/proof/sha_overrides.saw
+++ b/proof/sha_overrides.saw
@@ -2,7 +2,7 @@
  * Copyright (c) 2020 Galois, Inc.
  * SPDX-License-Identifier: Apache-2.0 OR MIT
 */
-import "../cryptol-specs/Primitive/Keyless/Hash/SHA256.cry";
+import "../cryptol-specs/Primitive/Keyless/Hash/SHA2Internal/SHA256.cry";
 
 // Needed for the sha subfunction specifications:
 let {{

--- a/spec/BLSGeneric.cry
+++ b/spec/BLSGeneric.cry
@@ -18,7 +18,7 @@ import Common::Field (FieldRep)
 import ShortWeierstrassCurve as EC
 import Parameters as P
 import Maybe
-import Primitive::Keyless::Hash::SHA256
+import Primitive::Keyless::Hash::SHA2Internal::SHA256
 import Primitive::Symmetric::KDF::HKDF256
 import rfc8017
 
@@ -50,6 +50,9 @@ parameter
     // type DST_len: #
     DST: [43][8]
 
+    //type constraint Hashable msg_len = (msg_len <= 255, 61 >= width (69 + msg_len + DST_len))
+    type constraint Hashable msg_len = (msg_len <= 255, 61 >= width (69 + msg_len + 43))
+
     hash_to_point: {msg_len} (Hashable msg_len) =>
                [msg_len][8] -> EC::AffinePoint t_F
 
@@ -68,9 +71,6 @@ parameter
 
     pubkey_subgroup_check: EC::AffinePoint t_F' -> Bool
     signature_subgroup_check: EC::AffinePoint t_F -> Bool
-
-//type constraint Hashable msg_len = (msg_len <= 255, 61 >= width (69 + msg_len + DST_len))
-type constraint Hashable msg_len = (msg_len <= 255, 61 >= width (69 + msg_len + 43))
 
 reexport_DST = DST
 

--- a/spec/BLSGeneric.cry
+++ b/spec/BLSGeneric.cry
@@ -19,7 +19,7 @@ import ShortWeierstrassCurve as EC
 import Parameters as P
 import Maybe
 import Primitive::Keyless::Hash::SHA2Internal::SHA256
-import Primitive::Symmetric::KDF::HKDF256
+import SHA2Internal::HKDF256
 import rfc8017
 
 // Section 2.2, "parameters"

--- a/spec/ExpandMessage.cry
+++ b/spec/ExpandMessage.cry
@@ -5,7 +5,7 @@
 module ExpandMessage where
 
 import rfc8017 (I2OSP, OS2IP)
-import Primitive::Keyless::Hash::SHA256 as SHA256
+import Primitive::Keyless::Hash::SHA2Internal::SHA256 as SHA256
 
 private
     // From Section 4. Utility Functions

--- a/spec/HashToCurveGeneric.cry
+++ b/spec/HashToCurveGeneric.cry
@@ -9,7 +9,7 @@
 module HashToCurveGeneric where
 
 import rfc8017 (I2OSP, OS2IP)
-import Primitive::Keyless::Hash::SHA256 as SHA256
+import Primitive::Keyless::Hash::SHA2Internal::SHA256 as SHA256
 import Common::Field
 import Parameters (t_Fp, Fp, to_Fp)
 import FieldExtras
@@ -35,11 +35,11 @@ parameter
     type constraint fin _m
 
     // various constraints thrown up by the type checker
-    type constraint 8 * ((128 + lg2 p) /^ 8) >= 384
-    type constraint 2 * m <= 127
+    type constraint 8 * ((128 + lg2 _p) /^ 8) >= 384
+    type constraint 2 * _m <= 127
 
     // Convert a list of elements of F_p to an element of F_q
-    _base_to_F: [m]t_Fp -> _t_F
+    _base_to_F: [_m]t_Fp -> _t_F
 
     // The curve (will be E1 or E2)
     _C: EC::EllipticCurve _t_F

--- a/spec/KeyGen.cry
+++ b/spec/KeyGen.cry
@@ -7,9 +7,10 @@ module KeyGen where
 // 2.3 KeyGen
 
 import Parameters as P
-import Primitive::Keyless::Hash::SHA256
+import Primitive::Keyless::Hash::SHA2Internal::SHA256
 import Primitive::Symmetric::KDF::HKDF256
 import rfc8017
+import ValidHMACSizes
 
 /**
  * KeyGen from draft-02

--- a/spec/KeyGen.cry
+++ b/spec/KeyGen.cry
@@ -8,7 +8,7 @@ module KeyGen where
 
 import Parameters as P
 import Primitive::Keyless::Hash::SHA2Internal::SHA256
-import Primitive::Symmetric::KDF::HKDF256
+import SHA2Internal::HKDF256
 import rfc8017
 import ValidHMACSizes
 

--- a/spec/PrimeField.cry
+++ b/spec/PrimeField.cry
@@ -4,7 +4,7 @@
 */
 // Three representation of a finite field with p elements, where p is prime.
 //
-// The first uses Integers, the second the modular type `Z n`, and 
+// The first uses Integers, the second the modular type `Z n`, and
 // the third uses bit vectors.
 //
 // In the second, then, "p" is a type parameter, while in the other two it

--- a/spec/PrimeField.cry
+++ b/spec/PrimeField.cry
@@ -13,7 +13,6 @@
 module PrimeField where
 
 import Common::Field
-import Common::ModDivZ
 import Common::mod_arith
 
 /**
@@ -117,3 +116,31 @@ prime_field_bv m =
     , field_unit = 1
     , is_equal (x, y) = x==y // does this need to handle unnormalized values?
     }
+
+// Historical note: the definitions below used to be provided by cryptol-specs,
+// but they have since been removed, as the `moddiv` function has been largely
+// superseded by the (/.) function over Fields. Unfortunately, it is not
+// entirely straightforward to replace uses of `moddiv` with (/.) in the code
+// above, as this would require changing a fair number of type signatures.
+// Moreover, it is unclear if the shape of the proof goals would be
+// substantially different or not.
+//
+// We opt to simply re-define `moddiv` below for the sake of convenience.
+private
+  even k = k % 2 == 0
+
+  // Calulate x / y in F_p using Euler's binary gcd algorithm
+  moddiv : {p}(fin p, p >= 3) => Z p -> Z p -> Z p  // p prime!
+  moddiv x y = if y == 0 then error "division by 0"  // zero has no inverse
+                         else fromInteger (egcd `p 0 (fromZ y) (fromZ x))
+      where
+
+      egcd : Integer -> Integer -> Integer -> Integer -> Integer
+      egcd a ra b rb =  // a odd!
+          if b == 0 then ra
+           | even b then egcd a ra (   b    / 2) (half rb)
+           | a < b  then egcd a ra ((b - a) / 2) (half ((rb - ra) % `p))
+                    else egcd b rb ((a - b) / 2) (half ((ra - rb) % `p))
+
+      half : Integer -> Integer
+      half k = (if even k then k else (k + `p)) / 2

--- a/spec/SHA2Internal/HKDF256.cry
+++ b/spec/SHA2Internal/HKDF256.cry
@@ -1,0 +1,14 @@
+// Like `Primitive::Symmetric::KDF::HKDF256`, but instantiated to use a version
+// of HMAC_SHA256 that uses `Primitive::Keyless::Hash::SHA2Internal::SHA256`
+// instead of `Primitive::Keyless::Hash::SHA2::Instantiations::SHA256`.
+module SHA2Internal::HKDF256 = Primitive::Symmetric::KDF::HKDF where
+
+import SHA2Internal::HMAC_SHA256 as HMAC_SHA256
+
+type HashLen = 32
+HMAC = hmacBytes
+
+hmacBytes : {n, m} (64 >= width (8 * (64 + m)),
+                    64 >= width (8 * n), 32 >= width m, fin m, fin n) =>
+            [n][8] -> [m][8] -> [32][8]
+hmacBytes key msg = HMAC_SHA256::hmac key msg

--- a/spec/SHA2Internal/HMAC_SHA256.cry
+++ b/spec/SHA2Internal/HMAC_SHA256.cry
@@ -1,0 +1,12 @@
+// Like `Primitive::Symmetric::MAC::HMAC::Instantiations::HMAC_SHA256`, but
+// instantiated to use `Primitive::Keyless::Hash::SHA2Internal::SHA256` instead
+// of `Primitive::Keyless::Hash::SHA2::Instantiations::SHA256`.
+module SHA2Internal::HMAC_SHA256 = Primitive::Symmetric::MAC::HMAC::Specification where
+
+import Primitive::Keyless::Hash::SHA2Internal::SHA256
+
+type B = 64
+type L = 32
+
+H : {T} (width (8 * T) <= B) => [T][8] -> [L][8]
+H M = split (SHAImp M)

--- a/spec/ValidHMACSizes.cry
+++ b/spec/ValidHMACSizes.cry
@@ -1,0 +1,13 @@
+module ValidHMACSizes where
+
+import Primitive::Symmetric::KDF::HKDF256
+
+// This is defined internally in cryptol-specs'
+// Primitive::Symmetric::KDF::HKDF256. For now, we simply redefine it here so
+// that other definitions may refer to it. We may consider re-exporting this
+// from cryptol-specs in the future.
+type constraint validHMACSizes KeyLen MsgLen =
+  ( fin KeyLen, fin MsgLen
+      , 32 >= width MsgLen
+      , 64 >= width (8 * KeyLen)
+      , 64 >= width (8 * 64 + MsgLen))

--- a/spec/ValidHMACSizes.cry
+++ b/spec/ValidHMACSizes.cry
@@ -1,6 +1,6 @@
 module ValidHMACSizes where
 
-import Primitive::Symmetric::KDF::HKDF256
+import SHA2Internal::HKDF256
 
 // This is defined internally in cryptol-specs'
 // Primitive::Symmetric::KDF::HKDF256. For now, we simply redefine it here so

--- a/spec/implementation/Keygen.cry
+++ b/spec/implementation/Keygen.cry
@@ -8,7 +8,7 @@ module implementation::Keygen where
 
 import Parameters as P
 import Primitive::Keyless::Hash::SHA2Internal::SHA256
-import Primitive::Symmetric::KDF::HKDF256
+import SHA2Internal::HKDF256
 import rfc8017
 import ValidHMACSizes
 

--- a/spec/implementation/Keygen.cry
+++ b/spec/implementation/Keygen.cry
@@ -7,9 +7,10 @@ module implementation::Keygen where
 // Definitions needed for the code proof of blst_keygen
 
 import Parameters as P
-import Primitive::Keyless::Hash::SHA256
+import Primitive::Keyless::Hash::SHA2Internal::SHA256
 import Primitive::Symmetric::KDF::HKDF256
 import rfc8017
+import ValidHMACSizes
 
 import Common::bv
 


### PR DESCRIPTION
This bumps the `cryptol-specs` submodule commit to a more recent commit (https://github.com/GaloisInc/cryptol-specs/commit/8638495a3ba8c1c0bd031f0c5d7f243b5e8617ff). This requires a fair bit of changes to the SAW proofs' Cryptol specifications in order to account for various API changes, including:

* The imperative SHA2 implementation now lives in `Primitive::Keyless::Hash::SHA2Internal::SHA`.

* The `ModDivZ` module has been removed, so bits of functionality from that module were redefined where necessary

* The `validHMACSizes` type constraint is now defined in a `parameter` block, which means that it is not directly accessible if you import `HKDF256`. For now, I simply opted to redefine it locally.

* Various definitions needed to be moved around in order to account for `parameter`-related tweaks.